### PR TITLE
docs(landing): refresh copy and add use cases section

### DIFF
--- a/packages/docs/src/pages/index.html
+++ b/packages/docs/src/pages/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mimic — Synthetic environments for AI agents</title>
-  <meta name="description" content="Open-source synthetic environment engine. One persona, coherent data across every database, API, and MCP server your agent touches." />
+  <meta name="description" content="Test your AI agents against the real world. Simulate APIs, databases, MCP servers, and user personas. Deterministic. Offline. Open source." />
   <meta property="og:title" content="Mimic — Synthetic environments for AI agents" />
   <meta property="og:description" content="One command to simulate every data source your AI agent talks to." />
   <meta property="og:type" content="website" />
@@ -559,6 +559,8 @@
       font-size: 0.8125rem;
       line-height: 1.9;
       color: var(--text-secondary);
+      white-space: pre;
+      overflow-x: auto;
     }
 
     .oss-tree .dir { color: var(--accent-bright); font-weight: 600; }
@@ -1104,6 +1106,110 @@
       line-height: 1.65;
     }
 
+    /* ─── USE CASES ───────────────────────────── */
+    .usecase-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+
+    .usecase-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-md);
+      padding: 0;
+      overflow: hidden;
+      transition: border-color 0.25s, transform 0.25s;
+      position: relative;
+    }
+
+    .usecase-card::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 3px;
+      height: 100%;
+      border-radius: 3px 0 0 3px;
+    }
+
+    .usecase-card:nth-child(1)::before { background: var(--accent-bright); }
+    .usecase-card:nth-child(2)::before { background: var(--green); }
+    .usecase-card:nth-child(3)::before { background: var(--pink); }
+    .usecase-card:nth-child(4)::before { background: var(--cyan); }
+
+    .usecase-card:hover {
+      border-color: var(--border-mid);
+      transform: translateY(-2px);
+    }
+
+    .usecase-card-inner {
+      padding: 32px 28px;
+    }
+
+    .usecase-header {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin-bottom: 14px;
+    }
+
+    .usecase-icon {
+      width: 42px;
+      height: 42px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .usecase-card h3 {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+
+    .usecase-card p {
+      color: var(--text-secondary);
+      font-size: 0.8125rem;
+      line-height: 1.65;
+      margin-bottom: 20px;
+    }
+
+    .usecase-cmd {
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--r-sm);
+      padding: 10px 14px;
+      margin-bottom: 18px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .usecase-cmd .prompt {
+      color: var(--accent-bright);
+      user-select: none;
+    }
+
+    .usecase-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .usecase-tag {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      padding: 3px 10px;
+      border-radius: 20px;
+      border: 1px solid;
+    }
+
     /* ─── CI/CD ────────────────────────────────── */
     .cicd-container {
       display: grid;
@@ -1399,6 +1505,7 @@
       .cicd-container { grid-template-columns: 1fr; }
 
       .feat-grid { grid-template-columns: 1fr; }
+      .usecase-grid { grid-template-columns: 1fr; }
 
       .pricing-container {
         grid-template-columns: 1fr;
@@ -1417,6 +1524,7 @@
         </a>
         <ul class="nav-links" id="navLinks">
           <li><a href="#how-it-works">How It Works</a></li>
+          <li><a href="#use-cases">Use Cases</a></li>
           <li><a href="#adapters">Adapters</a></li>
           <li><a href="#mcp">MCP</a></li>
           <li><a href="#pricing">Pricing</a></li>
@@ -1454,14 +1562,13 @@
     </div>
 
     <h1>
-      Simulate <span class="text-gradient">every data source</span><br/>
-      your AI agent talks to
+      Test your AI agents<br/>
+      against <span class="text-gradient">the real world</span>
     </h1>
 
     <p class="hero-desc">
-      <strong>One persona, coherent everywhere.</strong> Databases seeded,
-      APIs mocked, MCP servers ready &mdash; all from a single command.
-      Deterministic. Offline. Free.
+      Simulate APIs, databases, MCP servers, and user personas.<br/>
+      Deterministic. Offline. Open source.
     </p>
 
     <div class="hero-actions">
@@ -1508,31 +1615,31 @@
     <div class="oss-inner">
       <div class="oss-content">
         <p class="section-eyebrow">Open Source</p>
-        <h2 class="oss-title">Free forever.<br/>Community driven.</h2>
+        <h2 class="oss-title">Open source.<br/>No vendor lock-in.</h2>
         <p class="oss-desc">
-          The CLI, all 65+ adapters, every MCP server, and pre-built personas are
-          Apache 2.0 licensed. No vendor lock-in, no bait-and-switch. Use it, fork it, contribute to it.
+          The CLI, adapters, MCP servers, and personas are all Apache 2.0.
+          Fork it. Extend it. Run it anywhere.
         </p>
         <ul class="oss-list">
           <li>
             <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
-            CLI + all adapters &mdash; Apache 2.0
+            CLI and all adapters are fully open source
           </li>
           <li>
             <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
-            65+ MCP servers &mdash; Apache 2.0
+            65+ MCP servers included
           </li>
           <li>
             <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Pre-built personas &mdash; Apache 2.0
+            Pre-built personas for realistic testing
           </li>
           <li>
             <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Adapter SDK for community contributions
+            Build your own adapters with the SDK
           </li>
           <li>
             <span class="oss-check"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Works fully offline &mdash; no API keys needed
+            Runs fully offline &mdash; no API keys required
           </li>
         </ul>
         <div class="oss-links">
@@ -1548,22 +1655,22 @@
       </div>
       <div class="oss-visual">
         <div class="oss-tree">
-<span class="dir">mimic/</span>
-<span class="dir">  packages/</span>
-<span class="dir">    oss/</span>                    <span class="apache"># Apache 2.0</span>
-      cli/                  <span class="comment">@mimicai/cli</span>
-      adapter-sdk/          <span class="comment">build your own</span>
-      adapter-stripe/       <span class="comment">29 routes</span>
-      adapter-plaid/        <span class="comment">15 routes</span>
-      adapter-jira/         <span class="comment">21 routes</span>
-      ...                   <span class="comment">65+ adapters</span>
-      mcp-servers/          <span class="comment">65+ MCP servers</span>
-      mock-server/          <span class="comment">Fastify host</span>
-      blueprints/           <span class="comment">pre-built personas</span>
-<span class="dir">    commercial/</span>              <span class="elv2"># Elastic License v2</span>
-      blueprint-engine/     <span class="comment">custom generation</span>
-      test-advanced/        <span class="comment">LLM-as-judge</span>
-      dashboard/            <span class="comment">web UI</span></div>
+<span class="dir">mimic/</span>                      <span class="apache"># Apache 2.0</span>
+├─ <span class="dir">packages/</span>
+│  ├─ cli/                  <span class="comment">@mimicai/cli</span>
+│  ├─ core/                 <span class="comment">engine + types</span>
+│  ├─ adapter-sdk/          <span class="comment">build your own</span>
+│  ├─ <span class="dir">adapters/</span>
+│  │  ├─ adapter-postgres/  <span class="comment">PostgreSQL</span>
+│  │  ├─ adapter-stripe/    <span class="comment">Stripe mock</span>
+│  │  ├─ adapter-plaid/     <span class="comment">Plaid mock</span>
+│  │  └─ ...                <span class="comment">7 adapters</span>
+│  └─ blueprints/           <span class="comment">personas</span>
+└─ <span class="dir">examples/</span>
+   ├─ billing-agent/        <span class="comment">Stripe + PG</span>
+   ├─ finance-assistant/    <span class="comment">Plaid + PG</span>
+   ├─ fintech-multi-db/     <span class="comment">PG + Mongo</span>
+   └─ ...                   <span class="comment">9 examples</span></div>
       </div>
     </div>
   </div>
@@ -1575,54 +1682,54 @@
       <p class="section-eyebrow">The Problem</p>
       <h2 class="section-title">Testing AI agents is broken</h2>
       <p class="section-desc">
-        Your agent touches five APIs simultaneously. You can only test one at a time,
-        with inconsistent data, rate limits, and 60% API coverage.
+        Your agent depends on APIs, databases, and tools.
+        But sandbox testing is slow, inconsistent, and incomplete.
       </p>
       <div class="pain-grid">
         <div class="pain-card">
           <div class="pain-top">
             <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
-            Plaid sandbox has "Jane", Stripe has "test_customer_1", your DB has seed.sql from 2023
+            Three APIs, three fake users, zero consistency
           </div>
           <div class="pain-bottom">
             <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
-            One persona, coherent everywhere
+            One persona. Consistent across every system.
           </div>
         </div>
         <div class="pain-card">
           <div class="pain-top">
             <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
-            Third-party sandboxes throttle you during CI runs
+            Third-party sandboxes throttle your CI tests
           </div>
           <div class="pain-bottom">
             <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Local mock, zero latency, zero rate limits
+            Local mocks. Zero latency. No rate limits.
           </div>
         </div>
         <div class="pain-card">
           <div class="pain-top">
             <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
-            Sandboxes cover 60% of the API surface
+            Most sandboxes only cover part of the API
           </div>
           <div class="pain-bottom">
             <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Full API coverage with persona-seeded data
+            Full API coverage with realistic test data
           </div>
         </div>
         <div class="pain-card">
           <div class="pain-top">
             <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
-            Tests break when sandbox data changes
+            Sandbox data changes and tests start failing
           </div>
           <div class="pain-bottom">
             <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
-            Deterministic seeding &mdash; identical every run
+            Deterministic seeding. Identical every run.
           </div>
         </div>
         <div class="pain-card">
           <div class="pain-top">
             <span class="pain-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg></span>
-            MCP servers have nothing to test against
+            MCP servers have no real environment to test against
           </div>
           <div class="pain-bottom">
             <span class="fix-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
@@ -1640,33 +1747,121 @@
       <p class="section-eyebrow">How It Works</p>
       <h2 class="section-title">Four commands. Full environment.</h2>
       <p class="section-desc">
-        Point Mimic at your schema, pick a persona, and your agent gets a fully populated
-        local environment with realistic, cross-surface consistent data.
+        Point Mimic at your schema, choose a persona, and generate a fully populated local environment with consistent test data.
       </p>
       <div class="flow">
         <div class="flow-step">
           <div class="flow-num">1</div>
           <div class="flow-cmd">mimic init</div>
           <h3>Configure</h3>
-          <p>Declare databases, APIs, and MCP servers. Mimic reads your actual schema.</p>
+          <p>Declare APIs, databases, and MCP servers. Mimic reads your real schema.</p>
         </div>
         <div class="flow-step">
           <div class="flow-num">2</div>
           <div class="flow-cmd">mimic seed</div>
           <h3>Seed</h3>
-          <p>One persona generates coherent data across every surface. Pre-built personas ship free.</p>
+          <p>One persona generates consistent data across your entire environment.</p>
         </div>
         <div class="flow-step">
           <div class="flow-num">3</div>
           <div class="flow-cmd">mimic host</div>
           <h3>Mock</h3>
-          <p>Spins up all API mocks and MCP servers on localhost. Point your agent and go.</p>
+          <p>Start API mocks and MCP servers locally. Point your agent and go.</p>
         </div>
         <div class="flow-step">
           <div class="flow-num">4</div>
           <div class="flow-cmd">mimic test</div>
           <h3>Test</h3>
-          <p>Run scenarios with synthetic users and AI-powered evaluation. Fully CI/CD ready.</p>
+          <p>Run scenarios with synthetic users and AI evaluation. CI/CD ready.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── USE CASES ─────────────────────────── -->
+  <hr class="section-divider" />
+  <section class="section fade-in" id="use-cases">
+    <div class="container">
+      <p class="section-eyebrow">Use Cases</p>
+      <h2 class="section-title">What you can test with Mimic</h2>
+      <p class="section-desc">
+        Real examples from the repo. Each one ships with a persona, schema, and a working agent.
+      </p>
+      <div class="usecase-grid">
+        <div class="usecase-card">
+          <div class="usecase-card-inner">
+            <div class="usecase-header">
+              <div class="usecase-icon" style="background: var(--accent-glow);">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+              </div>
+              <h3>Billing &amp; subscription agents</h3>
+            </div>
+            <p>Simulate a SaaS billing platform with customers, invoices, and payments. Mock Stripe so your agent can query MRR and process refunds &mdash; without touching production.</p>
+            <div class="usecase-cmd">
+              <span class="prompt">$</span> cd examples/billing-agent &amp;&amp; mimic seed &amp;&amp; mimic serve
+            </div>
+            <div class="usecase-tags">
+              <span class="usecase-tag" style="border-color: rgba(124,106,255,0.3); color: var(--accent-bright);">PostgreSQL</span>
+              <span class="usecase-tag" style="border-color: rgba(62,207,113,0.3); color: var(--green);">Stripe API</span>
+              <span class="usecase-tag" style="border-color: rgba(45,212,191,0.3); color: var(--cyan);">MCP</span>
+            </div>
+          </div>
+        </div>
+        <div class="usecase-card">
+          <div class="usecase-card-inner">
+            <div class="usecase-header">
+              <div class="usecase-icon" style="background: var(--green-dim);">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+              </div>
+              <h3>Personal finance assistants</h3>
+            </div>
+            <p>Seed bank accounts, transactions, and spending patterns. Mock Plaid and test budgeting queries, balance checks, and spending breakdowns end-to-end.</p>
+            <div class="usecase-cmd">
+              <span class="prompt">$</span> cd examples/finance-assistant &amp;&amp; mimic seed &amp;&amp; mimic test
+            </div>
+            <div class="usecase-tags">
+              <span class="usecase-tag" style="border-color: rgba(124,106,255,0.3); color: var(--accent-bright);">PostgreSQL</span>
+              <span class="usecase-tag" style="border-color: rgba(245,183,49,0.3); color: var(--amber);">Plaid API</span>
+              <span class="usecase-tag" style="border-color: rgba(45,212,191,0.3); color: var(--cyan);">MCP</span>
+            </div>
+          </div>
+        </div>
+        <div class="usecase-card">
+          <div class="usecase-card-inner">
+            <div class="usecase-header">
+              <div class="usecase-icon" style="background: var(--pink-dim);">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pink)" stroke-width="2"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
+              </div>
+              <h3>E-commerce &amp; support agents</h3>
+            </div>
+            <p>Generate a full product catalog with customers, orders, and reviews in MySQL. Test product search, order history, and support workflows deterministically.</p>
+            <div class="usecase-cmd">
+              <span class="prompt">$</span> cd examples/ecommerce-mysql &amp;&amp; mimic seed &amp;&amp; mimic serve
+            </div>
+            <div class="usecase-tags">
+              <span class="usecase-tag" style="border-color: rgba(240,101,149,0.3); color: var(--pink);">MySQL</span>
+              <span class="usecase-tag" style="border-color: rgba(62,207,113,0.3); color: var(--green);">Schema introspection</span>
+            </div>
+          </div>
+        </div>
+        <div class="usecase-card">
+          <div class="usecase-card-inner">
+            <div class="usecase-header">
+              <div class="usecase-icon" style="background: var(--cyan-dim);">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+              </div>
+              <h3>Multi-database fintech agents</h3>
+            </div>
+            <p>Combine PostgreSQL for structured transactions with MongoDB for activity logs. Test agents that query across both databases transparently.</p>
+            <div class="usecase-cmd">
+              <span class="prompt">$</span> cd examples/fintech-multi-db &amp;&amp; mimic seed &amp;&amp; mimic serve
+            </div>
+            <div class="usecase-tags">
+              <span class="usecase-tag" style="border-color: rgba(124,106,255,0.3); color: var(--accent-bright);">PostgreSQL</span>
+              <span class="usecase-tag" style="border-color: rgba(245,183,49,0.3); color: var(--amber);">MongoDB</span>
+              <span class="usecase-tag" style="border-color: rgba(45,212,191,0.3); color: var(--cyan);">MCP</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1679,8 +1874,7 @@
       <p class="section-eyebrow">Architecture</p>
       <h2 class="section-title">One persona. Every surface.</h2>
       <p class="section-desc">
-        The Blueprint Engine generates a rich persona, then adapters project that data
-        consistently into every surface your agent touches. Same seed = identical output.
+        The Blueprint Engine generates a persona, then adapters project that data across every system your agent uses. Same seed = identical output.
       </p>
       <div class="arch-visual">
         <div class="arch-persona">
@@ -1698,7 +1892,7 @@
         <div class="arch-engine">
           <div class="arch-engine-box">
             <div class="arch-engine-label">Blueprint Engine</div>
-            <div class="arch-engine-sub">Cross-surface consistent generation</div>
+            <div class="arch-engine-sub">Generate consistent data across systems</div>
           </div>
         </div>
         <div class="arch-line">
@@ -1955,9 +2149,9 @@
   <section class="section fade-in" id="mcp">
     <div class="container">
       <p class="section-eyebrow">MCP Servers</p>
-      <h2 class="section-title">First-class MCP testing</h2>
+      <h2 class="section-title">First-class testing for MCP servers</h2>
       <p class="section-desc">
-        10,000+ MCP servers exist in the wild. Zero have standardised testing tooling. Until now.
+        10,000+ MCP servers exist in the wild. Almost none have standardized testing infrastructure. Until now.
       </p>
       <div class="mcp-layout">
         <div>
@@ -1968,7 +2162,7 @@
               </span>
               <div>
                 <h4>Drop-in compatible</h4>
-                <p>For Jira, Slack, Asana, HubSpot, GitHub, and GitLab &mdash; our MCP servers match exact tool names and schemas.</p>
+                <p>Our MCP servers mirror real tools &mdash; Jira, Slack, GitHub, GitLab, Asana, HubSpot. Same tool names. Same schemas.</p>
               </div>
             </li>
             <li class="mcp-point">
@@ -1977,7 +2171,7 @@
               </span>
               <div>
                 <h4>Swap the URL, not the code</h4>
-                <p>Replace MIMIC_BASE_URL with real credentials and your agent code doesn't change at all.</p>
+                <p>Replace <code>MIMIC_BASE_URL</code> with real credentials. Your agent code stays exactly the same.</p>
               </div>
             </li>
             <li class="mcp-point">
@@ -1986,7 +2180,7 @@
               </span>
               <div>
                 <h4>Works everywhere</h4>
-                <p>Claude Code, Cursor, VS Code Copilot, and any custom MCP-compatible agent runtime.</p>
+                <p>Claude Code, Cursor, VS Code Copilot, or any MCP-compatible runtime.</p>
               </div>
             </li>
           </ul>
@@ -2027,9 +2221,9 @@
   <section class="section fade-in" id="features">
     <div class="container">
       <p class="section-eyebrow">Features</p>
-      <h2 class="section-title">Built for agent developers</h2>
+      <h2 class="section-title">Built for AI agent developers</h2>
       <p class="section-desc">
-        Everything you need to test AI agents against realistic synthetic environments.
+        Everything you need to test AI agents in realistic environments.
       </p>
       <div class="feat-grid">
         <div class="feat-cell">
@@ -2037,21 +2231,21 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-bright)" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
           </div>
           <h3>Cross-surface consistency</h3>
-          <p>One persona generates coherent data across databases, APIs, and MCP servers. Same user, matching records everywhere.</p>
+          <p>One persona generates consistent data across databases, APIs, and MCP servers. Same user, matching records everywhere.</p>
         </div>
         <div class="feat-cell">
           <div class="feat-icon" style="background: var(--green-dim);">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
           </div>
           <h3>Deterministic seeding</h3>
-          <p>Same seed + same persona = identical data every run. No flaky tests from changing sandbox data.</p>
+          <p>Same seed + same persona = identical data every run. No flaky tests.</p>
         </div>
         <div class="feat-cell">
           <div class="feat-icon" style="background: var(--cyan-dim);">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
           </div>
           <h3>714K rows/sec</h3>
-          <p>COPY FROM STDIN seeding with FK-aware topological ordering. Atomic transactions.</p>
+          <p>High-performance database seeding with FK-aware ordering and atomic transactions.</p>
         </div>
         <div class="feat-cell">
           <div class="feat-icon" style="background: var(--amber-dim);">
@@ -2065,14 +2259,14 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pink)" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
           </div>
           <h3>Schema-first</h3>
-          <p>Reads your actual Prisma files, SQL DDL, or introspects live databases. Works for any domain.</p>
+          <p>Reads Prisma schemas, SQL DDL, or introspects live databases.</p>
         </div>
         <div class="feat-cell">
           <div class="feat-icon" style="background: var(--green-dim);">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
           </div>
           <h3>100% open source core</h3>
-          <p>CLI, all adapters, MCP servers, and personas are Apache 2.0. Community-contributable with a standardised SDK.</p>
+          <p>CLI, adapters, MCP servers, and personas are Apache 2.0 licensed.</p>
         </div>
       </div>
     </div>
@@ -2085,7 +2279,7 @@
       <p class="section-eyebrow">CI/CD</p>
       <h2 class="section-title">Test agents in every pipeline</h2>
       <p class="section-desc">
-        Add three lines to your workflow. Deterministic environments mean zero flaky agent tests.
+        Add three lines to your workflow. Every run produces the same environment.
       </p>
       <div class="cicd-container">
         <div>
@@ -2096,7 +2290,7 @@
               </span>
               <div>
                 <h4>Reproducible</h4>
-                <p>Same persona + same seed = identical environment in every CI run. No sandbox drift.</p>
+                <p>Same persona + same seed = identical environment in every CI run. No drift between runs.</p>
               </div>
             </li>
             <li class="mcp-point">
@@ -2105,7 +2299,7 @@
               </span>
               <div>
                 <h4>Fast</h4>
-                <p>Local mocks start in under 2 seconds. No network calls to external sandboxes.</p>
+                <p>Local mocks start in under 2 seconds. No external network calls.</p>
               </div>
             </li>
             <li class="mcp-point">


### PR DESCRIPTION
## Summary

- Rewrite hero, problem, open source, how-it-works, architecture, MCP, features, and CI/CD section copy for sharper developer-first messaging
- Add new **Use Cases** section with 4 cards grounded in real `/examples` directory (billing agents, finance assistants, e-commerce, multi-db fintech)
- Fix repo tree in open source section to match actual codebase structure
- Replace "cross-surface" and other internal jargon with plain language throughout

## Changes by section

| Section | Key change |
|---------|-----------|
| Hero | New headline: "Test your AI agents against the real world" |
| Problem | Tighter pain-point cards with dev-frustration language |
| Open Source | "Open source. No vendor lock-in." + accurate repo tree |
| How It Works | Trimmed step descriptions |
| Use Cases | **New section** — 4 cards with icons, CLI snippets, adapter tags |
| Architecture | Plain language for blueprint engine description |
| MCP | Clearer feature descriptions |
| Features | "Built for AI agent developers" + simplified card copy |
| CI/CD | Tighter subtitle and feature copy |

## Test plan

- [ ] Verify landing page renders correctly at `localhost:4321`
- [ ] Check responsive layout on mobile breakpoints
- [ ] Confirm use-case card grid displays properly
- [ ] Verify repo tree renders with correct indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)