### PR TITLE
fix(changesets): remove nonexistent @mimicai/adapter-slack from fixed…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,7 @@
       "@mimicai/adapter-mongodb",
       "@mimicai/adapter-sqlite",
       "@mimicai/adapter-plaid",
-      "@mimicai/adapter-slack",
+
       "@mimicai/adapter-stripe",
       "@mimicai/adapter-paddle",
       "@mimicai/adapter-chargebee",


### PR DESCRIPTION
… group

The package was listed in the changesets `fixed` config but never created, causing `changeset version` to fail with a ValidationError.

<!--
Thanks for contributing to Mimic! Please read our Contributing Guide before submitting:
https://github.com/mimicailab/mimic/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why is this change needed? Link to a related issue or discussion. -->

## Summary

<!-- What did you change? Keep it concise. -->

## Type

- [ ] Bug fix
- [ ] New adapter
- [ ] Feature
- [ ] Docs
- [ ] Test / CI
- [ ] Refactor

## How to verify

<!--
How did you manually verify this works end-to-end?
For adapter PRs: which routes did you test, and with what seed data?
Remove this section for docs-only changes.
-->

## Checklist

- [ ] Tests added or updated (`pnpm test` or `pnpm --filter @mimicai/adapter-{name} test`)
- [ ] Docs updated (if user-facing)
- [ ] Changeset added (`pnpm changeset`)
- [ ] Lint and typecheck pass (`pnpm lint && pnpm typecheck`)
- [ ] I have reviewed my own code (self-review)
- [ ] Linked issue or discussion (if any)

## Related issues

<!-- e.g., Fixes #123, Closes #456 -->
