### PR TITLE
chore: sync explorer into fixed release group for 0.10.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,7 +24,8 @@
       "@mimicai/adapter-revenuecat",
       "@mimicai/adapter-lemonsqueezy",
       "@mimicai/adapter-zuora",
-      "@mimicai/adapter-recurly"
+      "@mimicai/adapter-recurly",
+      "@mimicai/explorer"
     ]
   ],
   "linked": [],

--- a/.changeset/sync-explorer-version.md
+++ b/.changeset/sync-explorer-version.md
@@ -1,0 +1,5 @@
+---
+"@mimicai/explorer": minor
+---
+
+Sync explorer version with all other packages in the fixed release group


### PR DESCRIPTION
## Summary
- Add `@mimicai/explorer` to the changesets `fixed` group so all packages share the same version
- Includes a minor changeset to align explorer (`0.7.1`) with the rest of the monorepo

## Expected result
After merge, changesets will create a version PR bumping all 18 packages to `0.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)