### PR TITLE
docs: fix adapter route counts and remove stale Slack references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,13 @@ packages/
     adapter-mongodb/      # MongoDB database adapter
     adapter-stripe/       # Stripe API mock adapter (with MCP server)
     adapter-plaid/        # Plaid API mock adapter (with MCP server)
-    adapter-slack/        # Slack API mock adapter (with MCP server)
+    adapter-paddle/       # Paddle API mock adapter (with MCP server)
+    adapter-chargebee/    # Chargebee API mock adapter (with MCP server)
+    adapter-gocardless/   # GoCardless API mock adapter (with MCP server)
+    adapter-lemonsqueezy/ # Lemon Squeezy API mock adapter (with MCP server)
+    adapter-recurly/      # Recurly API mock adapter (with MCP server)
+    adapter-revenuecat/   # RevenueCat API mock adapter (with MCP server)
+    adapter-zuora/        # Zuora API mock adapter (with MCP server)
   docs/                   # Astro documentation site
 examples/                 # Example projects using Mimic
 docs/                     # Architecture and guide documents

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ---
 
-Your AI agent talks to Plaid for bank data, Stripe for payments, Slack for messages, and PostgreSQL for everything else. In production, that works. In testing, you're stitching together different sandboxes with inconsistent data, rate limits, and surprise breaking changes.
+Your AI agent talks to Plaid for bank data, Stripe for payments, and PostgreSQL for everything else. In production, that works. In testing, you're stitching together different sandboxes with inconsistent data, rate limits, and surprise breaking changes.
 
 Mimic replaces all of that with a single, consistent synthetic environment. One persona generates coherent data across every surface — the same user has the same bank accounts in Plaid, the same payment history in Stripe, and the same rows in PostgreSQL.
 
@@ -135,17 +135,17 @@ Mimic is a **synthetic environment engine** for AI agent development. It solves 
                     +------------------+-------------------+
                                        |
                                        v
-              +------------+-------+--------+------------+
-              v            v       v        v            v
-        +----------+ +----------+ +----------+ +----------+
-        |PostgreSQL| | Plaid    | | Stripe   | | Slack    |
-        | Adapter  | | Adapter  | | Adapter  | | Adapter  |
-        | (seed)   | | (mock)   | | (mock)   | | (mock)   |
-        +----------+ +----------+ +----------+ +----------+
-              |            |           |            |
-              v            v           v            v
-          Real DB     Mock API    Mock API     Mock API
-          seeded    :4100/plaid :4100/stripe :4100/slack
+              +------------+-------+--------+
+              v            v       v        v
+        +----------+ +----------+ +----------+
+        |PostgreSQL| | Plaid    | | Stripe   |
+        | Adapter  | | Adapter  | | Adapter  |
+        | (seed)   | | (mock)   | | (mock)   |
+        +----------+ +----------+ +----------+
+              |            |           |
+              v            v           v
+          Real DB     Mock API    Mock API
+          seeded    :4100/plaid :4100/stripe
                            |
                            v
                     Unified MCP Server
@@ -171,7 +171,13 @@ Pre-built personas ship with the package — no LLM calls needed for basic use. 
 |---------|---------|-------------|
 | Stripe | `@mimicai/adapter-stripe` | Payments, customers, subscriptions, invoices, products, prices |
 | Plaid | `@mimicai/adapter-plaid` | Link flow, accounts, transactions, identity, balance |
-| Slack | `@mimicai/adapter-slack` | Channels, messages, users, reactions, threads |
+| Paddle | `@mimicai/adapter-paddle` | Subscriptions, products, prices, transactions, customers, discounts |
+| Chargebee | `@mimicai/adapter-chargebee` | Subscriptions, customers, invoices, plans, addons, credit notes |
+| GoCardless | `@mimicai/adapter-gocardless` | Mandates, payments, customers, subscriptions, bank accounts |
+| Lemon Squeezy | `@mimicai/adapter-lemonsqueezy` | Products, variants, orders, subscriptions, customers, discounts |
+| Recurly | `@mimicai/adapter-recurly` | Accounts, subscriptions, invoices, transactions, plans, coupons |
+| RevenueCat | `@mimicai/adapter-revenuecat` | Subscribers, entitlements, offerings, products, purchases |
+| Zuora | `@mimicai/adapter-zuora` | Accounts, subscriptions, invoices, payments, products, rate plans |
 
 > **Building an adapter?** See the [Adapter Development Guide](docs/ADAPTER_GUIDE.md) and the [@mimicai/adapter-sdk](packages/adapter-sdk/).
 
@@ -238,7 +244,13 @@ mimic/
 │   │   ├── adapter-sqlite/
 │   │   ├── adapter-stripe/       # API mock adapters
 │   │   ├── adapter-plaid/
-│   │   └── adapter-slack/
+│   │   ├── adapter-paddle/
+│   │   ├── adapter-chargebee/
+│   │   ├── adapter-gocardless/
+│   │   ├── adapter-lemonsqueezy/
+│   │   ├── adapter-recurly/
+│   │   ├── adapter-revenuecat/
+│   │   └── adapter-zuora/
 │   └── docs/                     # Documentation site
 ├── examples/
 │   ├── billing-agent/            # Billing agent (PG + Stripe + chat UI)
@@ -310,7 +322,6 @@ mimic info                    Print environment info for bug reports
 | [`@mimicai/adapter-sqlite`](packages/adapters/adapter-sqlite/) | SQLite database seeder |
 | [`@mimicai/adapter-stripe`](packages/adapters/adapter-stripe/) | Stripe API mock + MCP server |
 | [`@mimicai/adapter-plaid`](packages/adapters/adapter-plaid/) | Plaid API mock + MCP server |
-| [`@mimicai/adapter-slack`](packages/adapters/adapter-slack/) | Slack API mock + MCP server |
 | [`@mimicai/adapter-paddle`](packages/adapters/adapter-paddle/) | Paddle API mock + MCP server |
 | [`@mimicai/adapter-chargebee`](packages/adapters/adapter-chargebee/) | Chargebee API mock + MCP server |
 | [`@mimicai/adapter-gocardless`](packages/adapters/adapter-gocardless/) | GoCardless API mock + MCP server |

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -14,7 +14,7 @@ Every adapter runs inside Mimic's Fastify mock server at a unique base path (e.g
 
 ## Getting Started
 
-Copy an existing adapter as a starting point — `adapter-stripe` and `adapter-plaid` are the best reference implementations.
+Copy an existing adapter as a starting point — `adapter-stripe` and `adapter-plaid` are the best reference implementations. See `private/building-adapters.md` for the comprehensive guide covering codegen, overrides, and the full `OpenApiMockAdapter` pipeline.
 
 ```bash
 cp -r packages/adapters/adapter-stripe packages/adapters/adapter-my-platform
@@ -342,6 +342,5 @@ The adapter SDK re-exports useful helpers from `@mimicai/core`:
 
 ## Reference Implementations
 
-- [`adapter-stripe`](../packages/adapters/adapter-stripe/) — Full Stripe API mock with 29 endpoints, webhooks, Zod config
-- [`adapter-plaid`](../packages/adapters/adapter-plaid/) — Plaid API mock with link flow, transactions, formatters
-- [`adapter-slack`](../packages/adapters/adapter-slack/) — Slack Web API mock with channels, messages, reactions
+- [`adapter-stripe`](../packages/adapters/adapter-stripe/) — Full Stripe API mock with 617 routes, OpenAPI codegen, overrides
+- [`adapter-plaid`](../packages/adapters/adapter-plaid/) — Plaid API mock with 326 routes, link flow, transactions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,8 +31,8 @@ This document describes Mimic's internal architecture. It's aimed at contributor
 |              | |          | |          |
 | PostgreSQL   | | Stripe   | | Built-in |
 | MongoDB      | | Plaid    | | per      |
-| MySQL        | | Slack    | | adapter  |
-| SQLite       | |          | |          |
+| MySQL        | | Paddle   | | adapter  |
+| SQLite       | | + 6 more | |          |
 +--------------+ +----------+ +----------+
 ```
 
@@ -52,7 +52,7 @@ Adapters are Mimic's plugin system. There are two types:
 
 **Database adapters** connect to real databases and seed them with persona data. They implement `DatabaseAdapter` with `seed()` and `clean()` methods. Available: PostgreSQL, MySQL, MongoDB, SQLite.
 
-**API mock adapters** register Fastify routes that simulate real API endpoints. They extend `BaseApiMockAdapter` with `registerRoutes()` and `getEndpoints()` methods. Each adapter includes seeded data in an in-memory state store. Available: Stripe, Plaid, Slack.
+**API mock adapters** register Fastify routes that simulate real API endpoints. They extend `OpenApiMockAdapter` with `registerRoutes()` and `getEndpoints()` methods. Each adapter includes seeded data in an in-memory state store. Available: Stripe, Plaid, Paddle, Chargebee, GoCardless, Lemon Squeezy, Recurly, RevenueCat, Zuora.
 
 ### State Store
 
@@ -137,7 +137,6 @@ The core differentiator is **cross-surface consistency**. When data is generated
 - PostgreSQL `users` table has Alex with matching IDs
 - Plaid API returns bank accounts owned by Alex
 - Stripe API returns payment history for Alex's card
-- Slack API shows messages from Alex
 
 This is achieved through the `apiEntities` system in `@mimicai/core`, which maintains shared identifiers and correlated values across all configured adapters.
 
@@ -153,12 +152,13 @@ This is achieved through the `apiEntities` system in `@mimicai/core`, which main
   +-- @mimicai/adapter-sqlite
   +-- @mimicai/adapter-stripe (optional)
   +-- @mimicai/adapter-plaid (optional)
-  +-- @mimicai/adapter-slack (optional)
+  +-- @mimicai/adapter-paddle (optional)
+  +-- ... (6 more API mock adapters)
 
 @mimicai/adapter-sdk
   +-- @mimicai/core
 
-@mimicai/adapter-{stripe,plaid,slack}
+@mimicai/adapter-{stripe,plaid,paddle,...}
   +-- @mimicai/adapter-sdk
   +-- @mimicai/core
 ```

--- a/docs/MCP_GUIDE.md
+++ b/docs/MCP_GUIDE.md
@@ -46,13 +46,6 @@ Add to your MCP configuration file:
         "MIMIC_BASE_URL": "http://localhost:4000"
       }
     },
-    "mimic-slack": {
-      "command": "npx",
-      "args": ["-y", "@mimicai/adapter-slack", "mcp"],
-      "env": {
-        "MIMIC_BASE_URL": "http://localhost:4000"
-      }
-    }
   }
 }
 ```
@@ -65,8 +58,7 @@ The simplest way — `mimic host` starts both mock API endpoints and MCP servers
 {
   "apis": [
     { "adapter": "stripe" },
-    { "adapter": "plaid" },
-    { "adapter": "slack" }
+    { "adapter": "plaid" }
   ]
 }
 ```
@@ -75,7 +67,6 @@ The simplest way — `mimic host` starts both mock API endpoints and MCP servers
 mimic host
 # Stripe API  -> http://localhost:4000/stripe/v1
 # Plaid API   -> http://localhost:4000/plaid
-# Slack API   -> http://localhost:4000/slack
 # MCP Server  -> stdio
 ```
 
@@ -87,7 +78,13 @@ Each API mock adapter includes a built-in MCP server:
 |---------|---------|-------------|
 | Stripe | `@mimicai/adapter-stripe` | `npx @mimicai/adapter-stripe mcp` |
 | Plaid | `@mimicai/adapter-plaid` | `npx @mimicai/adapter-plaid mcp` |
-| Slack | `@mimicai/adapter-slack` | `npx @mimicai/adapter-slack mcp` |
+| Paddle | `@mimicai/adapter-paddle` | `npx @mimicai/adapter-paddle mcp` |
+| Chargebee | `@mimicai/adapter-chargebee` | `npx @mimicai/adapter-chargebee mcp` |
+| GoCardless | `@mimicai/adapter-gocardless` | `npx @mimicai/adapter-gocardless mcp` |
+| Lemon Squeezy | `@mimicai/adapter-lemonsqueezy` | `npx @mimicai/adapter-lemonsqueezy mcp` |
+| Recurly | `@mimicai/adapter-recurly` | `npx @mimicai/adapter-recurly mcp` |
+| RevenueCat | `@mimicai/adapter-revenuecat` | `npx @mimicai/adapter-revenuecat mcp` |
+| Zuora | `@mimicai/adapter-zuora` | `npx @mimicai/adapter-zuora mcp` |
 
 ### Stripe MCP Tools
 
@@ -96,10 +93,6 @@ Tools derived from the adapter's `getEndpoints()`: list customers, create custom
 ### Plaid MCP Tools
 
 Create link token, exchange public token, get accounts, get transactions, get balance, get identity, get institutions, get auth, and more.
-
-### Slack MCP Tools
-
-List channels, post message, list messages, list users, get user info, add reaction, list reactions, upload file, get channel info, search messages, and more.
 
 ## Building an MCP Server for a New Adapter
 

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -1481,24 +1481,37 @@
 
       <div class="callout tip">
         <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span>
-        <p><strong>Shipped in v0.2.0:</strong> Stripe, Plaid, and Slack adapters are the first three API mock adapters shipped as publishable packages with full MCP server support, dedicated test suites, and working example agents. Each includes a standalone MCP binary (<code>adapter-{name}/src/bin/mcp.ts</code>) and is built on the <code>@mimicai/adapter-sdk</code>.</p>
+        <p><strong>9 adapters shipped:</strong> All adapters below are published packages with full mock route coverage, MCP server support, and a standalone MCP binary (<code>src/bin/mcp.ts</code>). Each is built on <code>@mimicai/adapter-sdk</code>.</p>
       </div>
 
       <div class="doc-table-wrap">
         <table class="doc-table">
           <thead><tr><th>Adapter</th><th>Package</th><th>MCP Tools</th><th>Status</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><strong>Stripe</strong></td><td><code>@mimicai/adapter-stripe</code></td><td>17</td><td style="color: var(--green);">Shipped</td><td>Customers, payment intents, charges, refunds, subscriptions, invoices, products, prices, balance</td></tr>
-            <tr><td><strong>Plaid</strong></td><td><code>@mimicai/adapter-plaid</code></td><td>10</td><td style="color: var(--green);">Shipped</td><td>Bank accounts, transactions, identity, auth, balance, link tokens</td></tr>
-            <tr><td><strong>Slack</strong></td><td><code>@mimicai/adapter-slack</code></td><td>12</td><td style="color: var(--green);">Shipped</td><td>Channels, messages, threads, reactions, users, search, team info</td></tr>
+            <tr><td><strong>Stripe</strong></td><td><code>@mimicai/adapter-stripe</code></td><td>617</td><td style="color: var(--green);">Shipped</td><td>Full v1 + v2 coverage: customers, payment intents, charges, refunds, subscriptions, invoices, products, prices, balance, billing meters, event destinations</td></tr>
+            <tr><td><strong>Plaid</strong></td><td><code>@mimicai/adapter-plaid</code></td><td>326</td><td style="color: var(--green);">Shipped</td><td>Accounts, transactions, identity, auth, balance, institutions, link tokens</td></tr>
+            <tr><td><strong>Paddle</strong></td><td><code>@mimicai/adapter-paddle</code></td><td>88</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, products, prices, transactions, customers, discounts, adjustments</td></tr>
+            <tr><td><strong>Chargebee</strong></td><td><code>@mimicai/adapter-chargebee</code></td><td>410</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, customers, invoices, plans, addons, credit notes, payment sources</td></tr>
+            <tr><td><strong>GoCardless</strong></td><td><code>@mimicai/adapter-gocardless</code></td><td>134</td><td style="color: var(--green);">Shipped</td><td>Mandates, payments, customers, subscriptions, bank accounts, refunds</td></tr>
+            <tr><td><strong>Lemon Squeezy</strong></td><td><code>@mimicai/adapter-lemonsqueezy</code></td><td>53</td><td style="color: var(--green);">Shipped</td><td>Products, variants, orders, subscriptions, customers, discounts, license keys</td></tr>
+            <tr><td><strong>Recurly</strong></td><td><code>@mimicai/adapter-recurly</code></td><td>194</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, transactions, plans, coupons, credit adjustments</td></tr>
+            <tr><td><strong>RevenueCat</strong></td><td><code>@mimicai/adapter-revenuecat</code></td><td>95</td><td style="color: var(--green);">Shipped</td><td>Subscribers, entitlements, offerings, products, purchases, receipts</td></tr>
+            <tr><td><strong>Zuora</strong></td><td><code>@mimicai/adapter-zuora</code></td><td>414</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, payments, products, rate plans, usage records</td></tr>
           </tbody>
         </table>
       </div>
 
       <h4>Fintech / Payments (24 adapters)</h4>
       <div class="adapter-doc-grid">
-        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Stripe</span><span class="adapter-doc-routes">29 routes</span></div>
-        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Plaid</span><span class="adapter-doc-routes">15 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Stripe</span><span class="adapter-doc-routes">617 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Plaid</span><span class="adapter-doc-routes">326 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Paddle</span><span class="adapter-doc-routes">88 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Chargebee</span><span class="adapter-doc-routes">410 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">GoCardless</span><span class="adapter-doc-routes">134 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Lemon Squeezy</span><span class="adapter-doc-routes">53 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Recurly</span><span class="adapter-doc-routes">194 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">RevenueCat</span><span class="adapter-doc-routes">95 routes</span></div>
+        <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Zuora</span><span class="adapter-doc-routes">414 routes</span></div>
         <div class="adapter-doc-item"><span class="adapter-doc-name">Square</span><span class="adapter-doc-routes">16 routes</span></div>
         <div class="adapter-doc-item"><span class="adapter-doc-name">Wise</span><span class="adapter-doc-routes">14 routes</span></div>
         <div class="adapter-doc-item"><span class="adapter-doc-name">Adyen</span><span class="adapter-doc-routes">12 routes</span></div>
@@ -1927,7 +1940,13 @@ MCP Server (@mimicai/mcp-jira)
   ├── @mimicai/adapter-sqlite      (shipped)
   ├── @mimicai/adapter-stripe      (shipped, + MCP)
   ├── @mimicai/adapter-plaid       (shipped, + MCP)
-  ├── @mimicai/adapter-slack       (shipped, + MCP)
+  ├── @mimicai/adapter-paddle      (shipped, + MCP)
+  ├── @mimicai/adapter-chargebee   (shipped, + MCP)
+  ├── @mimicai/adapter-gocardless  (shipped, + MCP)
+  ├── @mimicai/adapter-lemonsqueezy (shipped, + MCP)
+  ├── @mimicai/adapter-recurly     (shipped, + MCP)
+  ├── @mimicai/adapter-revenuecat  (shipped, + MCP)
+  ├── @mimicai/adapter-zuora       (shipped, + MCP)
   └── @mimicai/blueprints
         └── pre-built personas (JSON)
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -1569,8 +1569,8 @@
 <span class="dir">    oss/</span>                    <span class="apache"># Apache 2.0</span>
       cli/                  <span class="comment">@mimicai/cli</span>
       adapter-sdk/          <span class="comment">build your own</span>
-      adapter-stripe/       <span class="comment">29 routes</span>
-      adapter-plaid/        <span class="comment">15 routes</span>
+      adapter-stripe/       <span class="comment">617 routes</span>
+      adapter-plaid/        <span class="comment">326 routes</span>
       adapter-jira/         <span class="comment">21 routes</span>
       ...                   <span class="comment">65+ adapters</span>
       mcp-servers/          <span class="comment">65+ MCP servers</span>

--- a/packages/adapters/adapter-stripe/src/stripe-adapter.ts
+++ b/packages/adapters/adapter-stripe/src/stripe-adapter.ts
@@ -73,7 +73,7 @@ export class StripeAdapter extends OpenApiMockAdapter<StripeConfig> {
     // and singleton resources (balance, account) that aren't standard CRUD.
     this.mountOverrides(store);
 
-    // ── Generated CRUD scaffolding (616 routes across v1 + v2 Stripe paths) ───
+    // ── Generated CRUD scaffolding (617 routes across v1 + v2 Stripe paths) ───
     await this.registerGeneratedRoutes(server, data, store, ns);
   }
 

--- a/packages/docs/src/content/docs/01-getting-started.md
+++ b/packages/docs/src/content/docs/01-getting-started.md
@@ -92,7 +92,6 @@ Populates your PostgreSQL (or MongoDB, MySQL, SQLite) with persona-consistent da
 &#8203;
 <span class="ok">&#10003;</span> <span class="out">Stripe API    &rarr; http://localhost:4100/stripe/v1</span>
 <span class="ok">&#10003;</span> <span class="out">Plaid API     &rarr; http://localhost:4100/plaid</span>
-<span class="ok">&#10003;</span> <span class="out">Slack MCP     &rarr; stdio ready</span>
 <span class="ok">&#10003;</span> <span class="out">Ready in 1.2s</span></code></pre>
 </div>
 

--- a/packages/docs/src/content/docs/03-configuration.md
+++ b/packages/docs/src/content/docs/03-configuration.md
@@ -112,7 +112,7 @@ That's it. Two fields and you can run `mimic run` to generate blueprints. Add a 
       <tr><td><code>llm</code></td><td>No</td><td>object</td><td>LLM provider and model for blueprint generation</td></tr>
       <tr><td><code>generate</code></td><td>No</td><td>object</td><td>Volume, seed, and per-table row overrides</td></tr>
       <tr><td><code>databases</code></td><td>No</td><td>object</td><td>Named database targets to seed</td></tr>
-      <tr><td><code>apis</code></td><td>No</td><td>object</td><td>API mock adapters to enable (Stripe, Plaid, Slack, etc.)</td></tr>
+      <tr><td><code>apis</code></td><td>No</td><td>object</td><td>API mock adapters to enable (Stripe, Plaid, Paddle, etc.)</td></tr>
       <tr><td><code>test</code></td><td>No</td><td>object</td><td>Agent endpoint and test scenarios</td></tr>
     </tbody>
   </table>
@@ -384,14 +384,13 @@ MongoDB does not require a schema file. Mimic generates document shapes from the
 
 <h3 id="config-apis">apis</h3>
 
-A named map of API mock adapters. Each key is the adapter ID (e.g. `"stripe"`, `"plaid"`, `"slack"`), and the value configures the adapter's behaviour. When `mimic host` runs, enabled adapters are registered as Fastify routes on the mock server. When `mcp: true`, the adapter's tools are also registered on the unified MCP server.
+A named map of API mock adapters. Each key is the adapter ID (e.g. `"stripe"`, `"plaid"`, `"paddle"`), and the value configures the adapter's behaviour. When `mimic host` runs, enabled adapters are registered as Fastify routes on the mock server. When `mcp: true`, the adapter's tools are also registered on the unified MCP server.
 
 <div class="code-block">
   <div class="code-bar"><span class="code-bar-lang">json</span><button class="code-copy">Copy</button></div>
   <pre><code><span class="yk">"apis"</span>: {
   <span class="yk">"stripe"</span>: { <span class="yk">"enabled"</span>: <span class="ty">true</span>, <span class="yk">"mcp"</span>: <span class="ty">true</span> },
-  <span class="yk">"plaid"</span>: { <span class="yk">"enabled"</span>: <span class="ty">true</span>, <span class="yk">"mcp"</span>: <span class="ty">true</span> },
-  <span class="yk">"slack"</span>: { <span class="yk">"enabled"</span>: <span class="ty">true</span>, <span class="yk">"mcp"</span>: <span class="ty">false</span> }
+  <span class="yk">"plaid"</span>: { <span class="yk">"enabled"</span>: <span class="ty">true</span>, <span class="yk">"mcp"</span>: <span class="ty">true</span> }
 }</code></pre>
 </div>
 

--- a/packages/docs/src/content/docs/05-adapters.md
+++ b/packages/docs/src/content/docs/05-adapters.md
@@ -9,7 +9,7 @@ next: { slug: "mcp", title: "MCP Servers" }
 
 <h2 id="adapter-list">Adapter Catalog</h2>
 
-Mimic ships **10 API mock adapters** and **4 database adapters** today, with more planned. Every adapter is open source (Apache 2.0) and community-contributable.
+Mimic ships **9 API mock adapters** and **4 database adapters** today, with more planned. Every adapter is open source (Apache 2.0) and community-contributable.
 
 <h3 id="adapter-databases">Database Adapters</h3>
 
@@ -31,23 +31,22 @@ Mimic ships **10 API mock adapters** and **4 database adapters** today, with mor
 
 <div class="callout tip">
   <span class="callout-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span>
-  <div><p><strong>10 adapters shipped:</strong> All adapters below are published packages with full mock route coverage, MCP server support, and a standalone MCP binary (<code>src/bin/mcp.ts</code>). Each is built on <code>@mimicai/adapter-sdk</code>.</p></div>
+  <div><p><strong>9 adapters shipped:</strong> All adapters below are published packages with full mock route coverage, MCP server support, and a standalone MCP binary (<code>src/bin/mcp.ts</code>). Each is built on <code>@mimicai/adapter-sdk</code>.</p></div>
 </div>
 
 <div class="doc-table-wrap">
   <table class="doc-table">
     <thead><tr><th>Adapter</th><th>Package</th><th>Routes</th><th>Status</th><th>Description</th></tr></thead>
     <tbody>
-      <tr><td><strong>Stripe</strong></td><td><code>@mimicai/adapter-stripe</code></td><td>616</td><td style="color: var(--green);">Shipped</td><td>Full v1 + v2 coverage: customers, payment intents, charges, refunds, subscriptions, invoices, products, prices, balance, billing meters, event destinations</td></tr>
-      <tr><td><strong>Plaid</strong></td><td><code>@mimicai/adapter-plaid</code></td><td>10</td><td style="color: var(--green);">Shipped</td><td>Accounts, transactions, identity, auth, balance, institutions, link tokens</td></tr>
-      <tr><td><strong>Slack</strong></td><td><code>@mimicai/adapter-slack</code></td><td>28</td><td style="color: var(--green);">Shipped</td><td>Channels, messages, threads, reactions, users, search, team info</td></tr>
-      <tr><td><strong>Paddle</strong></td><td><code>@mimicai/adapter-paddle</code></td><td>83</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, products, prices, transactions, customers, discounts, adjustments</td></tr>
-      <tr><td><strong>Chargebee</strong></td><td><code>@mimicai/adapter-chargebee</code></td><td>55</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, customers, invoices, plans, addons, credit notes, payment sources</td></tr>
-      <tr><td><strong>GoCardless</strong></td><td><code>@mimicai/adapter-gocardless</code></td><td>45</td><td style="color: var(--green);">Shipped</td><td>Mandates, payments, customers, subscriptions, bank accounts, refunds</td></tr>
-      <tr><td><strong>Lemon Squeezy</strong></td><td><code>@mimicai/adapter-lemonsqueezy</code></td><td>50</td><td style="color: var(--green);">Shipped</td><td>Products, variants, orders, subscriptions, customers, discounts, license keys</td></tr>
-      <tr><td><strong>Recurly</strong></td><td><code>@mimicai/adapter-recurly</code></td><td>47</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, transactions, plans, coupons, credit adjustments</td></tr>
-      <tr><td><strong>RevenueCat</strong></td><td><code>@mimicai/adapter-revenuecat</code></td><td>42</td><td style="color: var(--green);">Shipped</td><td>Subscribers, entitlements, offerings, products, purchases, receipts</td></tr>
-      <tr><td><strong>Zuora</strong></td><td><code>@mimicai/adapter-zuora</code></td><td>54</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, payments, products, rate plans, usage records</td></tr>
+      <tr><td><strong>Stripe</strong></td><td><code>@mimicai/adapter-stripe</code></td><td>617</td><td style="color: var(--green);">Shipped</td><td>Full v1 + v2 coverage: customers, payment intents, charges, refunds, subscriptions, invoices, products, prices, balance, billing meters, event destinations</td></tr>
+      <tr><td><strong>Plaid</strong></td><td><code>@mimicai/adapter-plaid</code></td><td>326</td><td style="color: var(--green);">Shipped</td><td>Accounts, transactions, identity, auth, balance, institutions, link tokens</td></tr>
+      <tr><td><strong>Paddle</strong></td><td><code>@mimicai/adapter-paddle</code></td><td>88</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, products, prices, transactions, customers, discounts, adjustments</td></tr>
+      <tr><td><strong>Chargebee</strong></td><td><code>@mimicai/adapter-chargebee</code></td><td>410</td><td style="color: var(--green);">Shipped</td><td>Subscriptions, customers, invoices, plans, addons, credit notes, payment sources</td></tr>
+      <tr><td><strong>GoCardless</strong></td><td><code>@mimicai/adapter-gocardless</code></td><td>134</td><td style="color: var(--green);">Shipped</td><td>Mandates, payments, customers, subscriptions, bank accounts, refunds</td></tr>
+      <tr><td><strong>Lemon Squeezy</strong></td><td><code>@mimicai/adapter-lemonsqueezy</code></td><td>53</td><td style="color: var(--green);">Shipped</td><td>Products, variants, orders, subscriptions, customers, discounts, license keys</td></tr>
+      <tr><td><strong>Recurly</strong></td><td><code>@mimicai/adapter-recurly</code></td><td>194</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, transactions, plans, coupons, credit adjustments</td></tr>
+      <tr><td><strong>RevenueCat</strong></td><td><code>@mimicai/adapter-revenuecat</code></td><td>95</td><td style="color: var(--green);">Shipped</td><td>Subscribers, entitlements, offerings, products, purchases, receipts</td></tr>
+      <tr><td><strong>Zuora</strong></td><td><code>@mimicai/adapter-zuora</code></td><td>414</td><td style="color: var(--green);">Shipped</td><td>Accounts, subscriptions, invoices, payments, products, rate plans, usage records</td></tr>
     </tbody>
   </table>
 </div>
@@ -55,15 +54,15 @@ Mimic ships **10 API mock adapters** and **4 database adapters** today, with mor
 #### Fintech / Payments — shipped
 
 <div class="adapter-doc-grid">
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Stripe</span><span class="adapter-doc-routes">616 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Plaid</span><span class="adapter-doc-routes">10 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Paddle</span><span class="adapter-doc-routes">83 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Chargebee</span><span class="adapter-doc-routes">55 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">GoCardless</span><span class="adapter-doc-routes">45 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Lemon Squeezy</span><span class="adapter-doc-routes">50 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Recurly</span><span class="adapter-doc-routes">47 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">RevenueCat</span><span class="adapter-doc-routes">42 routes</span></div>
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Zuora</span><span class="adapter-doc-routes">54 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Stripe</span><span class="adapter-doc-routes">617 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Plaid</span><span class="adapter-doc-routes">326 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Paddle</span><span class="adapter-doc-routes">88 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Chargebee</span><span class="adapter-doc-routes">410 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">GoCardless</span><span class="adapter-doc-routes">134 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Lemon Squeezy</span><span class="adapter-doc-routes">53 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Recurly</span><span class="adapter-doc-routes">194 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">RevenueCat</span><span class="adapter-doc-routes">95 routes</span></div>
+  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Zuora</span><span class="adapter-doc-routes">414 routes</span></div>
 </div>
 
 #### Fintech / Payments — planned
@@ -85,7 +84,7 @@ Mimic ships **10 API mock adapters** and **4 database adapters** today, with mor
 #### Communication
 
 <div class="adapter-doc-grid">
-  <div class="adapter-doc-item" style="border-color: var(--green);"><span class="adapter-doc-name" style="color: var(--green);">Slack</span><span class="adapter-doc-routes">28 routes</span></div>
+  <div class="adapter-doc-item"><span class="adapter-doc-name">Slack</span><span class="adapter-doc-routes">28 routes</span></div>
   <div class="adapter-doc-item"><span class="adapter-doc-name">Twilio</span><span class="adapter-doc-routes">14 routes</span></div>
   <div class="adapter-doc-item"><span class="adapter-doc-name">SendGrid</span><span class="adapter-doc-routes">11 routes</span></div>
   <div class="adapter-doc-item"><span class="adapter-doc-name">Discord</span><span class="adapter-doc-routes">13 routes</span></div>
@@ -212,7 +211,7 @@ Adapters are built from OpenAPI specs using a **codegen-driven pipeline**. A cod
 
 <div class="code-block">
   <div class="code-bar"><span class="code-bar-lang">text</span><button class="code-copy">Copy</button></div>
-  <pre><code>OpenAPI spec (.json)
+  <pre><code>OpenAPI spec (.json or .yaml)
     &darr;
 Codegen script (pnpm generate)
     &darr;

--- a/packages/docs/src/content/docs/06-mcp.md
+++ b/packages/docs/src/content/docs/06-mcp.md
@@ -78,7 +78,7 @@ The simplest way &mdash; configure adapters in `mimic.json` with `mcp: true` and
 
 <h2 id="mcp-catalog">Available MCP Servers</h2>
 
-All 10 shipped adapters include a full MCP server. Each can be run standalone via `npx` or started together via `mimic host`.
+All 9 shipped adapters include a full MCP server. Each can be run standalone via `npx` or started together via `mimic host`.
 
 <div class="doc-table-wrap">
   <table class="doc-table">
@@ -86,7 +86,6 @@ All 10 shipped adapters include a full MCP server. Each can be run standalone vi
     <tbody>
       <tr><td><strong>Stripe</strong></td><td><code>@mimicai/adapter-stripe</code></td><td><code>npx @mimicai/adapter-stripe mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
       <tr><td><strong>Plaid</strong></td><td><code>@mimicai/adapter-plaid</code></td><td><code>npx @mimicai/adapter-plaid mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
-      <tr><td><strong>Slack</strong></td><td><code>@mimicai/adapter-slack</code></td><td><code>npx @mimicai/adapter-slack mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
       <tr><td><strong>Paddle</strong></td><td><code>@mimicai/adapter-paddle</code></td><td><code>npx @mimicai/adapter-paddle mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
       <tr><td><strong>Chargebee</strong></td><td><code>@mimicai/adapter-chargebee</code></td><td><code>npx @mimicai/adapter-chargebee mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
       <tr><td><strong>GoCardless</strong></td><td><code>@mimicai/adapter-gocardless</code></td><td><code>npx @mimicai/adapter-gocardless mcp</code></td><td style="color: var(--green);">Shipped</td></tr>
@@ -108,7 +107,6 @@ Mimic MCP tools are designed to match the official MCP servers published by each
     <tbody>
       <tr><td><strong>Stripe</strong></td><td><a href="https://mcp.stripe.com" target="_blank">mcp.stripe.com</a> official server</td><td>All 26 official tools + 4 Mimic extras for payment lifecycle testing</td></tr>
       <tr><td><strong>Plaid</strong></td><td>Plaid API surface</td><td>Link flow, accounts, transactions, balances, identity, auth, holdings, liabilities</td></tr>
-      <tr><td><strong>Slack</strong></td><td>Slack Web API</td><td>Channels, messages, threads, reactions, users, search, team info</td></tr>
       <tr><td><strong>Paddle</strong></td><td>Paddle Billing API</td><td>Products, prices, subscriptions, customers, transactions, discounts</td></tr>
       <tr><td><strong>Chargebee</strong></td><td>Chargebee API</td><td>Subscriptions, customers, invoices, plans, addons, events</td></tr>
       <tr><td><strong>GoCardless</strong></td><td>GoCardless API</td><td>Mandates, payments, customers, bank accounts, payouts, events</td></tr>

--- a/packages/docs/src/content/docs/07-architecture.md
+++ b/packages/docs/src/content/docs/07-architecture.md
@@ -68,7 +68,7 @@ next: { slug: "testing", title: "Testing & Auto-Scenarios" }
 &#8203;
 Mock Server (Fastify, port 4101)
   ├─ Route matched: /stripe/* &rarr; StripeAdapter (OpenApiMockAdapter)
-  ├─ Generated CRUD scaffolding (616 routes from OpenAPI spec)
+  ├─ Generated CRUD scaffolding (617 routes from OpenAPI spec)
   │   ├─ Seed ExpandedData into StateStore on first request
   │   ├─ Check override map &mdash; use custom handler if registered
   │   ├─ Otherwise auto-handle: list (cursor pagination), create,
@@ -101,7 +101,6 @@ The Blueprint Engine's core differentiator. When it generates data for persona "
 - Plaid API returns bank accounts owned by `user_001`
 - Stripe API returns payment history for `user_001`'s card
 - Chargebee API shows Alex's subscription and invoices
-- Slack API shows messages from Alex
 
 Achieved through a two-phase process:
 
@@ -132,7 +131,6 @@ Achieved through a two-phase process:
   └── API mock adapters (shipped, each includes MCP server)
         ├── @mimicai/adapter-stripe
         ├── @mimicai/adapter-plaid
-        ├── @mimicai/adapter-slack
         ├── @mimicai/adapter-paddle
         ├── @mimicai/adapter-chargebee
         ├── @mimicai/adapter-gocardless


### PR DESCRIPTION
## Summary
- Remove all `adapter-slack` references across docs, README, landing page, and config examples (removed in dbc4ca5 but docs were not updated)
- Fix route counts for all 9 shipped API mock adapters to match actual `GENERATED_ROUTES` arrays
- Add missing shipped adapters (Paddle, Chargebee, GoCardless, Lemon Squeezy, Recurly, RevenueCat, Zuora) to README, CONTRIBUTING, MCP_GUIDE, and ARCHITECTURE docs
- Fix pipeline overview to mention `.yaml` spec support alongside `.json`

### Route count corrections

| Adapter | Old (wrong) | New (actual) |
|---------|------------|-------------|
| Stripe | 616 | **617** |
| Plaid | 10 | **326** |
| Paddle | 83 | **88** |
| Chargebee | 55 | **410** |
| GoCardless | 45 | **134** |
| Lemon Squeezy | 50 | **53** |
| Recurly | 47 | **194** |
| RevenueCat | 42 | **95** |
| Zuora | 54 | **414** |

### Files changed (13)
- `packages/docs/src/content/docs/` — 05-adapters, 06-mcp, 07-architecture, 01-getting-started, 03-configuration
- `README.md`, `CONTRIBUTING.md`
- `docs/ADAPTER_GUIDE.md`, `docs/ARCHITECTURE.md`, `docs/MCP_GUIDE.md`
- `landing/docs.html`, `landing/index.html`
- `packages/adapters/adapter-stripe/src/stripe-adapter.ts` (comment only)

## Test plan
- [ ] Verify docs site renders correctly with updated adapter counts
- [ ] Confirm no remaining `adapter-slack` references in docs (`grep -r adapter-slack`)
- [ ] Spot-check route counts against `GENERATED_ROUTES` in each adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)