### PR TITLE
feat: add GitHub templates, `mimic info` command, and docs updates

### DIFF
--- a/.changeset/add-info-command.md
+++ b/.changeset/add-info-command.md
@@ -1,0 +1,9 @@
+---
+"@mimicai/cli": minor
+---
+
+Add `mimic info` command for bug reports and fix dynamic version display
+
+- New `mimic info` command prints OS, Node, package manager, installed @mimicai/* package versions, and config status
+- Supports `--json` flag for machine-readable output
+- `mimic --version` now reads from package.json instead of hardcoded value

--- a/.github/ISSUE_TEMPLATE/adapter-request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter-request.yml
@@ -1,0 +1,66 @@
+name: Adapter Request
+description: Request a new adapter for a platform Mimic doesn't support yet
+labels: ["adapter", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adapters are the highest-impact contribution to Mimic. Before requesting, check the [existing adapters](https://github.com/mimicailab/mimic/tree/main/packages/adapters) and [open adapter requests](https://github.com/mimicailab/mimic/labels/adapter).
+
+        Want to build it yourself? See the [Adapter Development Guide](https://github.com/mimicailab/mimic/blob/main/docs/ADAPTER_GUIDE.md) and use [`adapter-stripe`](https://github.com/mimicailab/mimic/tree/main/packages/adapters/adapter-stripe) as the reference implementation.
+
+  - type: input
+    id: platform
+    attributes:
+      label: What platform should be supported?
+      description: The name of the API or service you want Mimic to mock.
+      placeholder: "e.g., Twilio, HubSpot, Shopify, SendGrid"
+    validations:
+      required: true
+
+  - type: input
+    id: api-docs
+    attributes:
+      label: Link to official API documentation
+      description: A link to the platform's API reference so contributors can understand the surface area.
+      placeholder: "https://docs.example.com/api"
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: Who needs this? What use case is blocked without it?
+      placeholder: |
+        Our team builds AI agents that interact with [platform]. We need realistic mock data
+        for local development and CI testing, but currently have to hit the real API or
+        maintain custom fixtures.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Minimum viable scope
+      description: |
+        List the smallest set of endpoints or resources that would make this adapter useful.
+        Don't try to cover everything — focus on the core CRUD operations.
+      placeholder: |
+        - List / Get / Create / Update customers
+        - List / Get / Create invoices
+        - Webhook event simulation for invoice.paid
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution-intent
+    attributes:
+      label: Contribution intent
+      description: Are you able to help build or test this adapter?
+      options:
+        - "I can build this adapter"
+        - "I can help with testing and review"
+        - "I'm requesting only"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -85,14 +85,23 @@ body:
     attributes:
       label: Environment
       description: |
-        Provide your environment details. You can find package versions in your `package.json` or `node_modules/@mimicai/*/package.json`.
+        Run `mimic info` in your project root and paste the output here.
       render: bash
       placeholder: |
-        OS: macOS 15.3 / Ubuntu 24.04 / Windows 11
-        Node: 22.x
-        pnpm: 9.x
-        mimic --version: 0.5.0
-        @mimicai/adapter-stripe: 0.5.0
+        Mimic Environment Info
+
+        System:
+          OS:              darwin (25.3.0)
+          Arch:            arm64
+          Node:            v22.14.0
+          Package Manager: pnpm
+
+        Packages:
+          @mimicai/core              0.5.0
+          @mimicai/adapter-stripe    0.5.0
+
+        Config:
+          mimic.json:      found
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,118 @@
+name: Bug Report
+description: Report a reproducible issue with Mimic
+labels: ["bug", "needs: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please search [existing issues](https://github.com/mimicailab/mimic/issues) before submitting — someone may have already reported this.
+
+        If you're not sure whether this is a bug, please open a [Discussion](https://github.com/mimicailab/mimic/discussions/new?category=q-a) instead.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug. If you intend to submit a PR for this, mention it here.
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: A step-by-step description of how to reproduce the issue.
+      placeholder: |
+        1. Create mimic.json with ...
+        2. Run `mimic seed`
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual behavior
+      description: What did you expect to happen, and what actually happened?
+      placeholder: "I expected A to happen, but observed B instead."
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction-link
+    attributes:
+      label: Reproduction link
+      description: |
+        A link to a GitHub repo or Gist with a minimal reproduction. Issues without reproductions may take longer to investigate.
+      placeholder: "https://github.com/your-username/mimic-repro"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Which area(s) are affected?
+      description: Select all that apply.
+      multiple: true
+      options:
+        - "core"
+        - "cli"
+        - "adapter-sdk"
+        - "blueprints"
+        - "adapter-postgres"
+        - "adapter-mysql"
+        - "adapter-sqlite"
+        - "adapter-mongodb"
+        - "adapter-stripe"
+        - "adapter-plaid"
+        - "adapter-slack"
+        - "adapter-paddle"
+        - "adapter-chargebee"
+        - "adapter-gocardless"
+        - "adapter-recurly"
+        - "adapter-revenuecat"
+        - "adapter-lemonsqueezy"
+        - "adapter-zuora"
+        - "MCP server"
+        - "docs"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Provide your environment details. You can find package versions in your `package.json` or `node_modules/@mimicai/*/package.json`.
+      render: bash
+      placeholder: |
+        OS: macOS 15.3 / Ubuntu 24.04 / Windows 11
+        Node: 22.x
+        pnpm: 9.x
+        mimic --version: 0.5.0
+        @mimicai/adapter-stripe: 0.5.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant logs or error messages. Please redact secrets.
+      render: bash
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: before-submitting
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched existing issues and this hasn't been reported before
+          required: true
+        - label: I am using the latest version of Mimic
+          required: false
+        - label: I am willing to submit a pull request for this issue
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature request or idea
+    url: https://github.com/mimicailab/mimic/discussions/new?category=ideas
+    about: Propose new features or improvements in Discussions. Accepted ideas become scoped issues.
+  - name: Question or help
+    url: https://github.com/mimicailab/mimic/discussions/new?category=q-a
+    about: Ask questions in Discussions. Issues are for actionable bugs and adapter requests.
+  - name: Discord
+    url: https://discord.gg/mimic
+    about: Chat with the community and get real-time help.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for contributing to Mimic! Please read our Contributing Guide before submitting:
+https://github.com/mimicailab/mimic/blob/main/CONTRIBUTING.md
+-->
+
+## Background
+
+<!-- Why is this change needed? Link to a related issue or discussion. -->
+
+## Summary
+
+<!-- What did you change? Keep it concise. -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] New adapter
+- [ ] Feature
+- [ ] Docs
+- [ ] Test / CI
+- [ ] Refactor
+
+## How to verify
+
+<!--
+How did you manually verify this works end-to-end?
+For adapter PRs: which routes did you test, and with what seed data?
+Remove this section for docs-only changes.
+-->
+
+## Checklist
+
+- [ ] Tests added or updated (`pnpm test` or `pnpm --filter @mimicai/adapter-{name} test`)
+- [ ] Docs updated (if user-facing)
+- [ ] Changeset added (`pnpm changeset`)
+- [ ] Lint and typecheck pass (`pnpm lint && pnpm typecheck`)
+- [ ] I have reviewed my own code (self-review)
+- [ ] Linked issue or discussion (if any)
+
+## Related issues
+
+<!-- e.g., Fixes #123, Closes #456 -->

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ mimic test                    Run test scenarios
 mimic inspect                 View schema, data, or blueprint information
 mimic clean                   Remove all seeded data
 mimic adapters                Manage API mock adapters
+mimic info                    Print environment info for bug reports
 ```
 
 ## Packages
@@ -300,7 +301,7 @@ mimic adapters                Manage API mock adapters
 | Package | Description |
 |---------|-------------|
 | [`@mimicai/core`](packages/core/) | Engine — schema parsing, generation, seeding, MCP server, test runner |
-| [`@mimicai/cli`](packages/cli/) | CLI binary with 8 commands |
+| [`@mimicai/cli`](packages/cli/) | CLI binary with 9 commands |
 | [`@mimicai/blueprints`](packages/blueprints/) | Pre-built persona blueprints |
 | [`@mimicai/adapter-sdk`](packages/adapter-sdk/) | SDK for building custom adapters |
 | [`@mimicai/adapter-postgres`](packages/adapters/adapter-postgres/) | PostgreSQL database seeder |
@@ -310,6 +311,13 @@ mimic adapters                Manage API mock adapters
 | [`@mimicai/adapter-stripe`](packages/adapters/adapter-stripe/) | Stripe API mock + MCP server |
 | [`@mimicai/adapter-plaid`](packages/adapters/adapter-plaid/) | Plaid API mock + MCP server |
 | [`@mimicai/adapter-slack`](packages/adapters/adapter-slack/) | Slack API mock + MCP server |
+| [`@mimicai/adapter-paddle`](packages/adapters/adapter-paddle/) | Paddle API mock + MCP server |
+| [`@mimicai/adapter-chargebee`](packages/adapters/adapter-chargebee/) | Chargebee API mock + MCP server |
+| [`@mimicai/adapter-gocardless`](packages/adapters/adapter-gocardless/) | GoCardless API mock + MCP server |
+| [`@mimicai/adapter-recurly`](packages/adapters/adapter-recurly/) | Recurly API mock + MCP server |
+| [`@mimicai/adapter-revenuecat`](packages/adapters/adapter-revenuecat/) | RevenueCat API mock + MCP server |
+| [`@mimicai/adapter-lemonsqueezy`](packages/adapters/adapter-lemonsqueezy/) | Lemon Squeezy API mock + MCP server |
+| [`@mimicai/adapter-zuora`](packages/adapters/adapter-zuora/) | Zuora API mock + MCP server |
 
 ## Community
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { createRequire } from 'node:module';
+import { platform, release, arch } from 'node:os';
+import { join, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { fileExists } from '@mimicai/core';
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Known adapter package names
+// ---------------------------------------------------------------------------
+
+const ADAPTER_PACKAGES = [
+  '@mimicai/core',
+  '@mimicai/cli',
+  '@mimicai/adapter-sdk',
+  '@mimicai/blueprints',
+  '@mimicai/adapter-postgres',
+  '@mimicai/adapter-mysql',
+  '@mimicai/adapter-sqlite',
+  '@mimicai/adapter-mongodb',
+  '@mimicai/adapter-stripe',
+  '@mimicai/adapter-plaid',
+  '@mimicai/adapter-slack',
+  '@mimicai/adapter-paddle',
+  '@mimicai/adapter-chargebee',
+  '@mimicai/adapter-gocardless',
+  '@mimicai/adapter-recurly',
+  '@mimicai/adapter-revenuecat',
+  '@mimicai/adapter-lemonsqueezy',
+  '@mimicai/adapter-zuora',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerInfoCommand(program: Command): void {
+  program
+    .command('info')
+    .description('Print environment and package info for bug reports')
+    .option('--json', 'output as JSON')
+    .action(async (opts) => {
+      await printInfo(opts);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+interface InfoOutput {
+  platform: string;
+  arch: string;
+  osVersion: string;
+  nodeVersion: string;
+  packageManager: string;
+  packages: Record<string, string>;
+  configFound: boolean;
+}
+
+async function resolveVersion(pkg: string): Promise<string | null> {
+  // In a user project, packages are in cwd's node_modules.
+  // In the monorepo dev environment, they're symlinked in the CLI package's node_modules.
+  // We also walk up from cwd for pnpm hoisting.
+  const searchRoots = [
+    process.cwd(),
+    join(process.cwd(), '..'),
+    join(process.cwd(), '..', '..'),
+  ];
+
+  // Also try from the CLI package's own location (handles workspace symlinks).
+  // In the built CLI, __dirname is dist/src/ or dist/bin/, so walk up to package root.
+  const cliPkgRoot = join(__dirname, '..', '..');
+  searchRoots.push(cliPkgRoot);
+
+  for (const root of searchRoots) {
+    const candidate = join(root, 'node_modules', pkg, 'package.json');
+    try {
+      const raw = await readFile(candidate, 'utf-8');
+      const parsed = JSON.parse(raw) as { version: string };
+      return parsed.version;
+    } catch {
+      // continue
+    }
+  }
+
+  return null;
+}
+
+function detectPM(): string {
+  const ua = process.env.npm_config_user_agent;
+  if (ua) {
+    if (ua.startsWith('pnpm')) return 'pnpm';
+    if (ua.startsWith('yarn')) return 'yarn';
+    if (ua.startsWith('bun')) return 'bun';
+    if (ua.startsWith('npm')) return 'npm';
+  }
+  return 'unknown';
+}
+
+async function printInfo(opts: { json?: boolean }): Promise<void> {
+  const packages: Record<string, string> = {};
+  for (const pkg of ADAPTER_PACKAGES) {
+    const ver = await resolveVersion(pkg);
+    if (ver) packages[pkg] = ver;
+  }
+
+  const configPath = join(process.cwd(), 'mimic.json');
+  const configFound = await fileExists(configPath);
+
+  const info: InfoOutput = {
+    platform: `${platform()} (${release()})`,
+    arch: arch(),
+    osVersion: release(),
+    nodeVersion: process.version,
+    packageManager: detectPM(),
+    packages,
+    configFound,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(info, null, 2));
+    return;
+  }
+
+  console.log();
+  console.log(chalk.bold('  Mimic Environment Info'));
+  console.log();
+
+  console.log(chalk.bold('  System:'));
+  console.log(`    OS:              ${info.platform}`);
+  console.log(`    Arch:            ${info.arch}`);
+  console.log(`    Node:            ${info.nodeVersion}`);
+  console.log(`    Package Manager: ${info.packageManager}`);
+  console.log();
+
+  console.log(chalk.bold('  Packages:'));
+  if (Object.keys(packages).length === 0) {
+    console.log(chalk.dim('    (none found)'));
+  } else {
+    const maxLen = Math.max(...Object.keys(packages).map((k) => k.length));
+    for (const [pkg, ver] of Object.entries(packages)) {
+      console.log(`    ${pkg.padEnd(maxLen)}  ${chalk.yellow(ver)}`);
+    }
+  }
+  console.log();
+
+  console.log(chalk.bold('  Config:'));
+  console.log(`    mimic.json:      ${configFound ? chalk.green('found') : chalk.dim('not found')}`);
+  console.log();
+
+  console.log(chalk.dim('  Copy the above into your bug report.'));
+  console.log();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { createRequire } from 'node:module';
 
 import { registerInitCommand } from './commands/init.js';
 import { registerRunCommand } from './commands/run.js';
@@ -9,6 +10,10 @@ import { registerTestCommand } from './commands/test.js';
 import { registerInspectCommand } from './commands/inspect.js';
 import { registerCleanCommand } from './commands/clean.js';
 import { registerAdaptersCommand } from './commands/adapters.js';
+import { registerInfoCommand } from './commands/info.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json') as { version: string };
 
 const program = new Command();
 
@@ -17,7 +22,7 @@ program
   .description(
     'Persona-driven synthetic data for AI agent testing — generate, seed, host, and test.',
   )
-  .version('0.1.0', '-v, --version', 'display the current version');
+  .version(version, '-v, --version', 'display the current version');
 
 // ---------------------------------------------------------------------------
 // Register subcommands
@@ -31,6 +36,7 @@ registerTestCommand(program);
 registerInspectCommand(program);
 registerCleanCommand(program);
 registerAdaptersCommand(program);
+registerInfoCommand(program);
 
 // ---------------------------------------------------------------------------
 // Global error handling

--- a/packages/docs/src/components/Sidebar.astro
+++ b/packages/docs/src/components/Sidebar.astro
@@ -62,6 +62,7 @@ const groups: SidebarGroup[] = [
       { id: 'cli-inspect', title: 'mimic inspect' },
       { id: 'cli-clean', title: 'mimic clean' },
       { id: 'cli-adapters', title: 'mimic adapters' },
+      { id: 'cli-info', title: 'mimic info' },
     ],
   },
   {

--- a/packages/docs/src/content/docs/04-cli.md
+++ b/packages/docs/src/content/docs/04-cli.md
@@ -259,3 +259,42 @@ Show details and endpoints for an adapter.
 </div>
 
 Displays the adapter manifest (name, type, version, description) and lists all endpoints with their descriptions.
+
+<h2 id="cli-info">mimic info</h2>
+
+Print environment and package info for bug reports.
+
+<div class="code-block">
+  <div class="code-bar"><span class="code-bar-lang">bash</span><button class="code-copy">Copy</button></div>
+  <pre><code><span class="prompt">$</span> mimic info [options]
+&#8203;
+<span class="cm">Options:</span>
+  <span class="flag">--json</span>                   Output as JSON</code></pre>
+</div>
+
+Prints system information (OS, architecture, Node version, package manager), installed `@mimicai/*` package versions, and whether a `mimic.json` config file is found in the current directory.
+
+<div class="code-block">
+  <div class="code-bar"><span class="code-bar-lang">bash</span><button class="code-copy">Copy</button></div>
+  <pre><code><span class="prompt">$</span> mimic info
+&#8203;
+  Mimic Environment Info
+&#8203;
+  System:
+    OS:              darwin (25.3.0)
+    Arch:            arm64
+    Node:            v22.14.0
+    Package Manager: pnpm
+&#8203;
+  Packages:
+    @mimicai/core              0.6.0
+    @mimicai/cli               0.6.0
+    @mimicai/adapter-stripe    0.6.0
+&#8203;
+  Config:
+    mimic.json:      found
+&#8203;
+  Copy the above into your bug report.</code></pre>
+</div>
+
+Use `--json` for machine-readable output, useful in CI or automated diagnostics.


### PR DESCRIPTION
## Summary

- **GitHub issue/PR templates** — structured YAML forms for bug reports and adapter requests, config routing features/questions to Discussions, PR template with changeset reminder
- **`mimic info` CLI command** — prints system environment, installed `@mimicai/*` package versions, and config status for bug reports (similar to `next info` / `astro info`)
- **Version fix** — `mimic --version` now reads from `package.json` at runtime instead of hardcoded `0.1.0`
- **Docs updates** — `mimic info` added to CLI reference page, sidebar, and README; all 14 adapters now listed in README packages table

## New files

- `.github/ISSUE_TEMPLATE/bug-report.yml` — bug report form with adapter dropdown and `mimic info` environment block
- `.github/ISSUE_TEMPLATE/adapter-request.yml` — adapter request form linking to ADAPTER_GUIDE.md
- `.github/ISSUE_TEMPLATE/config.yml` — routes features/questions to Discussions, disables blank issues
- `.github/pull_request_template.md` — changeset reminder, adapter-specific test commands
- `packages/cli/src/commands/info.ts` — new `mimic info` command
- `.changeset/add-info-command.md` — minor changeset for CLI

## How to verify

```bash
pnpm build
node packages/cli/dist/bin/mimic.js --version  # should show 0.5.0
node packages/cli/dist/bin/mimic.js info        # should list system + packages
node packages/cli/dist/bin/mimic.js info --json  # JSON output
```

## Test plan

- [x] `pnpm test` — all 36 tasks pass
- [x] `pnpm --filter @mimicai/docs build` — docs site builds cleanly
- [x] `mimic info` resolves all 16 installed packages in monorepo
- [x] `mimic info --json` outputs valid JSON
- [x] `mimic --version` shows `0.5.0` (dynamic from package.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)