### PR TITLE
ci: add docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # For OIDC auth with AWS
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm --filter @mimicai/docs build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync packages/docs/dist/ s3://${{ secrets.DOCS_S3_BUCKET }}/ \
+            --delete \
+            --cache-control "public, max-age=3600" \
+            --exclude "_astro/*"
+
+          # Long cache for hashed assets
+          aws s3 sync packages/docs/dist/_astro/ s3://${{ secrets.DOCS_S3_BUCKET }}/_astro/ \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.DOCS_CLOUDFRONT_ID }} \
+            --paths "/*"


### PR DESCRIPTION
## Summary
- Adds GitHub Action to build and deploy the Astro docs site to AWS S3 + CloudFront
- Triggers on changes to `packages/docs/` or manual dispatch
- Uses OIDC for AWS auth, proper cache headers (1hr HTML, 1yr immutable for hashed assets)

## Required secrets (set after Terraform infra is provisioned)
| Secret | Description |
|--------|-------------|
| `AWS_DEPLOY_ROLE_ARN` | IAM role ARN for GitHub OIDC |
| `DOCS_S3_BUCKET` | S3 bucket name |
| `DOCS_CLOUDFRONT_ID` | CloudFront distribution ID |

## Test plan
- [ ] Verify workflow syntax with `act` or dry-run
- [ ] Set up Terraform infra in private repo
- [ ] Configure secrets and trigger manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)