### PR TITLE
feat(landing): add marketing site and documentation portal

### DIFF
--- a/landing/docs.html
+++ b/landing/docs.html
@@ -1,0 +1,1708 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Docs — Mimic</title>
+  <meta name="description" content="Mimic documentation. Learn how to simulate every data source your AI agent talks to." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700;14..32,800;14..32,900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #050507;
+      --bg-subtle: #0a0a0e;
+      --bg-raised: #0f0f14;
+      --bg-card: #131318;
+      --bg-card-hover: #19191f;
+      --bg-code: #0d0d12;
+      --border: #1e1e26;
+      --border-mid: #2a2a35;
+      --border-bright: #3a3a48;
+      --text: #f0f0f5;
+      --text-secondary: #9898a8;
+      --text-muted: #5c5c6e;
+      --accent: #7c6aff;
+      --accent-bright: #9585ff;
+      --accent-dim: #5a4ad4;
+      --accent-glow: rgba(124, 106, 255, 0.15);
+      --green: #3ecf71;
+      --green-dim: rgba(62, 207, 113, 0.12);
+      --cyan: #2dd4bf;
+      --cyan-dim: rgba(45, 212, 191, 0.12);
+      --amber: #f5b731;
+      --amber-dim: rgba(245, 183, 49, 0.12);
+      --pink: #f06595;
+      --red: #ef4444;
+      --mono: 'JetBrains Mono', ui-monospace, monospace;
+      --sans: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      --sidebar-w: 260px;
+      --r-sm: 8px;
+      --r-md: 12px;
+    }
+
+    html { scroll-behavior: smooth; scroll-padding-top: 80px; }
+
+    body {
+      font-family: var(--sans);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    ::selection { background: var(--accent); color: #fff; }
+
+    /* ─── NAV ──────────────────────────────────── */
+    .topnav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      height: 56px;
+      backdrop-filter: blur(20px) saturate(1.4);
+      -webkit-backdrop-filter: blur(20px) saturate(1.4);
+      background: rgba(5, 5, 7, 0.8);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      padding: 0 24px;
+    }
+
+    .topnav-inner {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .topnav-left {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+    }
+
+    .topnav-logo {
+      font-weight: 800;
+      font-size: 1rem;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: -0.03em;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .topnav-logo-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-dim));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .topnav-logo-icon svg { width: 14px; height: 14px; }
+
+    .topnav-badge {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--accent-bright);
+      background: var(--accent-glow);
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
+    .topnav-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .topnav-link {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      padding: 6px 12px;
+      border-radius: var(--r-sm);
+      transition: color 0.15s, background 0.15s;
+    }
+
+    .topnav-link:hover {
+      color: var(--text-secondary);
+      background: rgba(255,255,255,0.04);
+    }
+
+    .topnav-gh {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.8125rem;
+      padding: 6px 12px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border-mid);
+      transition: border-color 0.15s;
+    }
+
+    .topnav-gh:hover { border-color: var(--border-bright); }
+
+    .sidebar-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--text);
+      cursor: pointer;
+      padding: 4px;
+    }
+
+    /* ─── SIDEBAR ──────────────────────────────── */
+    .sidebar {
+      position: fixed;
+      top: 56px;
+      left: 0;
+      bottom: 0;
+      width: var(--sidebar-w);
+      border-right: 1px solid var(--border);
+      background: var(--bg-subtle);
+      overflow-y: auto;
+      padding: 24px 0;
+      z-index: 50;
+    }
+
+    .sidebar::-webkit-scrollbar { width: 4px; }
+    .sidebar::-webkit-scrollbar-thumb { background: var(--border-mid); border-radius: 4px; }
+    .sidebar::-webkit-scrollbar-track { background: transparent; }
+
+    .sidebar-group {
+      margin-bottom: 28px;
+    }
+
+    .sidebar-group-title {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+      padding: 0 24px;
+      margin-bottom: 8px;
+    }
+
+    .sidebar-link {
+      display: block;
+      padding: 6px 24px 6px 28px;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      text-decoration: none;
+      border-left: 2px solid transparent;
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
+      font-weight: 450;
+    }
+
+    .sidebar-link:hover {
+      color: var(--text-secondary);
+      background: rgba(255,255,255,0.02);
+    }
+
+    .sidebar-link.active {
+      color: var(--accent-bright);
+      border-left-color: var(--accent);
+      background: rgba(124, 106, 255, 0.05);
+      font-weight: 550;
+    }
+
+    /* ─── MAIN ─────────────────────────────────── */
+    .main {
+      margin-left: var(--sidebar-w);
+      padding: 56px 0 0;
+      min-height: 100vh;
+    }
+
+    .doc-content {
+      max-width: 780px;
+      margin: 0 auto;
+      padding: 48px 48px 120px;
+    }
+
+    /* ─── TYPOGRAPHY ───────────────────────────── */
+    .doc-content h1 {
+      font-size: 2rem;
+      font-weight: 800;
+      letter-spacing: -0.035em;
+      margin-bottom: 12px;
+      line-height: 1.15;
+      padding-top: 20px;
+    }
+
+    .doc-content h1 .eyebrow {
+      display: block;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 8px;
+    }
+
+    .doc-content > h2 {
+      font-size: 1.5rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      margin: 64px 0 16px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      line-height: 1.2;
+    }
+
+    .doc-content > h2:first-of-type {
+      border-top: none;
+      margin-top: 40px;
+    }
+
+    .doc-content h3 {
+      font-size: 1.125rem;
+      font-weight: 700;
+      margin: 40px 0 12px;
+      letter-spacing: -0.02em;
+    }
+
+    .doc-content h4 {
+      font-size: 0.9375rem;
+      font-weight: 700;
+      margin: 28px 0 8px;
+      color: var(--text-secondary);
+    }
+
+    .doc-content p {
+      color: var(--text-secondary);
+      font-size: 0.9375rem;
+      line-height: 1.75;
+      margin-bottom: 16px;
+    }
+
+    .doc-content > .lead {
+      font-size: 1.0625rem;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      margin-bottom: 40px;
+      padding-bottom: 32px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .doc-content a {
+      color: var(--accent-bright);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .doc-content a:hover { text-decoration: underline; }
+
+    .doc-content strong { color: var(--text); font-weight: 600; }
+
+    .doc-content ul, .doc-content ol {
+      margin: 0 0 16px 20px;
+      color: var(--text-secondary);
+      font-size: 0.9375rem;
+    }
+
+    .doc-content li {
+      margin-bottom: 6px;
+      line-height: 1.65;
+    }
+
+    .doc-content hr {
+      border: none;
+      height: 1px;
+      background: var(--border);
+      margin: 48px 0;
+    }
+
+    /* ─── CODE ─────────────────────────────────── */
+    .doc-content code {
+      font-family: var(--mono);
+      font-size: 0.8125em;
+      background: var(--bg-raised);
+      color: var(--accent-bright);
+      padding: 2px 7px;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+    }
+
+    .code-block {
+      position: relative;
+      margin: 16px 0 24px;
+      border-radius: var(--r-md);
+      border: 1px solid var(--border);
+      background: var(--bg-code);
+      overflow: hidden;
+    }
+
+    .code-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 16px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border);
+      font-family: var(--mono);
+      font-size: 0.6875rem;
+      color: var(--text-muted);
+    }
+
+    .code-bar-lang {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .code-copy {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.6875rem;
+      font-family: var(--sans);
+      font-weight: 500;
+      padding: 3px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .code-copy:hover {
+      color: var(--text-secondary);
+      border-color: var(--border-mid);
+    }
+
+    .code-block pre {
+      padding: 18px 20px;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      line-height: 1.7;
+      overflow-x: auto;
+      color: var(--text-secondary);
+    }
+
+    .code-block pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: inherit;
+      color: inherit;
+    }
+
+    .code-block .kw { color: var(--accent-bright); }
+    .code-block .str { color: var(--green); }
+    .code-block .cm { color: var(--text-muted); font-style: italic; }
+    .code-block .fn { color: var(--cyan); }
+    .code-block .ty { color: var(--amber); }
+    .code-block .op { color: var(--text-muted); }
+    .code-block .flag { color: var(--cyan); }
+    .code-block .prompt { color: var(--accent-bright); user-select: none; }
+    .code-block .ok { color: var(--green); }
+    .code-block .out { color: var(--text-muted); }
+    .code-block .yk { color: var(--cyan); }
+    .code-block .ys { color: var(--green); }
+
+    /* ─── TABLE ────────────────────────────────── */
+    .doc-table-wrap {
+      margin: 16px 0 24px;
+      overflow-x: auto;
+      border-radius: var(--r-md);
+      border: 1px solid var(--border);
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 10px 16px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border);
+      font-weight: 700;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      white-space: nowrap;
+    }
+
+    .doc-table td {
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-secondary);
+      vertical-align: top;
+    }
+
+    .doc-table tr:last-child td { border-bottom: none; }
+
+    .doc-table td code {
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+
+    /* ─── CALLOUT ──────────────────────────────── */
+    .callout {
+      padding: 16px 20px;
+      border-radius: var(--r-md);
+      margin: 20px 0 24px;
+      font-size: 0.875rem;
+      line-height: 1.6;
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .callout-icon {
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+
+    .callout p { margin: 0; font-size: 0.875rem; }
+
+    .callout.info {
+      background: rgba(124, 106, 255, 0.06);
+      border: 1px solid rgba(124, 106, 255, 0.15);
+      color: var(--text-secondary);
+    }
+
+    .callout.tip {
+      background: var(--green-dim);
+      border: 1px solid rgba(62, 207, 113, 0.2);
+      color: var(--text-secondary);
+    }
+
+    .callout.warn {
+      background: var(--amber-dim);
+      border: 1px solid rgba(245, 183, 49, 0.2);
+      color: var(--text-secondary);
+    }
+
+    /* ─── SECTION ANCHOR ───────────────────────── */
+    .doc-content [id] {
+      scroll-margin-top: 80px;
+    }
+
+    /* ─── ADAPTER GRID (compact for docs) ──────── */
+    .adapter-doc-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 8px;
+      margin: 16px 0 24px;
+    }
+
+    .adapter-doc-item {
+      padding: 10px 14px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-sm);
+      font-size: 0.8125rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .adapter-doc-name { font-weight: 600; }
+    .adapter-doc-routes { color: var(--text-muted); font-family: var(--mono); font-size: 0.6875rem; }
+
+    /* ─── CHECKLIST ─────────────────────────────── */
+    .checklist {
+      list-style: none;
+      margin: 16px 0 24px 0;
+    }
+
+    .checklist li {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+    }
+
+    .checklist li:last-child { border-bottom: none; }
+
+    .checklist-box {
+      width: 18px;
+      height: 18px;
+      border-radius: 4px;
+      border: 1.5px solid var(--border-mid);
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+
+    /* ─── FOOTER ───────────────────────────────── */
+    .doc-footer {
+      border-top: 1px solid var(--border);
+      padding: 32px 0;
+      margin-top: 64px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .doc-footer-nav {
+      display: flex;
+      gap: 32px;
+    }
+
+    .doc-footer a {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      text-decoration: none;
+    }
+
+    .doc-footer-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .doc-footer-title {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      color: var(--accent-bright);
+    }
+
+    .doc-footer a:hover .doc-footer-title { text-decoration: underline; }
+
+    /* ─── COPY FOR LLM ─────────────────────────── */
+    .llm-btn {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 90;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border-mid);
+      background: var(--bg-card);
+      color: var(--text-secondary);
+      font-family: var(--sans);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      cursor: pointer;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+      transition: border-color 0.2s, color 0.2s, background 0.2s;
+    }
+
+    .llm-btn:hover {
+      border-color: var(--accent);
+      color: var(--text);
+      background: var(--bg-card-hover);
+    }
+
+    .llm-btn.copied {
+      border-color: var(--green);
+      color: var(--green);
+    }
+
+    .llm-btn svg { flex-shrink: 0; }
+
+    /* ─── RESPONSIVE ───────────────────────────── */
+    @media (max-width: 900px) {
+      .sidebar {
+        transform: translateX(-100%);
+        transition: transform 0.25s ease;
+        z-index: 90;
+        width: 280px;
+      }
+
+      .sidebar.open { transform: translateX(0); }
+
+      .sidebar-toggle { display: block; }
+
+      .main { margin-left: 0; }
+
+      .doc-content { padding: 32px 20px 80px; }
+
+      .topnav-right .topnav-link { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <!-- ─── NAV ─────────────────────────────────── -->
+  <header class="topnav">
+    <div class="topnav-inner">
+      <div class="topnav-left">
+        <button class="sidebar-toggle" onclick="document.querySelector('.sidebar').classList.toggle('open')" aria-label="Toggle sidebar">
+          <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+        </button>
+        <a class="topnav-logo" href="index.html">
+          <span class="topnav-logo-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 18V12L8 8L12 14L16 8L20 12V18"/></svg>
+          </span>
+          mimic
+        </a>
+        <span class="topnav-badge">docs</span>
+      </div>
+      <div class="topnav-right">
+        <a href="index.html" class="topnav-link">Home</a>
+        <a href="index.html#pricing" class="topnav-link">Pricing</a>
+        <a href="https://github.com/mimicailab/mimic" class="topnav-gh">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <!-- ─── SIDEBAR ─────────────────────────────── -->
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Getting Started</div>
+      <a href="#introduction" class="sidebar-link active">Introduction</a>
+      <a href="#installation" class="sidebar-link">Installation</a>
+      <a href="#quickstart" class="sidebar-link">Quickstart</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Core Concepts</div>
+      <a href="#personas" class="sidebar-link">Personas &amp; Blueprints</a>
+      <a href="#adapters" class="sidebar-link">Adapters</a>
+      <a href="#mock-server" class="sidebar-link">Mock Server</a>
+      <a href="#state-store" class="sidebar-link">State Store</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Configuration</div>
+      <a href="#config-file" class="sidebar-link">Config File</a>
+      <a href="#env-vars" class="sidebar-link">Environment Variables</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">CLI Reference</div>
+      <a href="#cli-init" class="sidebar-link">mimic init</a>
+      <a href="#cli-seed" class="sidebar-link">mimic seed</a>
+      <a href="#cli-host" class="sidebar-link">mimic host</a>
+      <a href="#cli-test" class="sidebar-link">mimic test</a>
+      <a href="#cli-inspect" class="sidebar-link">mimic inspect</a>
+      <a href="#cli-clean" class="sidebar-link">mimic clean</a>
+      <a href="#cli-generate" class="sidebar-link">mimic generate</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Adapters</div>
+      <a href="#adapter-list" class="sidebar-link">Adapter Catalog</a>
+      <a href="#adapter-databases" class="sidebar-link">Database Adapters</a>
+      <a href="#adapter-api" class="sidebar-link">API Mock Adapters</a>
+      <a href="#adapter-dev" class="sidebar-link">Build an Adapter</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">MCP Servers</div>
+      <a href="#mcp-overview" class="sidebar-link">Overview</a>
+      <a href="#mcp-setup" class="sidebar-link">Setup &amp; Config</a>
+      <a href="#mcp-parity" class="sidebar-link">Official Parity</a>
+      <a href="#mcp-catalog" class="sidebar-link">Server Catalog</a>
+      <a href="#mcp-build" class="sidebar-link">Build an MCP Server</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Architecture</div>
+      <a href="#arch-overview" class="sidebar-link">System Overview</a>
+      <a href="#arch-data-flow" class="sidebar-link">Data Flow</a>
+      <a href="#arch-consistency" class="sidebar-link">Cross-Surface Consistency</a>
+      <a href="#arch-packages" class="sidebar-link">Package Graph</a>
+    </div>
+    <div class="sidebar-group">
+      <div class="sidebar-group-title">Guides</div>
+      <a href="#guide-finance" class="sidebar-link">Finance Agent</a>
+      <a href="#guide-support" class="sidebar-link">Support Agent</a>
+      <a href="#guide-cicd" class="sidebar-link">CI/CD</a>
+    </div>
+  </aside>
+
+  <!-- ─── MAIN CONTENT ────────────────────────── -->
+  <main class="main">
+    <div class="doc-content">
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- INTRODUCTION                               -->
+      <!-- ────────────────────────────────────────── -->
+      <h1 id="introduction">
+        <span class="eyebrow">Getting Started</span>
+        Mimic Documentation
+      </h1>
+      <p class="lead">
+        Mimic is an open-source synthetic environment engine for AI agent development.
+        One persona generates coherent data across every database, API, and MCP server your agent touches.
+        Deterministic, offline-capable, and free.
+      </p>
+
+      <h2 id="installation">Installation</h2>
+      <p>Install the CLI globally via npm, pnpm, or yarn:</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> npm install -g @mimicailab/cli</code></pre>
+      </div>
+
+      <p>Or run directly with <code>npx</code> — no install needed:</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> npx @mimicailab/cli init</code></pre>
+      </div>
+
+      <p><strong>Requirements:</strong> Node.js 18+ (Node 22 recommended). No other dependencies.</p>
+
+      <h2 id="quickstart">Quickstart</h2>
+      <p>Get a fully mocked environment running in under 60 seconds.</p>
+
+      <h3>1. Initialise a project</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic init</code></pre>
+      </div>
+      <p>Creates a <code>.mimic/</code> directory with a default <code>config.yaml</code>. Edit it to declare which surfaces your agent uses:</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">yaml</span><span>.mimic/config.yaml</span></div>
+        <pre><code><span class="yk">persona:</span> <span class="ys">finance-alex</span>        <span class="cm"># Pre-built persona (ships free)</span>
+
+<span class="yk">surfaces:</span>
+  <span class="yk">databases:</span>
+    - <span class="yk">adapter:</span> <span class="ys">postgres</span>
+      <span class="yk">connection:</span> <span class="ys">postgresql://localhost:5432/testdb</span>
+
+  <span class="yk">apis:</span>
+    - <span class="yk">adapter:</span> <span class="ys">plaid</span>
+    - <span class="yk">adapter:</span> <span class="ys">stripe</span>
+    - <span class="yk">adapter:</span> <span class="ys">jira</span>
+
+  <span class="yk">mcp:</span>
+    - <span class="yk">adapter:</span> <span class="ys">slack</span>
+    - <span class="yk">adapter:</span> <span class="ys">notion</span></code></pre>
+      </div>
+
+      <h3>2. Seed databases</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic seed</code></pre>
+      </div>
+      <p>Populates your PostgreSQL (or MongoDB, MySQL, etc.) with persona-consistent data &mdash; users, accounts, transactions, all matching the persona's story.</p>
+
+      <h3>3. Start mock APIs + MCP servers</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic host
+
+<span class="ok">&#10003;</span> <span class="out">Plaid API     &rarr; http://localhost:4000/plaid</span>
+<span class="ok">&#10003;</span> <span class="out">Stripe API    &rarr; http://localhost:4000/stripe/v1</span>
+<span class="ok">&#10003;</span> <span class="out">Jira API      &rarr; http://localhost:4000/jira/rest/api/3</span>
+<span class="ok">&#10003;</span> <span class="out">Slack MCP     &rarr; stdio ready</span>
+<span class="ok">&#10003;</span> <span class="out">Notion MCP    &rarr; stdio ready</span>
+<span class="ok">&#10003;</span> <span class="out">Ready in 1.2s</span></code></pre>
+      </div>
+      <p>Point your agent at <code>localhost:4000</code> instead of production APIs. Everything just works.</p>
+
+      <h3>4. Run tests</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic test</code></pre>
+      </div>
+      <p>Execute test scenarios against your mock environment with optional AI-powered evaluation.</p>
+
+      <h3>5. Clean up</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic clean</code></pre>
+      </div>
+      <p>Truncates seeded database rows, stops mock servers, and clears caches.</p>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- CORE CONCEPTS                              -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="personas">Personas &amp; Blueprints</h2>
+      <p>A <strong>persona</strong> is a fictional identity with a coherent life story. A <strong>blueprint</strong> is the concrete data that persona generates across all surfaces &mdash; database rows, API responses, MCP tool outputs.</p>
+      <p>Pre-built personas ship as JSON files and work offline without LLM calls. Custom personas are generated by the Blueprint Engine (Pro), which uses an LLM to create a coherent persona then a deterministic expander to produce consistent data across all configured surfaces.</p>
+
+      <div class="callout tip">
+        <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span>
+        <p>Pre-built personas ship free with every install. No API keys or LLM calls needed. Just <code>mimic seed --persona finance-alex</code> and go.</p>
+      </div>
+
+      <h3>Available pre-built personas</h3>
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Persona</th><th>Domain</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>finance-alex</code></td><td>Fintech</td><td>32, fintech PM, $85K, 3 bank accounts, active trader, Jira power user</td></tr>
+            <tr><td><code>freelancer-maya</code></td><td>Freelance</td><td>28, freelance designer, multi-currency income, Stripe/PayPal/invoicing</td></tr>
+            <tr><td><code>college-student</code></td><td>Education</td><td>20, college junior, part-time work, student loans, budgeting</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="adapters">Adapters</h2>
+      <p>Adapters are Mimic's plugin system. There are two types:</p>
+      <p><strong>Database adapters</strong> connect to real databases and seed them with persona data. They implement <code>DatabaseAdapter</code> with <code>seed()</code> and <code>clean()</code> methods.</p>
+      <p><strong>API mock adapters</strong> register Fastify routes that simulate real API endpoints. They implement <code>ApiMockAdapter</code> with <code>registerRoutes()</code> and <code>getEndpoints()</code> methods.</p>
+
+      <h2 id="mock-server">Mock Server</h2>
+      <p>The mock server is a Fastify instance that:</p>
+      <ol>
+        <li>Loads all configured adapters from <code>.mimic/config.yaml</code></li>
+        <li>Calls each adapter's <code>registerRoutes()</code> to mount route handlers</li>
+        <li>Serves HTTP requests, routing by path prefix to the correct adapter</li>
+        <li>Provides CORS headers for browser-based agent testing</li>
+      </ol>
+
+      <h2 id="state-store">State Store</h2>
+      <p>The state store is a per-adapter in-memory key-value store that holds seeded data during a mock server session.</p>
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Method</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>set(collection, id, data)</code></td><td>Store a record</td></tr>
+            <tr><td><code>get(collection, id)</code></td><td>Retrieve by ID</td></tr>
+            <tr><td><code>list(collection)</code></td><td>List all records in a collection</td></tr>
+            <tr><td><code>filter(collection, predicate)</code></td><td>Query records by predicate function</td></tr>
+            <tr><td><code>update(collection, id, partial)</code></td><td>Partial update a record</td></tr>
+            <tr><td><code>delete(collection, id)</code></td><td>Remove a record</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The state store resets when the server restarts. For stateful testing across sessions, the Pro tier offers session persistence.</p>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- CONFIGURATION                              -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="config-file">Configuration File</h2>
+      <p>Mimic is configured via <code>.mimic/config.yaml</code> in your project root. Created automatically by <code>mimic init</code>.</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">yaml</span><span>.mimic/config.yaml — full reference</span></div>
+        <pre><code><span class="cm"># Persona — use a pre-built or generate custom (Pro)</span>
+<span class="yk">persona:</span> <span class="ys">finance-alex</span>
+
+<span class="cm"># Port for the mock server</span>
+<span class="yk">port:</span> <span class="ys">4000</span>
+
+<span class="cm"># Seed for deterministic generation (optional)</span>
+<span class="yk">seed:</span> <span class="ys">42</span>
+
+<span class="cm"># Database surfaces</span>
+<span class="yk">surfaces:</span>
+  <span class="yk">databases:</span>
+    - <span class="yk">adapter:</span> <span class="ys">postgres</span>
+      <span class="yk">connection:</span> <span class="ys">postgresql://localhost:5432/testdb</span>
+      <span class="yk">tables:</span>              <span class="cm"># optional: limit to specific tables</span>
+        - users
+        - accounts
+        - transactions
+
+  <span class="cm"># API mock surfaces</span>
+  <span class="yk">apis:</span>
+    - <span class="yk">adapter:</span> <span class="ys">plaid</span>
+    - <span class="yk">adapter:</span> <span class="ys">stripe</span>
+      <span class="yk">config:</span>              <span class="cm"># adapter-specific options</span>
+        <span class="yk">webhookSecret:</span> <span class="ys">whsec_test</span>
+    - <span class="yk">adapter:</span> <span class="ys">jira</span>
+      <span class="yk">config:</span>
+        <span class="yk">projectKey:</span> <span class="ys">MIM</span>
+
+  <span class="cm"># MCP server surfaces</span>
+  <span class="yk">mcp:</span>
+    - <span class="yk">adapter:</span> <span class="ys">slack</span>
+      <span class="yk">transport:</span> <span class="ys">stdio</span>
+    - <span class="yk">adapter:</span> <span class="ys">notion</span>
+      <span class="yk">transport:</span> <span class="ys">stdio</span></code></pre>
+      </div>
+
+      <h2 id="env-vars">Environment Variables</h2>
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Variable</th><th>Description</th><th>Default</th></tr></thead>
+          <tbody>
+            <tr><td><code>MIMIC_PORT</code></td><td>Mock server port</td><td><code>4000</code></td></tr>
+            <tr><td><code>MIMIC_PERSONA</code></td><td>Persona blueprint to use</td><td><code>finance-alex</code></td></tr>
+            <tr><td><code>MIMIC_API_KEY</code></td><td>API key for Pro features</td><td>&mdash;</td></tr>
+            <tr><td><code>MIMIC_LOG_LEVEL</code></td><td>Logging verbosity</td><td><code>info</code></td></tr>
+            <tr><td><code>MIMIC_BASE_URL</code></td><td>Used by MCP servers to reach mock server</td><td><code>http://localhost:4000</code></td></tr>
+            <tr><td><code>MIMIC_AUTH_TOKEN</code></td><td>Auth token for MCP &rarr; mock requests</td><td><code>mimic_test</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- CLI REFERENCE                              -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="cli-init">mimic init</h2>
+      <p>Initialise a new Mimic project in the current directory.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic init [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--persona</span> &lt;name&gt;     Pre-select a persona (default: finance-alex)
+  <span class="flag">--force</span>              Overwrite existing .mimic/ directory</code></pre>
+      </div>
+      <p>Creates <code>.mimic/config.yaml</code>, <code>.mimic/blueprints/</code>, and <code>.mimic/scenarios/</code>. If a Prisma schema or SQL files are detected, surfaces are auto-configured.</p>
+
+      <h2 id="cli-seed">mimic seed</h2>
+      <p>Seed databases with persona-consistent data.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic seed [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--persona</span> &lt;name&gt;     Override the persona from config
+  <span class="flag">--tables</span> &lt;list&gt;      Comma-separated list of tables to seed
+  <span class="flag">--rows</span> &lt;n&gt;           Number of rows per table (default: varies by persona)
+  <span class="flag">--clean-first</span>        Truncate before seeding
+  <span class="flag">--dry-run</span>            Print SQL without executing</code></pre>
+      </div>
+      <p>Uses COPY FROM STDIN for PostgreSQL (&ge;500 rows) for ~714K rows/sec throughput. Handles foreign key ordering via topological sort. Atomic transactions &mdash; all or nothing.</p>
+
+      <h2 id="cli-host">mimic host</h2>
+      <p>Start the mock API server and MCP servers.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic host [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--port</span> &lt;n&gt;           Server port (default: 4000)
+  <span class="flag">--adapters</span> &lt;list&gt;    Comma-separated adapter IDs to load
+  <span class="flag">--background</span>         Run as background process
+  <span class="flag">--cors</span>               Enable CORS (default: true)
+  <span class="flag">--watch</span>              Reload on config changes</code></pre>
+      </div>
+      <p>Starts a Fastify server with all configured API mocks mounted at their base paths. MCP servers are available via stdio or HTTP transport as configured.</p>
+
+      <h2 id="cli-test">mimic test</h2>
+      <p>Run test scenarios against the mock environment.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic test [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--scenario</span> &lt;file&gt;    Path to specific scenario file
+  <span class="flag">--eval</span> &lt;mode&gt;        Evaluation mode: keyword | llm (Pro)
+  <span class="flag">--workers</span> &lt;n&gt;        Parallel test workers (Pro)
+  <span class="flag">--verbose</span>            Show detailed output</code></pre>
+      </div>
+      <p>Reads scenarios from <code>.mimic/scenarios/</code>. Each scenario defines synthetic user inputs and expected outcomes. Supports keyword matching (free) and LLM-as-judge evaluation (Pro).</p>
+
+      <h2 id="cli-inspect">mimic inspect</h2>
+      <p>View seeded data across all surfaces.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic inspect [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--surface</span> &lt;name&gt;     Inspect a specific surface (e.g., postgres, stripe)
+  <span class="flag">--format</span> &lt;fmt&gt;       Output format: table | json (default: table)</code></pre>
+      </div>
+
+      <h2 id="cli-clean">mimic clean</h2>
+      <p>Remove all seeded data and stop running servers.</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic clean [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--databases-only</span>     Only truncate database tables
+  <span class="flag">--keep-config</span>        Don't remove .mimic/ directory</code></pre>
+      </div>
+
+      <h2 id="cli-generate">mimic generate</h2>
+      <p>Generate a custom persona blueprint using the Blueprint Engine. <strong>Requires Pro.</strong></p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic generate [options]
+
+<span class="cm">Options:</span>
+  <span class="flag">--description</span> &lt;text&gt;  Natural language persona description
+  <span class="flag">--domain</span> &lt;name&gt;       Target domain: finance | support | devops | healthcare
+  <span class="flag">--output</span> &lt;path&gt;       Save blueprint to file
+  <span class="flag">--model</span> &lt;id&gt;          LLM model to use (default: claude-haiku-4-5)</code></pre>
+      </div>
+
+      <div class="callout info">
+        <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <p>Community tier gets 3 custom blueprints per month. Pro tier gets unlimited. Custom blueprints cost ~$0.02-$0.05 per generation via LLM.</p>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- ADAPTER CATALOG                            -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="adapter-list">Adapter Catalog</h2>
+      <p>Mimic supports <strong>65+ adapters</strong> across 8 categories. Every adapter is open source (Apache 2.0) and community-contributable.</p>
+
+      <h3 id="adapter-databases">Database Adapters</h3>
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Adapter</th><th>Package</th><th>Status</th><th>What it does</th></tr></thead>
+          <tbody>
+            <tr><td>PostgreSQL</td><td><code>@mimicailab/adapter-postgres</code></td><td>Stable</td><td>Seeds tables via COPY FROM STDIN, FK-aware ordering</td></tr>
+            <tr><td>MongoDB</td><td><code>@mimicailab/adapter-mongodb</code></td><td>Stable</td><td>Seeds collections with embedded documents</td></tr>
+            <tr><td>MySQL</td><td><code>@mimicailab/adapter-mysql</code></td><td>Stable</td><td>Seeds tables with relational integrity</td></tr>
+            <tr><td>Pinecone</td><td><code>@mimicailab/adapter-pinecone</code></td><td>Stable</td><td>Seeds vector embeddings for RAG testing</td></tr>
+            <tr><td>Redis</td><td><code>@mimicailab/adapter-redis</code></td><td>Stable</td><td>Seeds key-value pairs, sorted sets, streams</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="adapter-api">API Mock Adapters</h3>
+      <h4>Fintech / Payments (24 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Stripe</span><span class="adapter-doc-routes">29 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Plaid</span><span class="adapter-doc-routes">15 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Square</span><span class="adapter-doc-routes">16 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Wise</span><span class="adapter-doc-routes">14 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Adyen</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Coinbase</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">PayPal</span><span class="adapter-doc-routes">13 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Brex</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Ramp</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Mercury</span><span class="adapter-doc-routes">9 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Moov</span><span class="adapter-doc-routes">8 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">GoCardless</span><span class="adapter-doc-routes">11 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Marqeta</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Paddle</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Checkout.com</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">+9 more</span><span class="adapter-doc-routes"></span></div>
+      </div>
+
+      <h4>Communication (11 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Slack</span><span class="adapter-doc-routes">19 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Twilio</span><span class="adapter-doc-routes">14 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">SendGrid</span><span class="adapter-doc-routes">11 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Discord</span><span class="adapter-doc-routes">13 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">MS Teams</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">WhatsApp</span><span class="adapter-doc-routes">9 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Telegram</span><span class="adapter-doc-routes">11 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Mailgun</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Postmark</span><span class="adapter-doc-routes">9 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Vonage</span><span class="adapter-doc-routes">8 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">MessageBird</span><span class="adapter-doc-routes">7 routes</span></div>
+      </div>
+
+      <h4>CRM (7 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Salesforce</span><span class="adapter-doc-routes">16 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">HubSpot</span><span class="adapter-doc-routes">16 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Pipedrive</span><span class="adapter-doc-routes">14 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Zoho CRM</span><span class="adapter-doc-routes">13 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Close</span><span class="adapter-doc-routes">14 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Attio</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Dynamics 365</span><span class="adapter-doc-routes">11 routes</span></div>
+      </div>
+
+      <h4>Ticketing (8 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Zendesk</span><span class="adapter-doc-routes">24 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Jira</span><span class="adapter-doc-routes">21 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Linear</span><span class="adapter-doc-routes">20 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Intercom</span><span class="adapter-doc-routes">25 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">PagerDuty</span><span class="adapter-doc-routes">17 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Freshdesk</span><span class="adapter-doc-routes">18 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">ServiceNow</span><span class="adapter-doc-routes">9 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Shortcut</span><span class="adapter-doc-routes">22 routes</span></div>
+      </div>
+
+      <h4>Project Management (8 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Notion</span><span class="adapter-doc-routes">19 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Asana</span><span class="adapter-doc-routes">22 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Trello</span><span class="adapter-doc-routes">23 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Monday.com</span><span class="adapter-doc-routes">19 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Airtable</span><span class="adapter-doc-routes">11 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">ClickUp</span><span class="adapter-doc-routes">20 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Todoist</span><span class="adapter-doc-routes">18 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Basecamp</span><span class="adapter-doc-routes">23 routes</span></div>
+      </div>
+
+      <h4>Calendar / Scheduling (6 adapters)</h4>
+      <div class="adapter-doc-grid">
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Google Calendar</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Calendly</span><span class="adapter-doc-routes">11 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Cal.com</span><span class="adapter-doc-routes">12 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Nylas</span><span class="adapter-doc-routes">9 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Cronofy</span><span class="adapter-doc-routes">10 routes</span></div>
+        <div class="adapter-doc-item"><span class="adapter-doc-name">Acuity</span><span class="adapter-doc-routes">9 routes</span></div>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- ADAPTER DEV                                -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="adapter-dev">Build an Adapter</h2>
+      <p>Every adapter implements the <code>ApiMockAdapter</code> interface. Scaffold a new one with:</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> pnpm mimic:create-adapter my-platform</code></pre>
+      </div>
+
+      <h3>The Adapter Interface</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">typescript</span><span>src/index.ts</span></div>
+        <pre><code><span class="kw">import</span> { <span class="ty">ApiMockAdapter</span>, <span class="ty">EndpointDefinition</span> } <span class="kw">from</span> <span class="str">'@mimicailab/adapter-sdk'</span>;
+
+<span class="kw">export class</span> <span class="ty">MyPlatformAdapter</span> <span class="kw">implements</span> <span class="ty">ApiMockAdapter</span> {
+  <span class="kw">readonly</span> id <span class="op">=</span> <span class="str">'my-platform'</span>;
+  <span class="kw">readonly</span> name <span class="op">=</span> <span class="str">'My Platform API'</span>;
+  <span class="kw">readonly</span> type <span class="op">=</span> <span class="str">'api-mock'</span>;
+  <span class="kw">readonly</span> basePath <span class="op">=</span> <span class="str">'/my-platform'</span>;
+
+  <span class="cm">// Extract persona ID from auth header</span>
+  <span class="fn">resolvePersona</span>(req): <span class="ty">string</span> | <span class="ty">null</span> { <span class="cm">/* ... */</span> }
+
+  <span class="cm">// Register routes on the Fastify server</span>
+  <span class="kw">async</span> <span class="fn">registerRoutes</span>(server, data, state) { <span class="cm">/* ... */</span> }
+
+  <span class="cm">// Declare endpoints for docs + MCP generation</span>
+  <span class="fn">getEndpoints</span>(): <span class="ty">EndpointDefinition</span>[] { <span class="cm">/* ... */</span> }
+}</code></pre>
+      </div>
+
+      <h3>Key guidelines</h3>
+      <ul>
+        <li><strong>Match real response shapes exactly</strong> &mdash; agents are trained on real API docs</li>
+        <li><strong>Match real ID formats</strong> &mdash; Stripe uses <code>cus_xxx</code>, Jira uses <code>MIM-1</code>, Notion uses UUIDs</li>
+        <li><strong>Match real pagination</strong> &mdash; cursor-based, offset-based, or page-based per platform</li>
+        <li><strong>Match real error formats</strong> &mdash; Stripe wraps in <code>{"error": {...}}</code>, Jira uses <code>{"errorMessages": [...]}</code></li>
+        <li><strong>Seed realistic data</strong> &mdash; no "test", "foo", "bar" in seed values</li>
+        <li><strong>Aim for 8-20 routes</strong> &mdash; cover core CRUD + 1-2 domain-specific actions</li>
+      </ul>
+
+      <h3>Submission checklist</h3>
+      <ul class="checklist">
+        <li><span class="checklist-box"></span>Implements <code>ApiMockAdapter</code> interface</li>
+        <li><span class="checklist-box"></span><code>resolvePersona()</code> matches platform auth pattern</li>
+        <li><span class="checklist-box"></span>8+ routes covering core CRUD operations</li>
+        <li><span class="checklist-box"></span>Realistic seed data (3-5 records per resource)</li>
+        <li><span class="checklist-box"></span>Response shapes match real API docs</li>
+        <li><span class="checklist-box"></span>Error responses match real API error format</li>
+        <li><span class="checklist-box"></span><code>getEndpoints()</code> returns all route definitions</li>
+        <li><span class="checklist-box"></span>Tests cover list, create, get, update</li>
+        <li><span class="checklist-box"></span>TypeScript strict mode, no untyped <code>any</code></li>
+      </ul>
+
+      <p>PRs are reviewed within 48 hours. Once merged, a corresponding MCP server is auto-generated from your <code>getEndpoints()</code>.</p>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- MCP SERVERS                                -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="mcp-overview">MCP Servers &mdash; Overview</h2>
+      <p>Every API mock adapter has a corresponding MCP server. MCP servers translate MCP tool calls into HTTP requests against the Mimic mock server.</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span><span>data flow</span></div>
+        <pre><code>AI Agent  &mdash;MCP&mdash;&gt;  Mimic MCP Server  &mdash;HTTP&mdash;&gt;  Mimic Mock Adapter
+(Claude)           (mcp-jira)                    (adapter-jira)</code></pre>
+      </div>
+
+      <p>This matters because many agent frameworks use MCP as their primary tool interface. Mimic MCP servers give agents realistic mock data through the same protocol they'll use in production.</p>
+
+      <h2 id="mcp-setup">MCP Setup &amp; Config</h2>
+
+      <h3>With Claude Code</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> claude mcp add mimic-jira -- npx -y @mimicailab/mcp-jira
+
+<span class="cm"># With custom URL</span>
+<span class="prompt">$</span> claude mcp add <span class="flag">--env MIMIC_BASE_URL=http://localhost:4000</span> mimic-jira -- npx -y @mimicailab/mcp-jira</code></pre>
+      </div>
+
+      <h3>With Cursor / VS Code</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">json</span><span>MCP config</span></div>
+        <pre><code>{
+  <span class="yk">"mcpServers"</span>: {
+    <span class="yk">"mimic-jira"</span>: {
+      <span class="yk">"command"</span>: <span class="str">"npx"</span>,
+      <span class="yk">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@mimicailab/mcp-jira"</span>],
+      <span class="yk">"env"</span>: { <span class="yk">"MIMIC_BASE_URL"</span>: <span class="str">"http://localhost:4000"</span> }
+    },
+    <span class="yk">"mimic-slack"</span>: {
+      <span class="yk">"command"</span>: <span class="str">"npx"</span>,
+      <span class="yk">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@mimicailab/mcp-slack"</span>],
+      <span class="yk">"env"</span>: { <span class="yk">"MIMIC_BASE_URL"</span>: <span class="str">"http://localhost:4000"</span> }
+    }
+  }
+}</code></pre>
+      </div>
+
+      <h3>With Mimic CLI</h3>
+      <p>The simplest way &mdash; configure MCP servers in your config and <code>mimic host</code> starts them alongside API mocks:</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">yaml</span><span>.mimic/config.yaml</span></div>
+        <pre><code><span class="yk">surfaces:</span>
+  <span class="yk">mcp:</span>
+    - <span class="yk">adapter:</span> <span class="ys">jira</span>
+      <span class="yk">transport:</span> <span class="ys">stdio</span>
+    - <span class="yk">adapter:</span> <span class="ys">slack</span>
+      <span class="yk">transport:</span> <span class="ys">stdio</span></code></pre>
+      </div>
+
+      <h2 id="mcp-parity">Official MCP Parity</h2>
+      <p>For platforms that ship official MCP servers, Mimic matches the <strong>exact same tool names and parameter schemas</strong>. Develop against Mimic, swap to real credentials in production &mdash; zero code changes.</p>
+
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Platform</th><th>Official MCP</th><th>Mimic MCP</th><th>Parity</th></tr></thead>
+          <tbody>
+            <tr><td>Jira</td><td>Atlassian MCP</td><td><code>@mimicailab/mcp-jira</code></td><td style="color: var(--green);">Matched</td></tr>
+            <tr><td>Slack</td><td>Claude.ai connector</td><td><code>@mimicailab/mcp-slack</code></td><td style="color: var(--green);">Matched</td></tr>
+            <tr><td>Asana</td><td>mcp.asana.com/sse</td><td><code>@mimicailab/mcp-asana</code></td><td style="color: var(--green);">Matched</td></tr>
+            <tr><td>HubSpot</td><td>mcp.hubspot.com</td><td><code>@mimicailab/mcp-hubspot</code></td><td style="color: var(--green);">Matched</td></tr>
+            <tr><td>GitHub</td><td>@mcp/server-github</td><td><code>@mimicailab/mcp-github</code></td><td style="color: var(--green);">Matched</td></tr>
+            <tr><td>GitLab</td><td>Official GitLab MCP</td><td><code>@mimicailab/mcp-gitlab</code></td><td style="color: var(--green);">Matched</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="mcp-catalog">MCP Server Catalog</h2>
+      <div class="doc-table-wrap">
+        <table class="doc-table">
+          <thead><tr><th>Package</th><th>Tools</th><th>Primary Tools</th></tr></thead>
+          <tbody>
+            <tr><td><code>@mimicailab/mcp-stripe</code></td><td>12</td><td>create_payment_intent, list_charges, create_customer</td></tr>
+            <tr><td><code>@mimicailab/mcp-plaid</code></td><td>10</td><td>create_link_token, get_accounts, get_transactions</td></tr>
+            <tr><td><code>@mimicailab/mcp-slack</code></td><td>10</td><td>post_message, list_channels, search_messages</td></tr>
+            <tr><td><code>@mimicailab/mcp-jira</code></td><td>10</td><td>create_issue, search_jql, transition_issue</td></tr>
+            <tr><td><code>@mimicailab/mcp-salesforce</code></td><td>10</td><td>query_soql, create_record, update_record</td></tr>
+            <tr><td><code>@mimicailab/mcp-hubspot</code></td><td>10</td><td>search_contacts, create_deal, list_companies</td></tr>
+            <tr><td><code>@mimicailab/mcp-notion</code></td><td>10</td><td>query_database, create_page, search</td></tr>
+            <tr><td><code>@mimicailab/mcp-zendesk</code></td><td>8</td><td>create_ticket, update_ticket, search_tickets</td></tr>
+            <tr><td><code>@mimicailab/mcp-linear</code></td><td>8</td><td>create_issue, update_issue, list_issues</td></tr>
+            <tr><td><code>@mimicailab/mcp-asana</code></td><td>8</td><td>list_tasks, create_task, update_task</td></tr>
+            <tr><td><code>@mimicailab/mcp-pagerduty</code></td><td>8</td><td>create_incident, acknowledge, resolve</td></tr>
+            <tr><td><code>@mimicailab/mcp-trello</code></td><td>8</td><td>list_cards, create_card, move_card</td></tr>
+            <tr><td><code>@mimicailab/mcp-twilio</code></td><td>8</td><td>send_sms, make_call, list_messages</td></tr>
+            <tr><td><code>@mimicailab/mcp-sendgrid</code></td><td>6</td><td>send_email, list_contacts, get_stats</td></tr>
+            <tr><td><code>@mimicailab/mcp-airtable</code></td><td>6</td><td>list_records, create_records, update_records</td></tr>
+            <tr><td><code>@mimicailab/mcp-pipedrive</code></td><td>8</td><td>list_deals, create_person, search</td></tr>
+            <tr><td><code>@mimicailab/mcp-square</code></td><td>8</td><td>create_payment, list_orders, create_customer</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="mcp-build">Build an MCP Server</h2>
+      <p>Most MCP servers are auto-generated from the adapter's <code>getEndpoints()</code> definitions:</p>
+
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> pnpm mimic:generate-mcp my-platform</code></pre>
+      </div>
+
+      <p>For hand-tuned implementations:</p>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">typescript</span><span>mcp-server.ts</span></div>
+        <pre><code><span class="kw">import</span> { <span class="ty">McpServer</span> } <span class="kw">from</span> <span class="str">'@modelcontextprotocol/sdk/server/mcp.js'</span>;
+<span class="kw">import</span> { z } <span class="kw">from</span> <span class="str">'zod'</span>;
+
+<span class="kw">const</span> server = <span class="kw">new</span> <span class="ty">McpServer</span>({
+  name: <span class="str">'mimic-my-platform'</span>,
+  version: <span class="str">'1.0.0'</span>,
+});
+
+server.<span class="fn">tool</span>(
+  <span class="str">'create_item'</span>,
+  <span class="str">'Create a new item. Requires title. Optionally set priority.'</span>,
+  {
+    title: z.<span class="fn">string</span>().<span class="fn">describe</span>(<span class="str">'Item title'</span>),
+    priority: z.<span class="fn">enum</span>([<span class="str">'low'</span>, <span class="str">'medium'</span>, <span class="str">'high'</span>]).<span class="fn">optional</span>(),
+  },
+  <span class="kw">async</span> (params) <span class="op">=></span> {
+    <span class="kw">const</span> data = <span class="kw">await</span> <span class="fn">mimicFetch</span>(<span class="str">'POST'</span>, <span class="str">'/my-platform/items'</span>, params);
+    <span class="kw">return</span> {
+      content: [{ type: <span class="str">'text'</span>, text: <span class="str">`Created #${data.id}: "${data.title}"`</span> }]
+    };
+  }
+);</code></pre>
+      </div>
+
+      <div class="callout tip">
+        <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span>
+        <p><strong>Tool design tip:</strong> Name tools to match the platform's vocabulary. Write descriptions for LLMs, not humans. Return human-readable summaries for write operations, full JSON for reads.</p>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- ARCHITECTURE                               -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="arch-overview">System Overview</h2>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span><span>architecture</span></div>
+        <pre><code>┌──────────────────────────────────────────────────────────┐
+│                        CLI Layer                          │
+│   mimic init │ mimic seed │ mimic host │ mimic test       │
+└─────────────────────────┬────────────────────────────────┘
+                          │
+             ┌────────────┼────────────┐
+             │            │            │
+             v            v            v
+  ┌──────────────┐ ┌────────────┐ ┌────────────┐
+  │  Blueprint   │ │ Mock Server│ │Test Runner  │
+  │              │ │            │ │             │
+  │ Persona load │ │ Fastify    │ │ Scenarios   │
+  │ Engine (Pro) │ │ Adapters   │ │ Eval (Pro)  │
+  │ Expander     │ │ State store│ │ Coverage    │
+  └──────┬───────┘ └──────┬─────┘ └─────────────┘
+         │          ┌─────┴─────┐
+         │          │           │
+         v          v           v
+  ┌──────────┐ ┌────────┐ ┌────────┐
+  │ Database │ │API Mock│ │  MCP   │
+  │ Adapters │ │Adapters│ │Servers │
+  │          │ │        │ │        │
+  │ Postgres │ │ Stripe │ │mcp-jira│
+  │ MongoDB  │ │ Plaid  │ │mcp-slk │
+  │ MySQL    │ │ 60+    │ │ ...    │
+  └────┬─────┘ └────────┘ └────────┘
+       v
+   Real databases</code></pre>
+      </div>
+
+      <h2 id="arch-data-flow">Data Flow</h2>
+
+      <h3>Seeding flow</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span></div>
+        <pre><code>mimic seed
+  │
+  ├─ Load persona blueprint from .mimic/blueprints/{persona}.json
+  │
+  ├─ For each configured database adapter:
+  │   ├─ Connect to database
+  │   ├─ Map blueprint data to table schemas
+  │   ├─ INSERT/COPY rows (FK-aware ordering)
+  │   └─ Report: "Seeded 42 rows across 5 tables"
+  │
+  └─ Done (API mocks seed lazily on first request)</code></pre>
+      </div>
+
+      <h3>Request flow (API mock)</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span></div>
+        <pre><code>Agent sends: GET /jira/rest/api/3/search?jql=project=MIM
+
+Mock Server
+  ├─ Route matched: /jira/* &rarr; JiraAdapter
+  ├─ JiraAdapter.handleSearch(req, reply)
+  │   ├─ seedData()   &mdash; populate state store if empty
+  │   ├─ Parse JQL from query params
+  │   ├─ Filter state store by parsed criteria
+  │   ├─ Format response matching Jira's real shape
+  │   └─ reply.send({ issues: [...], total: N })
+  └─ Response returned to agent</code></pre>
+      </div>
+
+      <h3>MCP flow</h3>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span></div>
+        <pre><code>Agent calls MCP tool: search_jql({ jql: "project = MIM" })
+
+MCP Server (@mimicailab/mcp-jira)
+  ├─ Validate params with Zod schema
+  ├─ Translate to HTTP:
+  │   POST http://localhost:4000/jira/rest/api/3/search
+  ├─ Parse response
+  ├─ Format for agent: "Found 5 issues: MIM-1 | In Progress | ..."
+  └─ Return MCP response</code></pre>
+      </div>
+
+      <h2 id="arch-consistency">Cross-Surface Consistency</h2>
+      <p>The Blueprint Engine's core differentiator. When it generates data for persona "Alex", the <strong>same Alex appears across all surfaces</strong>:</p>
+      <ul>
+        <li>PostgreSQL <code>users</code> table has Alex with ID <code>user_001</code></li>
+        <li>Plaid API returns bank accounts owned by <code>user_001</code></li>
+        <li>Stripe API returns payment history for <code>user_001</code>'s card</li>
+        <li>Jira API returns issues assigned to Alex</li>
+        <li>Slack API shows messages from Alex</li>
+      </ul>
+      <p>Achieved through a two-phase process:</p>
+      <ol>
+        <li><strong>Phase 1: Persona Generation</strong> &mdash; LLM creates a detailed persona with relationships, financial profile, work context</li>
+        <li><strong>Phase 2: Deterministic Expansion</strong> &mdash; Rules engine expands into concrete data with shared identifiers, consistent timestamps, and correlated values</li>
+      </ol>
+
+      <h2 id="arch-packages">Package Dependency Graph</h2>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">text</span></div>
+        <pre><code>@mimicailab/cli
+  ├── @mimicailab/mock-server
+  │     ├── @mimicailab/adapter-sdk
+  │     ├── @mimicailab/adapter-stripe
+  │     ├── @mimicailab/adapter-jira
+  │     └── ... (all adapters)
+  ├── @mimicailab/blueprints
+  └── @mimicailab/core (Pro - optional)
+        ├── blueprint-engine
+        ├── consistency
+        └── test-advanced
+
+@mimicailab/mcp-jira (standalone)
+  └── @modelcontextprotocol/sdk
+
+@mimicailab/adapter-sdk (standalone)
+  └── zod, fastify (peer deps)</code></pre>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- GUIDES                                     -->
+      <!-- ────────────────────────────────────────── -->
+      <h2 id="guide-finance">Guide: Testing a Finance Agent</h2>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic init
+<span class="prompt">$</span> mimic seed <span class="flag">--persona finance-alex</span>
+<span class="prompt">$</span> mimic host &amp;
+
+<span class="cm"># Your agent connects to:</span>
+<span class="cm">#   Plaid    &rarr; http://localhost:4000/plaid</span>
+<span class="cm">#   Stripe   &rarr; http://localhost:4000/stripe/v1</span>
+<span class="cm">#   Postgres &rarr; postgresql://localhost:5432/testdb (seeded)</span>
+
+<span class="prompt">$</span> python my_finance_agent.py --test
+<span class="prompt">$</span> mimic clean</code></pre>
+      </div>
+
+      <h2 id="guide-support">Guide: Testing a Support Agent (MCP)</h2>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">bash</span></div>
+        <pre><code><span class="prompt">$</span> mimic host <span class="flag">--adapters jira,slack,zendesk</span> &amp;
+
+<span class="cm"># In your Claude/Cursor MCP config, add:</span>
+<span class="cm">#   "mimic-jira":    npx -y @mimicailab/mcp-jira</span>
+<span class="cm">#   "mimic-slack":   npx -y @mimicailab/mcp-slack</span>
+<span class="cm">#   "mimic-zendesk": npx -y @mimicailab/mcp-zendesk</span>
+
+<span class="cm"># Agent now has realistic tickets, messages, and support data</span></code></pre>
+      </div>
+
+      <h2 id="guide-cicd">Guide: CI/CD Integration</h2>
+      <div class="code-block">
+        <div class="code-bar"><span class="code-bar-lang">yaml</span><span>.github/workflows/agent-tests.yml</span></div>
+        <pre><code><span class="yk">name:</span> <span class="ys">Agent Tests</span>
+<span class="yk">on:</span> [push, pull_request]
+
+<span class="yk">jobs:</span>
+  <span class="yk">test:</span>
+    <span class="yk">runs-on:</span> <span class="ys">ubuntu-latest</span>
+    <span class="yk">steps:</span>
+      - <span class="yk">uses:</span> <span class="ys">actions/checkout@v4</span>
+      - <span class="yk">uses:</span> <span class="ys">actions/setup-node@v4</span>
+        <span class="yk">with:</span>
+          <span class="yk">node-version:</span> <span class="ys">22</span>
+
+      - <span class="yk">name:</span> <span class="ys">Start Mimic</span>
+        <span class="yk">run:</span> |
+          npx @mimicailab/cli seed --persona finance-alex
+          npx @mimicailab/cli host --background
+
+      - <span class="yk">name:</span> <span class="ys">Run agent tests</span>
+        <span class="yk">run:</span> <span class="ys">npm test</span>
+        <span class="yk">env:</span>
+          <span class="yk">PLAID_BASE_URL:</span> <span class="ys">http://localhost:4000/plaid</span>
+          <span class="yk">STRIPE_API_BASE:</span> <span class="ys">http://localhost:4000/stripe/v1</span>
+
+      - <span class="yk">name:</span> <span class="ys">Cleanup</span>
+        <span class="yk">run:</span> <span class="ys">npx @mimicailab/cli clean</span></code></pre>
+      </div>
+
+      <div class="callout info">
+        <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <p>Pre-built personas work fully offline &mdash; no API keys or secrets needed in your CI environment. Deterministic seeding guarantees identical data in every pipeline run.</p>
+      </div>
+
+      <!-- ────────────────────────────────────────── -->
+      <!-- FOOTER                                     -->
+      <!-- ────────────────────────────────────────── -->
+      <div class="doc-footer">
+        <div class="doc-footer-nav">
+          <a href="index.html">
+            <span class="doc-footer-label">&larr; Back</span>
+            <span class="doc-footer-title">Home</span>
+          </a>
+        </div>
+        <div class="doc-footer-nav">
+          <a href="https://github.com/mimicailab/mimic" style="text-align: right;">
+            <span class="doc-footer-label">Source</span>
+            <span class="doc-footer-title">GitHub &rarr;</span>
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- ─── COPY FOR LLM BUTTON ─────────────────── -->
+  <button class="llm-btn" id="llmCopyBtn" title="Copy entire docs as Markdown for LLM context">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+    <span id="llmBtnLabel">Copy for LLM</span>
+  </button>
+
+  <!-- ─── SCRIPTS ─────────────────────────────── -->
+  <script>
+    // Active sidebar link tracking
+    const sections = document.querySelectorAll('[id]');
+    const links = document.querySelectorAll('.sidebar-link');
+
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          links.forEach(l => l.classList.remove('active'));
+          const active = document.querySelector(`.sidebar-link[href="#${entry.target.id}"]`);
+          if (active) active.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-80px 0px -70% 0px', threshold: 0 });
+
+    sections.forEach(s => {
+      if (document.querySelector(`.sidebar-link[href="#${s.id}"]`)) {
+        obs.observe(s);
+      }
+    });
+
+    // Close sidebar on mobile when clicking a link
+    document.querySelectorAll('.sidebar-link').forEach(link => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth <= 900) {
+          document.querySelector('.sidebar').classList.remove('open');
+        }
+      });
+    });
+
+    // Copy buttons
+    document.querySelectorAll('.code-copy').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const code = btn.closest('.code-block').querySelector('pre').textContent;
+        navigator.clipboard.writeText(code).then(() => {
+          btn.textContent = 'Copied!';
+          setTimeout(() => btn.textContent = 'Copy', 1500);
+        });
+      });
+    });
+
+    // Copy for LLM — convert doc-content to clean Markdown
+    document.getElementById('llmCopyBtn').addEventListener('click', () => {
+      const content = document.querySelector('.doc-content');
+      if (!content) return;
+
+      const lines = [];
+
+      function textOf(el) {
+        return el.textContent.trim().replace(/\s+/g, ' ');
+      }
+
+      function processTable(table) {
+        const rows = table.querySelectorAll('tr');
+        if (!rows.length) return;
+        rows.forEach((row, ri) => {
+          const cells = row.querySelectorAll('th, td');
+          const vals = Array.from(cells).map(c => textOf(c));
+          lines.push('| ' + vals.join(' | ') + ' |');
+          if (ri === 0) {
+            lines.push('| ' + vals.map(() => '---').join(' | ') + ' |');
+          }
+        });
+        lines.push('');
+      }
+
+      function processList(ul, indent) {
+        const items = ul.querySelectorAll(':scope > li');
+        const ordered = ul.tagName === 'OL';
+        items.forEach((li, i) => {
+          const prefix = ordered ? `${i + 1}. ` : '- ';
+          // Get direct text (not nested lists)
+          const clone = li.cloneNode(true);
+          clone.querySelectorAll('ul, ol').forEach(n => n.remove());
+          lines.push(indent + prefix + textOf(clone));
+          // Handle nested lists
+          li.querySelectorAll(':scope > ul, :scope > ol').forEach(nested => {
+            processList(nested, indent + '  ');
+          });
+        });
+        lines.push('');
+      }
+
+      const children = content.children;
+      for (let i = 0; i < children.length; i++) {
+        const el = children[i];
+        const tag = el.tagName;
+
+        if (tag === 'H1') {
+          // Skip eyebrow span, get main text
+          const eyebrow = el.querySelector('.eyebrow');
+          const main = textOf(el).replace(eyebrow ? textOf(eyebrow) : '', '').trim();
+          if (eyebrow) lines.push('# ' + textOf(eyebrow) + ': ' + main);
+          else lines.push('# ' + main);
+          lines.push('');
+        } else if (tag === 'H2') {
+          lines.push('## ' + textOf(el));
+          lines.push('');
+        } else if (tag === 'H3') {
+          lines.push('### ' + textOf(el));
+          lines.push('');
+        } else if (tag === 'H4') {
+          lines.push('#### ' + textOf(el));
+          lines.push('');
+        } else if (tag === 'P') {
+          lines.push(textOf(el));
+          lines.push('');
+        } else if (tag === 'HR') {
+          lines.push('---');
+          lines.push('');
+        } else if (tag === 'UL' || tag === 'OL') {
+          processList(el, '');
+        } else if (el.classList.contains('code-block')) {
+          const langEl = el.querySelector('.code-bar-lang');
+          const lang = langEl ? textOf(langEl) : '';
+          const code = el.querySelector('pre')?.textContent || '';
+          lines.push('```' + lang);
+          lines.push(code.trim());
+          lines.push('```');
+          lines.push('');
+        } else if (el.classList.contains('doc-table-wrap')) {
+          const table = el.querySelector('table');
+          if (table) processTable(table);
+        } else if (el.classList.contains('callout')) {
+          const txt = textOf(el);
+          lines.push('> **Note:** ' + txt);
+          lines.push('');
+        } else if (el.classList.contains('arch-diagram') || el.classList.contains('flow-row')) {
+          // Skip visual-only elements
+        } else {
+          // Fallback: grab text content for any other element
+          const txt = textOf(el);
+          if (txt) {
+            lines.push(txt);
+            lines.push('');
+          }
+        }
+      }
+
+      const markdown = lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+      navigator.clipboard.writeText(markdown).then(() => {
+        const btn = document.getElementById('llmCopyBtn');
+        const label = document.getElementById('llmBtnLabel');
+        btn.classList.add('copied');
+        label.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          label.textContent = 'Copy for LLM';
+        }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,2255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mimic — Synthetic environments for AI agents</title>
+  <meta name="description" content="Open-source synthetic environment engine. One persona, coherent data across every database, API, and MCP server your agent touches." />
+  <meta property="og:title" content="Mimic — Synthetic environments for AI agents" />
+  <meta property="og:description" content="One command to simulate every data source your AI agent talks to." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://mimic.dev" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700;14..32,800;14..32,900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #050507;
+      --bg-subtle: #0a0a0e;
+      --bg-raised: #0f0f14;
+      --bg-card: #131318;
+      --bg-card-hover: #19191f;
+      --border: #1e1e26;
+      --border-mid: #2a2a35;
+      --border-bright: #3a3a48;
+      --text: #f0f0f5;
+      --text-secondary: #9898a8;
+      --text-muted: #5c5c6e;
+      --accent: #7c6aff;
+      --accent-bright: #9585ff;
+      --accent-dim: #5a4ad4;
+      --accent-glow: rgba(124, 106, 255, 0.15);
+      --accent-glow-strong: rgba(124, 106, 255, 0.3);
+      --green: #3ecf71;
+      --green-dim: rgba(62, 207, 113, 0.12);
+      --cyan: #2dd4bf;
+      --cyan-dim: rgba(45, 212, 191, 0.12);
+      --amber: #f5b731;
+      --amber-dim: rgba(245, 183, 49, 0.12);
+      --pink: #f06595;
+      --pink-dim: rgba(240, 101, 149, 0.12);
+      --red: #ef4444;
+      --mono: 'JetBrains Mono', ui-monospace, monospace;
+      --sans: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      --max-w: 1140px;
+      --r-sm: 8px;
+      --r-md: 12px;
+      --r-lg: 16px;
+      --r-xl: 20px;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--sans);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      overflow-x: hidden;
+    }
+
+    a { color: inherit; }
+
+    ::selection {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    /* ─── UTILITY ──────────────────────────────── */
+    .container {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    .fade-in {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+                  transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .fade-in.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    /* ─── NAV ──────────────────────────────────── */
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      backdrop-filter: blur(20px) saturate(1.4);
+      -webkit-backdrop-filter: blur(20px) saturate(1.4);
+      background: rgba(5, 5, 7, 0.75);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .nav-inner {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 24px;
+      height: 60px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-left {
+      display: flex;
+      align-items: center;
+      gap: 32px;
+    }
+
+    .nav-logo {
+      font-weight: 800;
+      font-size: 1.15rem;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: -0.03em;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .nav-logo-icon {
+      width: 26px;
+      height: 26px;
+      border-radius: 7px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-dim));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .nav-logo-icon svg { width: 16px; height: 16px; }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      list-style: none;
+    }
+
+    .nav-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      padding: 6px 12px;
+      border-radius: var(--r-sm);
+      transition: color 0.15s, background 0.15s;
+    }
+
+    .nav-links a:hover {
+      color: var(--text-secondary);
+      background: rgba(255,255,255,0.04);
+    }
+
+    .nav-right {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .nav-gh {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      padding: 7px 14px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border-mid);
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .nav-gh:hover {
+      border-color: var(--border-bright);
+      color: var(--text);
+    }
+
+    .nav-gh svg { opacity: 0.7; }
+
+    .nav-cta-btn {
+      background: var(--accent);
+      color: #fff;
+      padding: 7px 16px;
+      border-radius: var(--r-sm);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+
+    .nav-cta-btn:hover { background: var(--accent-bright); }
+
+    .mobile-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--text);
+      cursor: pointer;
+      padding: 4px;
+    }
+
+    /* ─── HERO ─────────────────────────────────── */
+    .hero {
+      padding: 152px 24px 80px;
+      text-align: center;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 100%;
+      max-width: 900px;
+      height: 600px;
+      background: radial-gradient(ellipse 70% 50% at 50% 0%, var(--accent-glow) 0%, transparent 100%);
+      pointer-events: none;
+    }
+
+    .hero-badges {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin-bottom: 36px;
+      position: relative;
+      flex-wrap: wrap;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 14px 5px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border-mid);
+      background: var(--bg-raised);
+      font-size: 0.78rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: border-color 0.2s;
+    }
+
+    .badge:hover { border-color: var(--border-bright); }
+
+    .badge-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .badge-oss {
+      border-color: rgba(62, 207, 113, 0.25);
+    }
+
+    .badge-oss .badge-icon { color: var(--green); }
+
+    h1 {
+      font-size: clamp(2.75rem, 6.5vw, 4.5rem);
+      font-weight: 900;
+      letter-spacing: -0.045em;
+      line-height: 1.05;
+      max-width: 800px;
+      margin: 0 auto 28px;
+      position: relative;
+    }
+
+    .text-gradient {
+      background: linear-gradient(135deg, #b4a5ff 0%, var(--accent) 40%, var(--cyan) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero-desc {
+      font-size: clamp(1rem, 1.8vw, 1.2rem);
+      color: var(--text-secondary);
+      max-width: 560px;
+      margin: 0 auto 44px;
+      line-height: 1.7;
+      font-weight: 400;
+    }
+
+    .hero-desc strong {
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .hero-actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 20px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 13px 28px;
+      border-radius: var(--r-md);
+      font-size: 0.9375rem;
+      font-weight: 600;
+      text-decoration: none;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 0 0 1px rgba(124,106,255,0.3), 0 1px 2px rgba(0,0,0,0.3), 0 0 32px var(--accent-glow);
+    }
+
+    .btn-primary:hover {
+      background: var(--accent-bright);
+      box-shadow: 0 0 0 1px rgba(124,106,255,0.5), 0 2px 8px rgba(0,0,0,0.3), 0 0 48px var(--accent-glow-strong);
+      transform: translateY(-1px);
+    }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-secondary);
+      border: 1px solid var(--border-mid);
+    }
+
+    .btn-ghost:hover {
+      color: var(--text);
+      border-color: var(--border-bright);
+      background: rgba(255,255,255,0.03);
+    }
+
+    .install-bar {
+      display: inline-flex;
+      align-items: center;
+      gap: 14px;
+      margin-top: 20px;
+      padding: 10px 18px;
+      border-radius: var(--r-sm);
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      font-family: var(--mono);
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      cursor: pointer;
+      transition: border-color 0.2s;
+      user-select: none;
+    }
+
+    .install-bar:hover { border-color: var(--border-mid); }
+    .install-bar .cmd { color: var(--text-secondary); }
+    .install-bar .copy-btn {
+      color: var(--text-muted);
+      transition: color 0.15s;
+      display: flex;
+    }
+    .install-bar:hover .copy-btn { color: var(--text-secondary); }
+
+    /* ─── HERO TERMINAL ────────────────────────── */
+    .hero-visual {
+      margin-top: 64px;
+      position: relative;
+      max-width: 720px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .hero-visual::before {
+      content: '';
+      position: absolute;
+      inset: -1px;
+      border-radius: calc(var(--r-lg) + 1px);
+      padding: 1px;
+      background: linear-gradient(180deg, var(--border-mid) 0%, var(--border) 100%);
+      -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      -webkit-mask-composite: xor;
+      mask-composite: exclude;
+      pointer-events: none;
+    }
+
+    .terminal {
+      border-radius: var(--r-lg);
+      background: var(--bg-raised);
+      overflow: hidden;
+      box-shadow: 0 32px 80px -12px rgba(0, 0, 0, 0.6),
+                  0 0 0 1px var(--border);
+    }
+
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 14px 18px;
+      background: var(--bg-card);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .terminal-dot {
+      width: 11px;
+      height: 11px;
+      border-radius: 50%;
+    }
+
+    .terminal-dot.r { background: #ff5f57; }
+    .terminal-dot.y { background: #febc2e; }
+    .terminal-dot.g { background: #28c840; }
+
+    .terminal-title {
+      flex: 1;
+      text-align: center;
+      font-size: 0.6875rem;
+      color: var(--text-muted);
+      font-family: var(--mono);
+      letter-spacing: 0.02em;
+    }
+
+    .terminal-body {
+      padding: 24px 28px 28px;
+      font-family: var(--mono);
+      font-size: 0.8125rem;
+      line-height: 2;
+    }
+
+    .t-prompt { color: var(--accent-bright); user-select: none; }
+    .t-cmd { color: var(--text); }
+    .t-flag { color: var(--cyan); }
+    .t-out { color: var(--text-muted); }
+    .t-ok { color: var(--green); }
+    .t-url { color: var(--text-secondary); }
+    .t-blank { display: block; height: 8px; }
+
+    /* ─── OPEN SOURCE BANNER ───────────────────── */
+    .oss-banner {
+      padding: 100px 24px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .oss-banner::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, transparent 0%, rgba(62, 207, 113, 0.03) 50%, transparent 100%);
+      pointer-events: none;
+    }
+
+    .oss-inner {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 64px;
+      align-items: center;
+    }
+
+    .oss-content .section-eyebrow {
+      color: var(--green);
+    }
+
+    .oss-title {
+      font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+      font-weight: 800;
+      letter-spacing: -0.035em;
+      line-height: 1.15;
+      margin-bottom: 20px;
+    }
+
+    .oss-desc {
+      color: var(--text-secondary);
+      font-size: 1.0625rem;
+      line-height: 1.7;
+      margin-bottom: 32px;
+      max-width: 480px;
+    }
+
+    .oss-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      margin-bottom: 36px;
+    }
+
+    .oss-list li {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+    }
+
+    .oss-check {
+      width: 28px;
+      height: 28px;
+      border-radius: 8px;
+      background: var(--green-dim);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .oss-check svg { color: var(--green); }
+
+    .oss-links {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .oss-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      border-radius: var(--r-sm);
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+    }
+
+    .oss-link.gh {
+      background: #fff;
+      color: #000;
+    }
+
+    .oss-link.gh:hover { opacity: 0.9; }
+
+    .oss-link.discord {
+      background: rgba(88, 101, 242, 0.12);
+      color: #7289da;
+      border: 1px solid rgba(88, 101, 242, 0.2);
+    }
+
+    .oss-link.discord:hover {
+      background: rgba(88, 101, 242, 0.18);
+    }
+
+    .oss-visual {
+      position: relative;
+    }
+
+    .oss-tree {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      padding: 32px;
+      font-family: var(--mono);
+      font-size: 0.8125rem;
+      line-height: 1.9;
+      color: var(--text-muted);
+    }
+
+    .oss-tree .dir { color: var(--accent-bright); font-weight: 600; }
+    .oss-tree .apache { color: var(--green); }
+    .oss-tree .elv2 { color: var(--amber); }
+    .oss-tree .comment { color: var(--text-muted); font-style: italic; }
+
+    /* ─── SECTIONS ─────────────────────────────── */
+    .section {
+      padding: 110px 24px;
+    }
+
+    .section-eyebrow {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 14px;
+    }
+
+    .section-title {
+      font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+      font-weight: 800;
+      letter-spacing: -0.035em;
+      line-height: 1.15;
+      margin-bottom: 16px;
+    }
+
+    .section-desc {
+      font-size: 1.0625rem;
+      color: var(--text-secondary);
+      max-width: 580px;
+      line-height: 1.7;
+      margin-bottom: 56px;
+    }
+
+    .section-desc.center {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .section-divider {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      border: none;
+      height: 1px;
+      background: var(--border);
+    }
+
+    /* ─── PROBLEM ──────────────────────────────── */
+    .pain-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 16px;
+    }
+
+    .pain-card {
+      border-radius: var(--r-md);
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      overflow: hidden;
+      transition: border-color 0.25s, transform 0.25s;
+    }
+
+    .pain-card:hover {
+      border-color: var(--border-mid);
+      transform: translateY(-2px);
+    }
+
+    .pain-top {
+      padding: 22px 24px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      line-height: 1.5;
+    }
+
+    .pain-icon {
+      flex-shrink: 0;
+      width: 20px;
+      margin-top: 1px;
+      color: var(--red);
+      opacity: 0.7;
+    }
+
+    .pain-bottom {
+      padding: 22px 24px;
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: rgba(62, 207, 113, 0.03);
+    }
+
+    .fix-icon {
+      flex-shrink: 0;
+      width: 20px;
+      margin-top: 1px;
+      color: var(--green);
+    }
+
+    /* ─── HOW IT WORKS ─────────────────────────── */
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0;
+      position: relative;
+    }
+
+    .flow::before {
+      content: '';
+      position: absolute;
+      top: 38px;
+      left: 60px;
+      right: 60px;
+      height: 2px;
+      background: linear-gradient(90deg, var(--accent) 0%, var(--cyan) 100%);
+      opacity: 0.2;
+      z-index: 0;
+    }
+
+    .flow-step {
+      text-align: center;
+      position: relative;
+      z-index: 1;
+      padding: 0 12px;
+    }
+
+    .flow-num {
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background: var(--bg-card);
+      border: 2px solid var(--border-mid);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 0.875rem;
+      color: var(--accent-bright);
+      margin: 0 auto 20px;
+      transition: border-color 0.3s, background 0.3s;
+    }
+
+    .flow-step:hover .flow-num {
+      border-color: var(--accent);
+      background: var(--accent-glow);
+    }
+
+    .flow-cmd {
+      font-family: var(--mono);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--accent-bright);
+      margin-bottom: 10px;
+    }
+
+    .flow-step h3 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+
+    .flow-step p {
+      color: var(--text-muted);
+      font-size: 0.8125rem;
+      line-height: 1.55;
+      max-width: 220px;
+      margin: 0 auto;
+    }
+
+    /* ─── ARCHITECTURE ─────────────────────────── */
+    .arch-visual {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .arch-persona {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+
+    .arch-persona-box {
+      display: inline-block;
+      background: linear-gradient(135deg, rgba(124,106,255,0.08), rgba(45,212,191,0.06));
+      border: 1px solid var(--border-mid);
+      border-radius: var(--r-md);
+      padding: 24px 40px;
+      position: relative;
+    }
+
+    .arch-persona-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent-bright);
+      margin-bottom: 8px;
+    }
+
+    .arch-persona-text {
+      font-family: var(--mono);
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .arch-line {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 12px;
+    }
+
+    .arch-line-svg { color: var(--border-mid); }
+
+    .arch-engine {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+
+    .arch-engine-box {
+      display: inline-block;
+      background: var(--bg-card);
+      border: 1px solid var(--accent);
+      border-radius: var(--r-md);
+      padding: 14px 32px;
+      box-shadow: 0 0 32px var(--accent-glow);
+    }
+
+    .arch-engine-label {
+      font-size: 0.8125rem;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    .arch-engine-sub {
+      font-size: 0.6875rem;
+      color: var(--text-muted);
+      margin-top: 2px;
+    }
+
+    .arch-outputs {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 12px;
+    }
+
+    .arch-adapter {
+      text-align: center;
+      padding: 20px 8px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-md);
+      transition: border-color 0.25s;
+    }
+
+    .arch-adapter:hover { border-color: var(--border-mid); }
+
+    .arch-adapter-name {
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    .arch-adapter-type {
+      font-size: 0.625rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+    }
+
+    .arch-adapter-type.db { color: var(--green); }
+    .arch-adapter-type.api { color: var(--cyan); }
+    .arch-adapter-type.mcp { color: var(--accent-bright); }
+
+    .arch-adapter-target {
+      font-family: var(--mono);
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      margin-top: 8px;
+    }
+
+    /* ─── ADAPTERS ─────────────────────────────── */
+    .adapter-stat {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 10px;
+      margin-bottom: 48px;
+    }
+
+    .adapter-stat-num {
+      font-size: 4rem;
+      font-weight: 900;
+      letter-spacing: -0.04em;
+      background: linear-gradient(135deg, var(--accent-bright), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      line-height: 1;
+    }
+
+    .adapter-stat-label {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+    }
+
+    .adapter-category {
+      margin-bottom: 40px;
+    }
+
+    .adapter-category:last-child { margin-bottom: 0; }
+
+    .adapter-category-head {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .adapter-category-icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 7px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .adapter-category-title {
+      font-size: 0.9375rem;
+      font-weight: 700;
+    }
+
+    .adapter-category-count {
+      font-family: var(--mono);
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+      padding: 2px 8px;
+      border-radius: 4px;
+      margin-left: 4px;
+    }
+
+    .adapter-logo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+      gap: 8px;
+    }
+
+    .al-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-sm);
+      transition: border-color 0.2s, background 0.2s, transform 0.2s;
+      cursor: default;
+    }
+
+    .al-item:hover {
+      border-color: var(--border-mid);
+      background: var(--bg-card-hover);
+      transform: translateY(-1px);
+    }
+
+    .al-icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 800;
+      font-size: 0.6875rem;
+      letter-spacing: -0.02em;
+      flex-shrink: 0;
+      font-family: var(--sans);
+    }
+
+    .al-name {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .al-item:hover .al-name { color: var(--text); }
+
+    .al-more {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 10px 14px;
+      background: var(--bg-raised);
+      border: 1px dashed var(--border);
+      border-radius: var(--r-sm);
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      transition: color 0.2s;
+    }
+
+    .al-more:hover { color: var(--text-secondary); }
+
+    /* ─── MCP ──────────────────────────────────── */
+    .mcp-layout {
+      display: grid;
+      grid-template-columns: 1fr 1.15fr;
+      gap: 48px;
+      align-items: center;
+    }
+
+    .mcp-points {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      margin-top: 32px;
+    }
+
+    .mcp-point {
+      display: flex;
+      gap: 16px;
+      align-items: flex-start;
+    }
+
+    .mcp-point-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .mcp-point h4 {
+      font-size: 0.9375rem;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+
+    .mcp-point p {
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    .mcp-code-block {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      overflow: hidden;
+    }
+
+    .mcp-code-bar {
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--mono);
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .mcp-code-bar .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+      opacity: 0.5;
+    }
+
+    .mcp-code-block pre {
+      padding: 24px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      line-height: 1.75;
+      overflow-x: auto;
+      color: var(--text-muted);
+    }
+
+    .mcp-code-block .k { color: var(--cyan); }
+    .mcp-code-block .s { color: var(--green); }
+    .mcp-code-block .c { color: var(--text-muted); font-style: italic; }
+
+    /* ─── FEATURES ─────────────────────────────── */
+    .feat-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: var(--border);
+      border-radius: var(--r-lg);
+      overflow: hidden;
+      border: 1px solid var(--border);
+    }
+
+    .feat-cell {
+      background: var(--bg-card);
+      padding: 36px 32px;
+      transition: background 0.25s;
+    }
+
+    .feat-cell:hover {
+      background: var(--bg-card-hover);
+    }
+
+    .feat-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 20px;
+    }
+
+    .feat-cell h3 {
+      font-size: 0.9375rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+
+    .feat-cell p {
+      color: var(--text-muted);
+      font-size: 0.8125rem;
+      line-height: 1.6;
+    }
+
+    /* ─── CI/CD ────────────────────────────────── */
+    .cicd-container {
+      display: grid;
+      grid-template-columns: 1fr 1.3fr;
+      gap: 48px;
+      align-items: center;
+    }
+
+    .cicd-code {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      overflow: hidden;
+    }
+
+    .cicd-code-bar {
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--mono);
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+    }
+
+    .cicd-code pre {
+      padding: 24px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      line-height: 1.75;
+      overflow-x: auto;
+    }
+
+    .cicd-code .yk { color: var(--cyan); }
+    .cicd-code .ys { color: var(--green); }
+    .cicd-code .yc { color: var(--text-muted); }
+
+    /* ─── PRICING ──────────────────────────────── */
+    .pricing-container {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .price-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      padding: 36px 32px;
+      position: relative;
+      transition: border-color 0.25s;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .price-card:hover { border-color: var(--border-mid); }
+
+    .price-card.pop {
+      border-color: var(--accent);
+      background: linear-gradient(180deg, rgba(124,106,255,0.06) 0%, var(--bg-card) 40%);
+    }
+
+    .price-card.pop::before {
+      content: 'Popular';
+      position: absolute;
+      top: -10px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--accent);
+      color: #fff;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      padding: 3px 14px;
+      border-radius: 999px;
+      letter-spacing: 0.03em;
+    }
+
+    .price-tier-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 12px;
+    }
+
+    .price-number {
+      font-size: 2.75rem;
+      font-weight: 900;
+      letter-spacing: -0.04em;
+      line-height: 1;
+      margin-bottom: 4px;
+    }
+
+    .price-number .per {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text-muted);
+      letter-spacing: 0;
+    }
+
+    .price-tagline {
+      color: var(--text-muted);
+      font-size: 0.8125rem;
+      margin-bottom: 28px;
+      padding-bottom: 28px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .price-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-bottom: 32px;
+      flex: 1;
+    }
+
+    .price-list li {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+    }
+
+    .price-list li svg {
+      flex-shrink: 0;
+      color: var(--green);
+    }
+
+    .price-action {
+      display: block;
+      width: 100%;
+      text-align: center;
+      padding: 11px;
+      border-radius: var(--r-sm);
+      font-weight: 600;
+      font-size: 0.8125rem;
+      text-decoration: none;
+      transition: all 0.15s;
+      cursor: pointer;
+    }
+
+    .price-action.outline {
+      border: 1px solid var(--border-mid);
+      color: var(--text-secondary);
+      background: transparent;
+    }
+
+    .price-action.outline:hover {
+      border-color: var(--border-bright);
+      color: var(--text);
+    }
+
+    .price-action.accent {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+    }
+
+    .price-action.accent:hover { background: var(--accent-bright); }
+
+    .price-action.white {
+      background: #fff;
+      color: #000;
+      border: none;
+    }
+
+    .price-action.white:hover { opacity: 0.9; }
+
+    /* ─── CTA ──────────────────────────────────── */
+    .final-cta {
+      padding: 120px 24px 140px;
+      text-align: center;
+      position: relative;
+    }
+
+    .final-cta::before {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 100%;
+      max-width: 900px;
+      height: 400px;
+      background: radial-gradient(ellipse 60% 60% at 50% 100%, var(--accent-glow) 0%, transparent 100%);
+      pointer-events: none;
+    }
+
+    .final-cta h2 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 900;
+      letter-spacing: -0.04em;
+      margin-bottom: 16px;
+      position: relative;
+    }
+
+    .final-cta p {
+      color: var(--text-secondary);
+      font-size: 1.0625rem;
+      max-width: 480px;
+      margin: 0 auto 40px;
+      line-height: 1.7;
+      position: relative;
+    }
+
+    /* ─── FOOTER ───────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 40px 24px;
+    }
+
+    .footer-inner {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+
+    .footer-left {
+      color: var(--text-muted);
+      font-size: 0.8125rem;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 20px;
+      list-style: none;
+    }
+
+    .footer-links a {
+      color: var(--text-muted);
+      font-size: 0.8125rem;
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+
+    .footer-links a:hover { color: var(--text-secondary); }
+
+    /* ─── RESPONSIVE ───────────────────────────── */
+    @media (max-width: 1024px) {
+      .adapter-logo-grid { grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); }
+      .arch-outputs { grid-template-columns: repeat(3, 1fr); }
+      .feat-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    @media (max-width: 768px) {
+      .nav-links, .nav-right { display: none; }
+      .mobile-toggle { display: block; }
+
+      .nav-links.open {
+        display: flex;
+        flex-direction: column;
+        position: absolute;
+        top: 60px;
+        left: 0;
+        right: 0;
+        background: var(--bg);
+        border-bottom: 1px solid var(--border);
+        padding: 16px 24px;
+        gap: 8px;
+      }
+
+      .hero { padding: 120px 24px 60px; }
+
+      .oss-inner { grid-template-columns: 1fr; gap: 40px; }
+      .pain-grid { grid-template-columns: 1fr; }
+
+      .flow {
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+
+      .flow::before { display: none; }
+
+      .arch-outputs {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      .adapter-logo-grid { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); }
+
+      .mcp-layout { grid-template-columns: 1fr; }
+      .cicd-container { grid-template-columns: 1fr; }
+
+      .feat-grid { grid-template-columns: 1fr; }
+
+      .pricing-container {
+        grid-template-columns: 1fr;
+        max-width: 380px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <!-- ─── NAV ─────────────────────────────────── -->
+  <nav>
+    <div class="nav-inner">
+      <div class="nav-left">
+        <a class="nav-logo" href="#">
+          <span class="nav-logo-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 18V12L8 8L12 14L16 8L20 12V18"/>
+            </svg>
+          </span>
+          mimic
+        </a>
+        <ul class="nav-links" id="navLinks">
+          <li><a href="#how-it-works">How It Works</a></li>
+          <li><a href="#adapters">Adapters</a></li>
+          <li><a href="#mcp">MCP</a></li>
+          <li><a href="#pricing">Pricing</a></li>
+          <li><a href="docs.html">Docs</a></li>
+        </ul>
+      </div>
+      <div class="nav-right">
+        <a href="https://github.com/mimicailab/mimic" class="nav-gh">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          Star
+        </a>
+        <a href="#cta" class="nav-cta-btn">Get Started</a>
+      </div>
+      <button class="mobile-toggle" onclick="document.getElementById('navLinks').classList.toggle('open')" aria-label="Menu">
+        <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+    </div>
+  </nav>
+
+  <!-- ─── HERO ────────────────────────────────── -->
+  <section class="hero">
+    <div class="hero-badges">
+      <a href="https://github.com/mimicailab/mimic" class="badge badge-oss">
+        <span class="badge-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+        </span>
+        Open Source &middot; Apache 2.0
+      </a>
+      <span class="badge">
+        <span class="badge-icon" style="color: var(--accent-bright);">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        </span>
+        v0.1.0
+      </span>
+    </div>
+
+    <h1>
+      Simulate <span class="text-gradient">every data source</span><br/>
+      your AI agent talks to
+    </h1>
+
+    <p class="hero-desc">
+      <strong>One persona, coherent everywhere.</strong> Databases seeded,
+      APIs mocked, MCP servers ready &mdash; all from a single command.
+      Deterministic. Offline. Free.
+    </p>
+
+    <div class="hero-actions">
+      <a href="#cta" class="btn btn-primary">Get Started Free</a>
+      <a href="https://github.com/mimicailab/mimic" class="btn btn-ghost">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        Star on GitHub
+      </a>
+    </div>
+
+    <div class="install-bar" onclick="navigator.clipboard.writeText('npm install -g @mimicailab/cli').then(() => { this.querySelector('.copy-btn').innerHTML = 'Copied!'; setTimeout(() => { this.querySelector('.copy-btn').innerHTML = '<svg width=14 height=14 viewBox=&quot;0 0 24 24&quot; fill=none stroke=currentColor stroke-width=2><rect x=9 y=9 width=13 height=13 rx=2 /><path d=&quot;M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1&quot; /></svg>'; }, 1500); })">
+      <span style="color: var(--text-muted);">$</span>
+      <span class="cmd">npm install -g @mimicailab/cli</span>
+      <span class="copy-btn"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+    </div>
+
+    <div class="hero-visual">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <span class="terminal-dot r"></span>
+          <span class="terminal-dot y"></span>
+          <span class="terminal-dot g"></span>
+          <span class="terminal-title">mimic &mdash; finance-alex</span>
+        </div>
+        <div class="terminal-body">
+          <div><span class="t-prompt">$</span> <span class="t-cmd">mimic init</span></div>
+          <div><span class="t-prompt">$</span> <span class="t-cmd">mimic seed</span> <span class="t-flag">--persona finance-alex</span></div>
+          <div><span class="t-prompt">$</span> <span class="t-cmd">mimic host</span></div>
+          <span class="t-blank"></span>
+          <div><span class="t-ok">&#10003;</span> <span class="t-out">PostgreSQL</span>  <span class="t-out">&rarr;</span> <span class="t-url">seeded 4 tables, 1,247 rows</span></div>
+          <div><span class="t-ok">&#10003;</span> <span class="t-out">Plaid API</span>   <span class="t-out">&rarr;</span> <span class="t-url">http://localhost:4000/plaid</span></div>
+          <div><span class="t-ok">&#10003;</span> <span class="t-out">Stripe API</span>  <span class="t-out">&rarr;</span> <span class="t-url">http://localhost:4000/stripe/v1</span></div>
+          <div><span class="t-ok">&#10003;</span> <span class="t-out">Jira API</span>    <span class="t-out">&rarr;</span> <span class="t-url">http://localhost:4000/jira/rest/api/3</span></div>
+          <div><span class="t-ok">&#10003;</span> <span class="t-out">Slack MCP</span>   <span class="t-out">&rarr;</span> <span class="t-url">stdio ready</span></div>
+          <div><span class="t-ok">&#10003;</span> <span class="t-url">Ready in 1.2s</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── OPEN SOURCE BANNER ──────────────────── -->
+  <hr class="section-divider" />
+  <div class="oss-banner fade-in">
+    <div class="oss-inner">
+      <div class="oss-content">
+        <p class="section-eyebrow">Open Source</p>
+        <h2 class="oss-title">Free forever.<br/>Community driven.</h2>
+        <p class="oss-desc">
+          The CLI, all 65+ adapters, every MCP server, and pre-built personas are
+          Apache 2.0 licensed. No vendor lock-in, no bait-and-switch. Use it, fork it, contribute to it.
+        </p>
+        <ul class="oss-list">
+          <li>
+            <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            CLI + all adapters &mdash; Apache 2.0
+          </li>
+          <li>
+            <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            65+ MCP servers &mdash; Apache 2.0
+          </li>
+          <li>
+            <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Pre-built personas &mdash; Apache 2.0
+          </li>
+          <li>
+            <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Adapter SDK for community contributions
+          </li>
+          <li>
+            <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Works fully offline &mdash; no API keys needed
+          </li>
+        </ul>
+        <div class="oss-links">
+          <a href="https://github.com/mimicailab/mimic" class="oss-link gh">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+            View on GitHub
+          </a>
+          <a href="https://discord.gg/mimic" class="oss-link discord">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/></svg>
+            Join Discord
+          </a>
+        </div>
+      </div>
+      <div class="oss-visual">
+        <div class="oss-tree">
+<span class="dir">mimic/</span>
+<span class="dir">  packages/</span>
+<span class="dir">    oss/</span>                    <span class="apache"># Apache 2.0</span>
+      cli/                  <span class="comment">@mimicailab/cli</span>
+      adapter-sdk/          <span class="comment">build your own</span>
+      adapter-stripe/       <span class="comment">29 routes</span>
+      adapter-plaid/        <span class="comment">15 routes</span>
+      adapter-jira/         <span class="comment">21 routes</span>
+      ...                   <span class="comment">65+ adapters</span>
+      mcp-servers/          <span class="comment">65+ MCP servers</span>
+      mock-server/          <span class="comment">Fastify host</span>
+      blueprints/           <span class="comment">pre-built personas</span>
+<span class="dir">    commercial/</span>              <span class="elv2"># Elastic License v2</span>
+      blueprint-engine/     <span class="comment">custom generation</span>
+      test-advanced/        <span class="comment">LLM-as-judge</span>
+      dashboard/            <span class="comment">web UI</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─── PROBLEM ─────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in">
+    <div class="container">
+      <p class="section-eyebrow">The Problem</p>
+      <h2 class="section-title">Testing AI agents is broken</h2>
+      <p class="section-desc">
+        Your agent touches five APIs simultaneously. You can only test one at a time,
+        with inconsistent data, rate limits, and 60% API coverage.
+      </p>
+      <div class="pain-grid">
+        <div class="pain-card">
+          <div class="pain-top">
+            <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
+            Plaid sandbox has "Jane", Stripe has "test_customer_1", your DB has seed.sql from 2023
+          </div>
+          <div class="pain-bottom">
+            <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            One persona, coherent everywhere
+          </div>
+        </div>
+        <div class="pain-card">
+          <div class="pain-top">
+            <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
+            Third-party sandboxes throttle you during CI runs
+          </div>
+          <div class="pain-bottom">
+            <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Local mock, zero latency, zero rate limits
+          </div>
+        </div>
+        <div class="pain-card">
+          <div class="pain-top">
+            <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
+            Sandboxes cover 60% of the API surface
+          </div>
+          <div class="pain-bottom">
+            <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Full API coverage with persona-seeded data
+          </div>
+        </div>
+        <div class="pain-card">
+          <div class="pain-top">
+            <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
+            Tests break when sandbox data changes
+          </div>
+          <div class="pain-bottom">
+            <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Deterministic seeding &mdash; identical every run
+          </div>
+        </div>
+        <div class="pain-card">
+          <div class="pain-top">
+            <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
+            MCP servers have nothing to test against
+          </div>
+          <div class="pain-bottom">
+            <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            Mock MCP servers with realistic tool responses
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── HOW IT WORKS ────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="how-it-works">
+    <div class="container">
+      <p class="section-eyebrow">How It Works</p>
+      <h2 class="section-title">Four commands. Full environment.</h2>
+      <p class="section-desc">
+        Point Mimic at your schema, pick a persona, and your agent gets a fully populated
+        local environment with realistic, cross-surface consistent data.
+      </p>
+      <div class="flow">
+        <div class="flow-step">
+          <div class="flow-num">1</div>
+          <div class="flow-cmd">mimic init</div>
+          <h3>Configure</h3>
+          <p>Declare databases, APIs, and MCP servers. Mimic reads your actual schema.</p>
+        </div>
+        <div class="flow-step">
+          <div class="flow-num">2</div>
+          <div class="flow-cmd">mimic seed</div>
+          <h3>Seed</h3>
+          <p>One persona generates coherent data across every surface. Pre-built personas ship free.</p>
+        </div>
+        <div class="flow-step">
+          <div class="flow-num">3</div>
+          <div class="flow-cmd">mimic host</div>
+          <h3>Mock</h3>
+          <p>Spins up all API mocks and MCP servers on localhost. Point your agent and go.</p>
+        </div>
+        <div class="flow-step">
+          <div class="flow-num">4</div>
+          <div class="flow-cmd">mimic test</div>
+          <h3>Test</h3>
+          <p>Run scenarios with synthetic users and AI-powered evaluation. Fully CI/CD ready.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── ARCHITECTURE ────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="architecture">
+    <div class="container">
+      <p class="section-eyebrow">Architecture</p>
+      <h2 class="section-title">One persona. Every surface.</h2>
+      <p class="section-desc">
+        The Blueprint Engine generates a rich persona, then adapters project that data
+        consistently into every surface your agent touches. Same seed = identical output.
+      </p>
+      <div class="arch-visual">
+        <div class="arch-persona">
+          <div class="arch-persona-box">
+            <div class="arch-persona-label">Persona Blueprint</div>
+            <div class="arch-persona-text">
+              "Alex, 32, fintech PM, $85K, 3 bank accounts,<br/>
+              active trader, Jira power user, Slack daily"
+            </div>
+          </div>
+        </div>
+        <div class="arch-line">
+          <svg class="arch-line-svg" width="2" height="32" viewBox="0 0 2 32"><line x1="1" y1="0" x2="1" y2="32" stroke="currentColor" stroke-width="2" stroke-dasharray="4 4"/></svg>
+        </div>
+        <div class="arch-engine">
+          <div class="arch-engine-box">
+            <div class="arch-engine-label">Blueprint Engine</div>
+            <div class="arch-engine-sub">Cross-surface consistent generation</div>
+          </div>
+        </div>
+        <div class="arch-line">
+          <svg class="arch-line-svg" width="2" height="32" viewBox="0 0 2 32"><line x1="1" y1="0" x2="1" y2="32" stroke="currentColor" stroke-width="2" stroke-dasharray="4 4"/></svg>
+        </div>
+        <div class="arch-outputs">
+          <div class="arch-adapter">
+            <div class="arch-adapter-name">PostgreSQL</div>
+            <div class="arch-adapter-type db">DATABASE</div>
+            <div class="arch-adapter-target">Real DB seeded</div>
+          </div>
+          <div class="arch-adapter">
+            <div class="arch-adapter-name">Plaid</div>
+            <div class="arch-adapter-type api">API MOCK</div>
+            <div class="arch-adapter-target">:4000/plaid</div>
+          </div>
+          <div class="arch-adapter">
+            <div class="arch-adapter-name">Stripe</div>
+            <div class="arch-adapter-type api">API MOCK</div>
+            <div class="arch-adapter-target">:4000/stripe</div>
+          </div>
+          <div class="arch-adapter">
+            <div class="arch-adapter-name">Jira</div>
+            <div class="arch-adapter-type api">API MOCK</div>
+            <div class="arch-adapter-target">:4000/jira</div>
+          </div>
+          <div class="arch-adapter">
+            <div class="arch-adapter-name">Slack</div>
+            <div class="arch-adapter-type mcp">MCP</div>
+            <div class="arch-adapter-target">stdio</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── ADAPTERS ────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="adapters">
+    <div class="container">
+      <p class="section-eyebrow">Adapters</p>
+      <h2 class="section-title">Every API your agent needs</h2>
+      <div class="adapter-stat">
+        <span class="adapter-stat-num">65+</span>
+        <span class="adapter-stat-label">adapters across 8 categories</span>
+      </div>
+      <!-- Fintech -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(99,91,255,0.12); color: #635bff;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/></svg>
+          </span>
+          <span class="adapter-category-title">Fintech &amp; Payments</span>
+          <span class="adapter-category-count">24</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#635bff;color:#fff;">S</span><span class="al-name">Stripe</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#111;color:#fff;border:1px solid #333;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><circle cx="7" cy="12" r="4" fill="#111"/><circle cx="12" cy="7" r="4" fill="#333"/><circle cx="17" cy="12" r="4" fill="#555"/></svg>
+          </span><span class="al-name">Plaid</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#006aff;color:#fff;">Sq</span><span class="al-name">Square</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#003087;color:#fff;">PP</span><span class="al-name">PayPal</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0abf53;color:#fff;">A</span><span class="al-name">Adyen</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#9fe870;color:#163300;">W</span><span class="al-name">Wise</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f5a623;color:#fff;">C</span><span class="al-name">Coinbase</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#ff5733;color:#fff;">B</span><span class="al-name">Brex</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1c1c1c;color:#fff;border:1px solid #333;">R</span><span class="al-name">Ramp</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#4c3bcf;color:#fff;">M</span><span class="al-name">Mercury</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2d9cdb;color:#fff;">Mv</span><span class="al-name">Moov</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1e856d;color:#fff;">GC</span><span class="al-name">GoCardless</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#e87427;color:#fff;">Dw</span><span class="al-name">Dwolla</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0ba4db;color:#fff;">Ps</span><span class="al-name">Paystack</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f5a623;color:#fff;">Fw</span><span class="al-name">Flutterwave</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#003545;color:#22d3a7;">Mq</span><span class="al-name">Marqeta</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1a1a2e;color:#fff;border:1px solid #333;">Li</span><span class="al-name">Lithic</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f97316;color:#fff;">In</span><span class="al-name">Increase</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2563eb;color:#fff;">Co</span><span class="al-name">Column</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0666eb;color:#fff;">Rv</span><span class="al-name">Revolut</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#113d6b;color:#48e5c2;">Aw</span><span class="al-name">Airwallex</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0e1f3b;color:#00d67e;">Ck</span><span class="al-name">Checkout</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2e2e3a;color:#fff;border:1px solid #444;">Pd</span><span class="al-name">Paddle</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0d3b66;color:#6ec1e4;">Rp</span><span class="al-name">Rapyd</span></div>
+        </div>
+      </div>
+
+      <!-- Communication -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(45,212,191,0.12); color: var(--cyan);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </span>
+          <span class="adapter-category-title">Communication</span>
+          <span class="adapter-category-count">11</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#4a154b;color:#e01e5a;font-size:1rem;font-weight:900;">#</span><span class="al-name">Slack</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f22f46;color:#fff;">Tw</span><span class="al-name">Twilio</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1a82e2;color:#fff;">SG</span><span class="al-name">SendGrid</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#5865f2;color:#fff;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="#fff"><path d="M20.317 4.37a19.79 19.79 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.74 19.74 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.11 13.11 0 01-1.872-.892.077.077 0 01-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 01.078-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.099.246.198.373.292a.077.077 0 01-.006.127 12.3 12.3 0 01-1.873.892.076.076 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.84 19.84 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/></svg>
+          </span><span class="al-name">Discord</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#5558af;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M19.404 4.596L12 2 4.596 4.596 2 12l2.596 7.404L12 22l7.404-2.596L22 12l-2.596-7.404zM9 16.5V7.5l8 4.5-8 4.5z"/></svg>
+          </span><span class="al-name">MS Teams</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#25d366;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/></svg>
+          </span><span class="al-name">WhatsApp</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0088cc;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/></svg>
+          </span><span class="al-name">Telegram</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f06b54;color:#fff;">Mg</span><span class="al-name">Mailgun</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#ffde00;color:#000;">Pm</span><span class="al-name">Postmark</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1a1a2e;color:#fff;border:1px solid #333;">Vn</span><span class="al-name">Vonage</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2481d7;color:#fff;">MB</span><span class="al-name">MessageBird</span></div>
+        </div>
+      </div>
+
+      <!-- CRM -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(245,183,49,0.12); color: var(--amber);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+          </span>
+          <span class="adapter-category-title">CRM</span>
+          <span class="adapter-category-count">7</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#00a1e0;color:#fff;">SF</span><span class="al-name">Salesforce</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#ff7a59;color:#fff;">HS</span><span class="al-name">HubSpot</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1b1b1b;color:#21d07a;border:1px solid #333;">Pd</span><span class="al-name">Pipedrive</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#e42527;color:#fff;">Z</span><span class="al-name">Zoho CRM</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2b2e33;color:#fff;border:1px solid #444;">Cl</span><span class="al-name">Close</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#4346e3;color:#fff;">At</span><span class="al-name">Attio</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#002050;color:#00bcf2;">D3</span><span class="al-name">Dynamics 365</span></div>
+        </div>
+      </div>
+
+      <!-- Ticketing -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(240,101,149,0.12); color: var(--pink);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14,2 14,8 20,8"/></svg>
+          </span>
+          <span class="adapter-category-title">Ticketing</span>
+          <span class="adapter-category-count">8</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#03363d;color:#78a300;">Zd</span><span class="al-name">Zendesk</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0052cc;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M11.53 2c0 2.4 1.97 4.35 4.35 4.35h1.78v1.7c0 2.4 1.94 4.34 4.34 4.35V2.84A.84.84 0 0021.16 2H11.53zM6.77 7.17a4.36 4.36 0 004.34 4.34h1.78v1.71a4.36 4.36 0 004.35 4.35V7.99a.84.84 0 00-.84-.82H6.77zM2 12.36a4.35 4.35 0 004.34 4.34h1.79v1.71A4.35 4.35 0 0012.47 22v-9.57a.84.84 0 00-.84-.84H2v.77z"/></svg>
+          </span><span class="al-name">Jira</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#5e6ad2;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M3 7l6.5 10h5L21 7H3z"/></svg>
+          </span><span class="al-name">Linear</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#286efa;color:#fff;">Ic</span><span class="al-name">Intercom</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#06ac38;color:#fff;">PD</span><span class="al-name">PagerDuty</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#25c16f;color:#fff;">Fd</span><span class="al-name">Freshdesk</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#62d84e;color:#1b2a14;">SN</span><span class="al-name">ServiceNow</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#58b0de;color:#fff;">Sc</span><span class="al-name">Shortcut</span></div>
+        </div>
+      </div>
+
+      <!-- Project Management -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: var(--accent-glow); color: var(--accent-bright);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+          </span>
+          <span class="adapter-category-title">Project Management</span>
+          <span class="adapter-category-count">8</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#191919;color:#fff;border:1px solid #333;">N</span><span class="al-name">Notion</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#f06a6a;color:#fff;">As</span><span class="al-name">Asana</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0079bf;color:#fff;">Tr</span><span class="al-name">Trello</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#ff3d57;color:#fff;">Mo</span><span class="al-name">Monday</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#fcb400;color:#1b1b1b;">Ai</span><span class="al-name">Airtable</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#7b68ee;color:#fff;">Cu</span><span class="al-name">ClickUp</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#e44332;color:#fff;">Td</span><span class="al-name">Todoist</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#1d2d35;color:#5cc974;">Bc</span><span class="al-name">Basecamp</span></div>
+        </div>
+      </div>
+
+      <!-- Calendar -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(245,183,49,0.12); color: var(--amber);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+          </span>
+          <span class="adapter-category-title">Calendar &amp; Scheduling</span>
+          <span class="adapter-category-count">6</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#4285f4;color:#fff;">G</span><span class="al-name">Google Cal</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#006bff;color:#fff;">Ca</span><span class="al-name">Calendly</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#111;color:#fff;border:1px solid #333;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/></svg>
+          </span><span class="al-name">Cal.com</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#0054ff;color:#fff;">Ny</span><span class="al-name">Nylas</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#15b9a8;color:#fff;">Cr</span><span class="al-name">Cronofy</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#3b82f6;color:#fff;">Ac</span><span class="al-name">Acuity</span></div>
+        </div>
+      </div>
+
+      <!-- Databases -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: var(--green-dim); color: var(--green);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+          </span>
+          <span class="adapter-category-title">Databases</span>
+          <span class="adapter-category-count">5</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#336791;color:#fff;">Pg</span><span class="al-name">PostgreSQL</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#00684a;color:#00ed64;">M</span><span class="al-name">MongoDB</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#00618a;color:#f29111;">My</span><span class="al-name">MySQL</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#111;color:#fff;border:1px solid #333;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 22 8 22 16 12 22 2 16 2 8"/></svg>
+          </span><span class="al-name">Pinecone</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#dc382d;color:#fff;">Re</span><span class="al-name">Redis</span></div>
+        </div>
+      </div>
+
+      <!-- Developer -->
+      <div class="adapter-category">
+        <div class="adapter-category-head">
+          <span class="adapter-category-icon" style="background: rgba(240,101,149,0.12); color: var(--pink);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          </span>
+          <span class="adapter-category-title">Developer &amp; Other</span>
+          <span class="adapter-category-count">8+</span>
+        </div>
+        <div class="adapter-logo-grid">
+          <div class="al-item"><span class="al-icon" style="background:#24292e;color:#fff;border:1px solid #444;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          </span><span class="al-name">GitHub</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#fc6d26;color:#fff;">GL</span><span class="al-name">GitLab</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#96bf48;color:#fff;">Sh</span><span class="al-name">Shopify</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#ff9900;color:#232f3e;">S3</span><span class="al-name">AWS S3</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#eb5424;color:#fff;">A0</span><span class="al-name">Auth0</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#7856ff;color:#fff;">Mx</span><span class="al-name">Mixpanel</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#2ca01c;color:#fff;">QB</span><span class="al-name">QuickBooks</span></div>
+          <div class="al-item"><span class="al-icon" style="background:#4285f4;color:#fff;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M7.71 3.5l1.63 2.83-5.66 9.82H8l3.64-6.32L15.28 17H20L12 3.5H7.71z"/></svg>
+          </span><span class="al-name">Google Drive</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── MCP ─────────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="mcp">
+    <div class="container">
+      <p class="section-eyebrow">MCP Servers</p>
+      <h2 class="section-title">First-class MCP testing</h2>
+      <p class="section-desc">
+        10,000+ MCP servers exist in the wild. Zero have standardised testing tooling. Until now.
+      </p>
+      <div class="mcp-layout">
+        <div>
+          <ul class="mcp-points">
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--accent-glow);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+              </span>
+              <div>
+                <h4>Drop-in compatible</h4>
+                <p>For Jira, Slack, Asana, HubSpot, GitHub, and GitLab &mdash; our MCP servers match exact tool names and schemas.</p>
+              </div>
+            </li>
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--green-dim);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+              </span>
+              <div>
+                <h4>Swap the URL, not the code</h4>
+                <p>Replace MIMIC_BASE_URL with real credentials and your agent code doesn't change at all.</p>
+              </div>
+            </li>
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--cyan-dim);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+              </span>
+              <div>
+                <h4>Works everywhere</h4>
+                <p>Claude Code, Cursor, VS Code Copilot, and any custom MCP-compatible agent runtime.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="mcp-code-block">
+          <div class="mcp-code-bar">
+            <span class="dot"></span>
+            claude_desktop_config.json
+          </div>
+          <pre>{
+  <span class="k">"mcpServers"</span>: {
+    <span class="k">"mimic-jira"</span>: {
+      <span class="k">"command"</span>: <span class="s">"npx"</span>,
+      <span class="k">"args"</span>: [<span class="s">"-y"</span>, <span class="s">"@mimicailab/mcp-jira"</span>],
+      <span class="k">"env"</span>: {
+        <span class="k">"MIMIC_BASE_URL"</span>: <span class="s">"http://localhost:4000"</span>
+      }
+    },
+    <span class="k">"mimic-slack"</span>: {
+      <span class="k">"command"</span>: <span class="s">"npx"</span>,
+      <span class="k">"args"</span>: [<span class="s">"-y"</span>, <span class="s">"@mimicailab/mcp-slack"</span>],
+      <span class="k">"env"</span>: {
+        <span class="k">"MIMIC_BASE_URL"</span>: <span class="s">"http://localhost:4000"</span>
+      }
+    }
+  }
+}
+
+<span class="c">// Swap for production — zero code changes</span>
+<span class="c">// "JIRA_API_TOKEN": "real-token-here"</span></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── FEATURES ────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="features">
+    <div class="container">
+      <p class="section-eyebrow">Features</p>
+      <h2 class="section-title">Built for agent developers</h2>
+      <p class="section-desc">
+        Everything you need to test AI agents against realistic synthetic environments.
+      </p>
+      <div class="feat-grid">
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--accent-glow);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+          </div>
+          <h3>Cross-surface consistency</h3>
+          <p>One persona generates coherent data across databases, APIs, and MCP servers. Same user, matching records everywhere.</p>
+        </div>
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--green-dim);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          </div>
+          <h3>Deterministic seeding</h3>
+          <p>Same seed + same persona = identical data every run. No flaky tests from changing sandbox data.</p>
+        </div>
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--cyan-dim);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          </div>
+          <h3>714K rows/sec</h3>
+          <p>COPY FROM STDIN seeding with FK-aware topological ordering. Atomic transactions.</p>
+        </div>
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--amber-dim);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+          </div>
+          <h3>Works offline</h3>
+          <p>Pre-built personas ship with the package. No LLM calls, no API keys, no internet needed.</p>
+        </div>
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--pink-dim);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pink)" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          </div>
+          <h3>Schema-first</h3>
+          <p>Reads your actual Prisma files, SQL DDL, or introspects live databases. Works for any domain.</p>
+        </div>
+        <div class="feat-cell">
+          <div class="feat-icon" style="background: var(--green-dim);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+          </div>
+          <h3>100% open source core</h3>
+          <p>CLI, all adapters, MCP servers, and personas are Apache 2.0. Community-contributable with a standardised SDK.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── CI/CD ───────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="cicd">
+    <div class="container">
+      <p class="section-eyebrow">CI/CD</p>
+      <h2 class="section-title">Test agents in every pipeline</h2>
+      <p class="section-desc">
+        Add three lines to your workflow. Deterministic environments mean zero flaky agent tests.
+      </p>
+      <div class="cicd-container">
+        <div>
+          <ul class="mcp-points">
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--green-dim);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+              </span>
+              <div>
+                <h4>Reproducible</h4>
+                <p>Same persona + same seed = identical environment in every CI run. No sandbox drift.</p>
+              </div>
+            </li>
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--cyan-dim);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+              </span>
+              <div>
+                <h4>Fast</h4>
+                <p>Local mocks start in under 2 seconds. No network calls to external sandboxes.</p>
+              </div>
+            </li>
+            <li class="mcp-point">
+              <span class="mcp-point-icon" style="background: var(--amber-dim);">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              </span>
+              <div>
+                <h4>No secrets needed</h4>
+                <p>Pre-built personas work offline. No API keys or service credentials in CI.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="cicd-code">
+          <div class="cicd-code-bar">.github/workflows/agent-tests.yml</div>
+          <pre><span class="yk">- name:</span> <span class="ys">Start Mimic</span>
+  <span class="yk">run:</span> |
+    npx @mimicailab/cli seed --persona finance-alex
+    npx @mimicailab/cli host --background
+
+<span class="yk">- name:</span> <span class="ys">Run agent tests</span>
+  <span class="yk">run:</span> npm test
+  <span class="yk">env:</span>
+    <span class="yk">PLAID_BASE_URL:</span> <span class="ys">http://localhost:4000/plaid</span>
+    <span class="yk">STRIPE_API_BASE:</span> <span class="ys">http://localhost:4000/stripe/v1</span>
+
+<span class="yk">- name:</span> <span class="ys">Cleanup</span>
+  <span class="yk">run:</span> npx @mimicailab/cli clean</pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── PRICING ─────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="pricing">
+    <div class="container" style="text-align: center;">
+      <p class="section-eyebrow">Pricing</p>
+      <h2 class="section-title" style="text-align: center;">Free to start. Scale when ready.</h2>
+      <p class="section-desc center">
+        The open-source core works without an account. Pro unlocks custom personas and advanced testing.
+      </p>
+      <div class="pricing-container">
+        <div class="price-card">
+          <div class="price-tier-label">Community</div>
+          <div class="price-number">Free</div>
+          <div class="price-tagline">Everything to get started</div>
+          <ul class="price-list">
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> CLI + all 65+ adapters</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> All MCP servers</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> 3 pre-built personas</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> 3 custom blueprints/mo</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> 500 test runs/mo</li>
+          </ul>
+          <a href="#cta" class="price-action outline">Get Started</a>
+        </div>
+        <div class="price-card pop">
+          <div class="price-tier-label">Pro</div>
+          <div class="price-number">$39 <span class="per">/seat/mo</span></div>
+          <div class="price-tagline">For teams shipping agents</div>
+          <ul class="price-list">
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Everything in Community</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> All domain personas</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Unlimited blueprints</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> 25K test runs/mo</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> LLM-powered evaluation</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> CI/CD integration</li>
+          </ul>
+          <a href="https://mimic.dev/pricing" class="price-action accent">Start Free Trial</a>
+        </div>
+        <div class="price-card">
+          <div class="price-tier-label">Enterprise</div>
+          <div class="price-number">Custom</div>
+          <div class="price-tagline">Compliance &amp; scale</div>
+          <ul class="price-list">
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Everything in Pro</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Unlimited test runs</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> SSO / SAML / RBAC</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Self-hosted option</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Custom persona building</li>
+            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg> Dedicated SLA</li>
+          </ul>
+          <a href="https://mimic.dev/contact" class="price-action white">Contact Sales</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── CTA ─────────────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="final-cta" id="cta">
+    <h2>Start testing agents<br/>the way they actually run</h2>
+    <p>Install in 30 seconds. No account required. Pre-built personas ship free. Open source forever.</p>
+    <div class="hero-actions" style="position: relative;">
+      <a href="docs.html" class="btn btn-primary">Read the Docs</a>
+      <a href="https://github.com/mimicailab/mimic" class="btn btn-ghost">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        Star on GitHub
+      </a>
+    </div>
+    <div class="install-bar" style="position: relative; margin-top: 20px;" onclick="navigator.clipboard.writeText('npm install -g @mimicailab/cli').then(() => { this.querySelector('.copy-btn').innerHTML = 'Copied!'; setTimeout(() => { this.querySelector('.copy-btn').innerHTML = '<svg width=14 height=14 viewBox=&quot;0 0 24 24&quot; fill=none stroke=currentColor stroke-width=2><rect x=9 y=9 width=13 height=13 rx=2 /><path d=&quot;M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1&quot; /></svg>'; }, 1500); })">
+      <span style="color: var(--text-muted);">$</span>
+      <span class="cmd">npm install -g @mimicailab/cli</span>
+      <span class="copy-btn"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+    </div>
+  </section>
+
+  <!-- ─── FOOTER ──────────────────────────────── -->
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-left">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 18V12L8 8L12 14L16 8L20 12V18"/></svg>
+        Mimic &middot; Apache 2.0 + ELv2
+      </div>
+      <ul class="footer-links">
+        <li><a href="docs.html">Docs</a></li>
+        <li><a href="https://github.com/mimicailab/mimic">GitHub</a></li>
+        <li><a href="https://discord.gg/mimic">Discord</a></li>
+        <li><a href="https://twitter.com/mimic_data">Twitter</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <!-- ─── SCROLL REVEAL ────────────────────────── -->
+  <script>
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); } });
+    }, { threshold: 0.08 });
+    document.querySelectorAll('.fade-in').forEach(el => obs.observe(el));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Add a complete landing page and documentation site for the Mimic project, built as static single-file HTML pages with no external dependencies beyond Google Fonts.

Landing page (index.html):
- Dark-themed design system (Inter + JetBrains Mono, #050507 base)
- Hero section with animated terminal demo
- Open-source positioning with Apache 2.0 callout
- Problem/solution narrative, How It Works flow diagram
- Architecture overview with interactive diagram
- 65+ adapter catalog with brand-colored monogram icons
- MCP server integration section
- Bento-grid feature highlights
- CI/CD pipeline example with YAML snippet
- Pricing tiers (OSS / Pro / Enterprise)
- Scroll-reveal animations via IntersectionObserver

Documentation site (docs.html):
- Fixed sidebar navigation with 8 groups, 28 section links
- Active section tracking via IntersectionObserver
- Full coverage: quickstart, core concepts, config reference, CLI commands, adapter catalog, MCP setup, architecture, guides
- Syntax-highlighted code blocks with copy buttons
- Styled tables, callout boxes, and responsive layout
- "Copy for LLM" floating button that converts the entire doc page to clean Markdown and copies to clipboard