### PR TITLE
fix(changesets): ignore example packages from version bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -31,5 +31,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": []
+  "ignore": ["stripe-explorer-example", "cfo-agent-example"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,9 +559,6 @@ importers:
       '@mimicai/adapter-revenuecat':
         specifier: workspace:*
         version: link:../adapters/adapter-revenuecat
-      '@mimicai/adapter-slack':
-        specifier: workspace:*
-        version: link:../adapters/adapter-slack
       '@mimicai/adapter-stripe':
         specifier: workspace:*
         version: link:../adapters/adapter-stripe


### PR DESCRIPTION
## Summary
- Add `stripe-explorer-example` and `cfo-agent-example` to changesets `ignore` list
- Prevents unnecessary version bumps for private example packages during releases

## Test plan
- [ ] Verify publish workflow no longer bumps example package versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)