### PR TITLE
feat(core): add StateStore.serialize() and hydrate()

### DIFF
--- a/.changeset/state-store-serialization.md
+++ b/.changeset/state-store-serialization.md
@@ -1,0 +1,5 @@
+---
+"@mimicai/core": minor
+---
+
+Add `StateStore.serialize()` and `hydrate()` methods for cloud persistence

--- a/packages/core/src/mock/state-store.ts
+++ b/packages/core/src/mock/state-store.ts
@@ -52,4 +52,21 @@ export class StateStore {
   clear(): void {
     this.state.clear();
   }
+
+  /** Serialize state to a plain JSON-safe object (for R2/disk persistence). */
+  serialize(): Record<string, Record<string, unknown>> {
+    const result: Record<string, Record<string, unknown>> = {};
+    for (const [ns, map] of this.state) {
+      result[ns] = Object.fromEntries(map);
+    }
+    return result;
+  }
+
+  /** Restore state from a previously serialized snapshot. */
+  hydrate(data: Record<string, Record<string, unknown>>): void {
+    this.state.clear();
+    for (const [ns, entries] of Object.entries(data)) {
+      this.state.set(ns, new Map(Object.entries(entries)));
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `StateStore.serialize()` and `hydrate()` methods for cloud persistence
- Includes changeset for minor version bump (0.11.0)

## Test plan
- [x] Verify `serialize()` returns a JSON-serializable snapshot of the store
- [x] Verify `hydrate()` restores state from a serialized snapshot
- [x] Confirm all existing tests still pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)