### PR TITLE
fix(cli): remove nonexistent adapter-slack references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,8 +58,7 @@
     "@mimicai/adapter-lemonsqueezy": "workspace:*",
     "@mimicai/adapter-zuora": "workspace:*",
     "@mimicai/adapter-recurly": "workspace:*",
-    "@mimicai/adapter-plaid": "workspace:*",
-    "@mimicai/adapter-slack": "workspace:*"
+    "@mimicai/adapter-plaid": "workspace:*"
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -27,7 +27,6 @@ const ADAPTER_PACKAGES = [
   '@mimicai/adapter-mongodb',
   '@mimicai/adapter-stripe',
   '@mimicai/adapter-plaid',
-  '@mimicai/adapter-slack',
   '@mimicai/adapter-paddle',
   '@mimicai/adapter-chargebee',
   '@mimicai/adapter-gocardless',


### PR DESCRIPTION
## Summary
- Remove `@mimicai/adapter-slack` from CLI `optionalDependencies` and `info.ts` package list
- The package was never created, causing `changeset publish` to fail with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (all 35 tasks, 0 failures)
- [ ] Verify publish workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)