### PR TITLE
fix: remove @mimicailab/docs from changesets ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,5 +24,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": ["@mimicailab/docs"]
+  "ignore": []
 }


### PR DESCRIPTION
The docs package is not yet in the workspace, causing changesets version to fail with a ValidationError.