### PR TITLE
Release 0.11.0

### DIFF
--- a/examples/cfo-agent/mimic.json
+++ b/examples/cfo-agent/mimic.json
@@ -2,8 +2,8 @@
   "domain": "Multi-platform SaaS billing and subscription management. A growth-stage analytics company (Verida Analytics) that simultaneously uses 8 billing platforms across different customer segments and geographies. Core business: B2B analytics SaaS with starter, pro, and enterprise tiers.",
 
   "llm": {
-    "provider": "openai",
-    "model": "gpt-5.4"
+    "provider": "anthropic",
+    "model": "claude-sonnet-4-6"
   },
 
   "personas": [

--- a/examples/cfo-agent/package.json
+++ b/examples/cfo-agent/package.json
@@ -3,14 +3,14 @@
   "version": "0.0.4",
   "private": true,
   "dependencies": {
-    "@mimicai/cli": "^0.11.0",
-    "@mimicai/adapter-stripe": "^0.11.0",
-    "@mimicai/adapter-paddle": "^0.11.0",
-    "@mimicai/adapter-chargebee": "^0.11.0",
-    "@mimicai/adapter-gocardless": "^0.11.0",
-    "@mimicai/adapter-revenuecat": "^0.11.0",
-    "@mimicai/adapter-zuora": "^0.11.0",
-    "@mimicai/adapter-recurly": "^0.11.0",
-    "@mimicai/adapter-postgres": "^0.11.0"
+    "@mimicai/cli": "workspace:*",
+    "@mimicai/adapter-stripe": "workspace:*",
+    "@mimicai/adapter-paddle": "workspace:*",
+    "@mimicai/adapter-chargebee": "workspace:*",
+    "@mimicai/adapter-gocardless": "workspace:*",
+    "@mimicai/adapter-revenuecat": "workspace:*",
+    "@mimicai/adapter-zuora": "workspace:*",
+    "@mimicai/adapter-recurly": "workspace:*",
+    "@mimicai/adapter-postgres": "workspace:*"
   }
 }

--- a/examples/cfo-agent/package.json
+++ b/examples/cfo-agent/package.json
@@ -9,7 +9,6 @@
     "@mimicai/adapter-chargebee": "^0.11.0",
     "@mimicai/adapter-gocardless": "^0.11.0",
     "@mimicai/adapter-revenuecat": "^0.11.0",
-    "@mimicai/adapter-lemonsqueezy": "^0.11.0",
     "@mimicai/adapter-zuora": "^0.11.0",
     "@mimicai/adapter-recurly": "^0.11.0",
     "@mimicai/adapter-postgres": "^0.11.0"

--- a/examples/tasks-sqlite/package.json
+++ b/examples/tasks-sqlite/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@mimicai/cli": "^0.11.0",
+    "@mimicai/cli": "workspace:*",
     "better-sqlite3": "^12.8.0"
   }
 }

--- a/packages/adapters/adapter-chargebee/adapter.json
+++ b/packages/adapters/adapter-chargebee/adapter.json
@@ -3,7 +3,7 @@
   "name": "Chargebee",
   "description": "Chargebee subscription billing mock adapter",
   "type": "api-mock",
-  "basePath": "/chargebee",
+  "basePath": "",
   "versions": ["v2"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://apidocs.chargebee.com/docs/api",

--- a/packages/adapters/adapter-chargebee/scripts/chargebee-codegen.ts
+++ b/packages/adapters/adapter-chargebee/scripts/chargebee-codegen.ts
@@ -557,7 +557,7 @@ type RouteOperation = 'list' | 'create' | 'retrieve' | 'update' | 'delete' | 'ac
 interface ExtractedRoute {
   method: 'GET' | 'POST';
   stripePath: string;        // original spec path (field name is historical)
-  fastifyPath: string;       // Fastify path with /chargebee prefix
+  fastifyPath: string;       // Fastify route path with colon params
   resource: string;          // e.g. 'customers'
   operation: RouteOperation;
   description: string;
@@ -580,7 +580,7 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const description = operation.summary ?? operation.operationId ?? '';
 
       // Convert path params: {param-name} → :param_name (kebab→snake for Fastify compat)
-      const fastifyPath = '/chargebee' + specPath.replace(/\{([^}]+)\}/g, (_m, p) => ':' + p.replace(/-/g, '_'));
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, (_m, p) => ':' + p.replace(/-/g, '_'));
 
       // Detect resource from path
       const resource = detectResource(specPath, knownResourceKeys);
@@ -860,7 +860,7 @@ function generateRoutesTs(routes: ExtractedRoute[]): string {
     `export interface GeneratedRoute {`,
     `  /** HTTP method */`,
     `  method: RouteMethod;`,
-    `  /** Fastify route path with colon params and /chargebee prefix */`,
+    `  /** Fastify route path with colon params */`,
     `  fastifyPath: string;`,
     `  /** Original spec path for documentation (field name is historical) */`,
     `  stripePath: string;`,

--- a/packages/adapters/adapter-chargebee/src/__tests__/chargebee-adapter.test.ts
+++ b/packages/adapters/adapter-chargebee/src/__tests__/chargebee-adapter.test.ts
@@ -19,7 +19,7 @@ describe('ChargebeeAdapter', () => {
 
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('chargebee');
-    expect(adapter.basePath).toBe('/chargebee');
+    expect(adapter.basePath).toBe('');
     expect(adapter.name).toBe('Chargebee');
   });
 
@@ -39,7 +39,7 @@ describe('ChargebeeAdapter', () => {
   it('should create a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'email=test@example.com&first_name=Test&last_name=User',
     });
@@ -55,7 +55,7 @@ describe('ChargebeeAdapter', () => {
   it('should list customers', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/chargebee/customers',
+      url: '/customers',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -67,7 +67,7 @@ describe('ChargebeeAdapter', () => {
   it('should retrieve a customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/chargebee/customers/${customerId}`,
+      url: `/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -79,7 +79,7 @@ describe('ChargebeeAdapter', () => {
   it('should update a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/customers/${customerId}`,
+      url: `/customers/${customerId}`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'first_name=Updated&company=Acme',
     });
@@ -94,7 +94,7 @@ describe('ChargebeeAdapter', () => {
   it('should delete a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/customers/${customerId}/delete`,
+      url: `/customers/${customerId}/delete`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -105,7 +105,7 @@ describe('ChargebeeAdapter', () => {
   it('should return 404 for non-existent customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/chargebee/customers/nonexistent_id',
+      url: '/customers/nonexistent_id',
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -119,7 +119,7 @@ describe('ChargebeeAdapter', () => {
   it('should create an item', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/items',
+      url: '/items',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'id=silver-plan&name=Silver+Plan&type=plan',
     });
@@ -133,7 +133,7 @@ describe('ChargebeeAdapter', () => {
   it('should list items', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/chargebee/items',
+      url: '/items',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -150,7 +150,7 @@ describe('ChargebeeAdapter', () => {
     // First create a customer
     const cusRes = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'email=subscriber@example.com',
     });
@@ -158,7 +158,7 @@ describe('ChargebeeAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/customers/${cusId}/subscription_for_items`,
+      url: `/customers/${cusId}/subscription_for_items`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });
     expect(res.statusCode).toBe(200);
@@ -172,7 +172,7 @@ describe('ChargebeeAdapter', () => {
   it('should cancel a subscription', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${subId}/cancel_for_items`,
+      url: `/subscriptions/${subId}/cancel_for_items`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });
     expect(res.statusCode).toBe(200);
@@ -183,7 +183,7 @@ describe('ChargebeeAdapter', () => {
   it('should reactivate a cancelled subscription', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${subId}/reactivate`,
+      url: `/subscriptions/${subId}/reactivate`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -193,7 +193,7 @@ describe('ChargebeeAdapter', () => {
   it('should pause a subscription', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${subId}/pause`,
+      url: `/subscriptions/${subId}/pause`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -203,7 +203,7 @@ describe('ChargebeeAdapter', () => {
   it('should resume a paused subscription', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${subId}/resume`,
+      url: `/subscriptions/${subId}/resume`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -213,7 +213,7 @@ describe('ChargebeeAdapter', () => {
   it('should cancel at end of term', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${subId}/cancel_for_items`,
+      url: `/subscriptions/${subId}/cancel_for_items`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'end_of_term=true',
     });
@@ -230,7 +230,7 @@ describe('ChargebeeAdapter', () => {
   it('should create an invoice via /invoices/create_for_charge_items_and_charges', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/invoices/create_for_charge_items_and_charges',
+      url: '/invoices/create_for_charge_items_and_charges',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'customer_id=cus_test&total=5000&amount_due=5000',
     });
@@ -244,7 +244,7 @@ describe('ChargebeeAdapter', () => {
   it('should record payment on an invoice', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/invoices/${invoiceId}/record_payment`,
+      url: `/invoices/${invoiceId}/record_payment`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'amount=5000',
     });
@@ -257,7 +257,7 @@ describe('ChargebeeAdapter', () => {
     // Create a new invoice first
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/invoices/create_for_charge_items_and_charges',
+      url: '/invoices/create_for_charge_items_and_charges',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'customer_id=cus_test&total=3000&amount_due=3000',
     });
@@ -265,7 +265,7 @@ describe('ChargebeeAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/invoices/${newInvId}/void`,
+      url: `/invoices/${newInvId}/void`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -279,7 +279,7 @@ describe('ChargebeeAdapter', () => {
     for (let i = 0; i < 3; i++) {
       await ts.server.inject({
         method: 'POST',
-        url: '/chargebee/customers',
+        url: '/customers',
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
         payload: `email=page${i}@test.com`,
       });
@@ -287,7 +287,7 @@ describe('ChargebeeAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/chargebee/customers?limit=2',
+      url: '/customers?limit=2',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -297,7 +297,7 @@ describe('ChargebeeAdapter', () => {
     // Fetch next page
     const res2 = await ts.server.inject({
       method: 'GET',
-      url: `/chargebee/customers?limit=2&offset=${body.next_offset}`,
+      url: `/customers?limit=2&offset=${body.next_offset}`,
     });
     expect(res2.statusCode).toBe(200);
     const body2 = res2.json();
@@ -310,7 +310,7 @@ describe('ChargebeeAdapter', () => {
     // Create a customer and subscription
     const cusRes = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'email=cancel-test@example.com',
     });
@@ -318,20 +318,20 @@ describe('ChargebeeAdapter', () => {
 
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/customers/${cusId}/subscription_for_items`,
+      url: `/customers/${cusId}/subscription_for_items`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });
     const sid = createRes.json().subscription.id;
 
     await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${sid}/cancel_for_items`,
+      url: `/subscriptions/${sid}/cancel_for_items`,
     });
 
     // Try to cancel again
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/subscriptions/${sid}/cancel_for_items`,
+      url: `/subscriptions/${sid}/cancel_for_items`,
     });
     expect(res.statusCode).toBe(400);
   });
@@ -340,7 +340,7 @@ describe('ChargebeeAdapter', () => {
     // invoiceId was already paid in earlier test
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/chargebee/invoices/${invoiceId}/void`,
+      url: `/invoices/${invoiceId}/void`,
     });
     expect(res.statusCode).toBe(400);
   });
@@ -368,7 +368,7 @@ describe('ChargebeeAdapter', () => {
   it('should create and list coupons', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/chargebee/coupons/create_for_items',
+      url: '/coupons/create_for_items',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       payload: 'id=SUMMER20&name=Summer+Discount&discount_type=percentage&discount_percentage=20',
     });
@@ -378,7 +378,7 @@ describe('ChargebeeAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/chargebee/coupons',
+      url: '/coupons',
     });
     expect(listRes.statusCode).toBe(200);
     expect(listRes.json().list.length).toBeGreaterThan(0);

--- a/packages/adapters/adapter-chargebee/src/chargebee-adapter.ts
+++ b/packages/adapters/adapter-chargebee/src/chargebee-adapter.ts
@@ -243,47 +243,47 @@ export class ChargebeeAdapter extends OpenApiMockAdapter<ChargebeeConfig> {
   private mountOverrides(store: StateStore): void {
     // ── Subscriptions — create via /customers/{id}/subscription_for_items ──
     this.registerOverride(
-      'POST', '/chargebee/customers/:customer_id/subscription_for_items',
+      'POST', '/customers/:customer_id/subscription_for_items',
       subOverrides.buildCreateSubscriptionHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/subscriptions/:subscription_id/cancel_for_items',
+      'POST', '/subscriptions/:subscription_id/cancel_for_items',
       subOverrides.buildCancelHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/subscriptions/:subscription_id/reactivate',
+      'POST', '/subscriptions/:subscription_id/reactivate',
       subOverrides.buildReactivateHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/subscriptions/:subscription_id/pause',
+      'POST', '/subscriptions/:subscription_id/pause',
       subOverrides.buildPauseHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/subscriptions/:subscription_id/resume',
+      'POST', '/subscriptions/:subscription_id/resume',
       subOverrides.buildResumeHandler(store),
     );
 
     // ── Invoices — create via /invoices/create_for_charge_items_and_charges ──
     this.registerOverride(
-      'POST', '/chargebee/invoices/create_for_charge_items_and_charges',
+      'POST', '/invoices/create_for_charge_items_and_charges',
       invOverrides.buildCreateInvoiceHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/invoices/:invoice_id/void',
+      'POST', '/invoices/:invoice_id/void',
       invOverrides.buildVoidHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/invoices/:invoice_id/write_off',
+      'POST', '/invoices/:invoice_id/write_off',
       invOverrides.buildWriteOffHandler(store),
     );
     this.registerOverride(
-      'POST', '/chargebee/invoices/:invoice_id/record_payment',
+      'POST', '/invoices/:invoice_id/record_payment',
       invOverrides.buildRecordPaymentHandler(store),
     );
 
     // ── Coupons — create via /coupons/create_for_items ──
     this.registerOverride(
-      'POST', '/chargebee/coupons/create_for_items',
+      'POST', '/coupons/create_for_items',
       async (req, reply) => {
         const body = this.parseBody(req);
         const factory = SCHEMA_DEFAULTS['coupon'];

--- a/packages/adapters/adapter-chargebee/src/generated/meta.ts
+++ b/packages/adapters/adapter-chargebee/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-chargebee generate
 // Chargebee OpenAPI spec version: 2026-03-02.b15ef3737e5ee8e1f69b9db0da59425bde82959d
-// Generated at: 2026-03-13T10:59:46.380Z
+// Generated at: 2026-03-20T11:03:13.037Z
 
 export const CHARGEBEE_SPEC_VERSION = "2026-03-02.b15ef3737e5ee8e1f69b9db0da59425bde82959d";
-export const CHARGEBEE_SPEC_GENERATED_AT = "2026-03-13T10:59:46.380Z";
+export const CHARGEBEE_SPEC_GENERATED_AT = "2026-03-20T11:03:13.037Z";

--- a/packages/adapters/adapter-chargebee/src/generated/routes.ts
+++ b/packages/adapters/adapter-chargebee/src/generated/routes.ts
@@ -6,7 +6,7 @@ export type RouteOperation = 'list' | 'create' | 'retrieve' | 'update' | 'delete
 export interface GeneratedRoute {
   /** HTTP method */
   method: RouteMethod;
-  /** Fastify route path with colon params and /chargebee prefix */
+  /** Fastify route path with colon params */
   fastifyPath: string;
   /** Original spec path for documentation (field name is historical) */
   stripePath: string;
@@ -27,7 +27,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_advance_invoice_schedule",
+    fastifyPath: "/subscriptions/:subscription_id/remove_advance_invoice_schedule",
     stripePath: "/subscriptions/{subscription-id}/remove_advance_invoice_schedule",
     resource: "subscriptions",
     operation: "action",
@@ -38,7 +38,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/update_for_items",
+    fastifyPath: "/subscriptions/:subscription_id/update_for_items",
     stripePath: "/subscriptions/{subscription-id}/update_for_items",
     resource: "subscriptions",
     operation: "action",
@@ -49,7 +49,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_coupons",
+    fastifyPath: "/subscriptions/:subscription_id/remove_coupons",
     stripePath: "/subscriptions/{subscription-id}/remove_coupons",
     resource: "subscriptions",
     operation: "action",
@@ -60,7 +60,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/resume",
+    fastifyPath: "/subscriptions/:subscription_id/resume",
     stripePath: "/subscriptions/{subscription-id}/resume",
     resource: "subscriptions",
     operation: "action",
@@ -71,7 +71,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/cancel_for_items",
+    fastifyPath: "/subscriptions/:subscription_id/cancel_for_items",
     stripePath: "/subscriptions/{subscription-id}/cancel_for_items",
     resource: "subscriptions",
     operation: "action",
@@ -82,7 +82,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/regenerate_invoice",
+    fastifyPath: "/subscriptions/:subscription_id/regenerate_invoice",
     stripePath: "/subscriptions/{subscription-id}/regenerate_invoice",
     resource: "subscriptions",
     operation: "action",
@@ -93,7 +93,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -103,7 +103,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/move",
+    fastifyPath: "/subscriptions/:subscription_id/move",
     stripePath: "/subscriptions/{subscription-id}/move",
     resource: "subscriptions",
     operation: "action",
@@ -114,7 +114,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/import_for_items",
+    fastifyPath: "/customers/:customer_id/import_for_items",
     stripePath: "/customers/{customer-id}/import_for_items",
     resource: "customers",
     operation: "action",
@@ -125,7 +125,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/retrieve_advance_invoice_schedule",
+    fastifyPath: "/subscriptions/:subscription_id/retrieve_advance_invoice_schedule",
     stripePath: "/subscriptions/{subscription-id}/retrieve_advance_invoice_schedule",
     resource: "subscriptions",
     operation: "list",
@@ -136,7 +136,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_scheduled_cancellation",
+    fastifyPath: "/subscriptions/:subscription_id/remove_scheduled_cancellation",
     stripePath: "/subscriptions/{subscription-id}/remove_scheduled_cancellation",
     resource: "subscriptions",
     operation: "action",
@@ -147,7 +147,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/retrieve_with_scheduled_changes",
+    fastifyPath: "/subscriptions/:subscription_id/retrieve_with_scheduled_changes",
     stripePath: "/subscriptions/{subscription-id}/retrieve_with_scheduled_changes",
     resource: "subscriptions",
     operation: "list",
@@ -158,7 +158,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/reactivate",
+    fastifyPath: "/subscriptions/:subscription_id/reactivate",
     stripePath: "/subscriptions/{subscription-id}/reactivate",
     resource: "subscriptions",
     operation: "action",
@@ -169,7 +169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/charge_future_renewals",
+    fastifyPath: "/subscriptions/:subscription_id/charge_future_renewals",
     stripePath: "/subscriptions/{subscription-id}/charge_future_renewals",
     resource: "subscriptions",
     operation: "action",
@@ -180,7 +180,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/add_charge_at_term_end",
+    fastifyPath: "/subscriptions/:subscription_id/add_charge_at_term_end",
     stripePath: "/subscriptions/{subscription-id}/add_charge_at_term_end",
     resource: "subscriptions",
     operation: "action",
@@ -191,7 +191,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_scheduled_changes",
+    fastifyPath: "/subscriptions/:subscription_id/remove_scheduled_changes",
     stripePath: "/subscriptions/{subscription-id}/remove_scheduled_changes",
     resource: "subscriptions",
     operation: "action",
@@ -202,7 +202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/change_term_end",
+    fastifyPath: "/subscriptions/:subscription_id/change_term_end",
     stripePath: "/subscriptions/{subscription-id}/change_term_end",
     resource: "subscriptions",
     operation: "action",
@@ -213,7 +213,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/delete",
+    fastifyPath: "/subscriptions/:subscription_id/delete",
     stripePath: "/subscriptions/{subscription-id}/delete",
     resource: "subscriptions",
     operation: "delete",
@@ -224,7 +224,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/subscription_for_items",
+    fastifyPath: "/customers/:customer_id/subscription_for_items",
     stripePath: "/customers/{customer-id}/subscription_for_items",
     resource: "customers",
     operation: "action",
@@ -235,7 +235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/import_unbilled_charges",
+    fastifyPath: "/subscriptions/:subscription_id/import_unbilled_charges",
     stripePath: "/subscriptions/{subscription-id}/import_unbilled_charges",
     resource: "subscriptions",
     operation: "action",
@@ -246,7 +246,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_scheduled_resumption",
+    fastifyPath: "/subscriptions/:subscription_id/remove_scheduled_resumption",
     stripePath: "/subscriptions/{subscription-id}/remove_scheduled_resumption",
     resource: "subscriptions",
     operation: "action",
@@ -257,7 +257,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription-id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -268,7 +268,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/import_contract_term",
+    fastifyPath: "/subscriptions/:subscription_id/import_contract_term",
     stripePath: "/subscriptions/{subscription-id}/import_contract_term",
     resource: "subscriptions",
     operation: "action",
@@ -279,7 +279,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/override_billing_profile",
+    fastifyPath: "/subscriptions/:subscription_id/override_billing_profile",
     stripePath: "/subscriptions/{subscription-id}/override_billing_profile",
     resource: "subscriptions",
     operation: "action",
@@ -290,7 +290,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/remove_scheduled_pause",
+    fastifyPath: "/subscriptions/:subscription_id/remove_scheduled_pause",
     stripePath: "/subscriptions/{subscription-id}/remove_scheduled_pause",
     resource: "subscriptions",
     operation: "action",
@@ -301,7 +301,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/edit_advance_invoice_schedule",
+    fastifyPath: "/subscriptions/:subscription_id/edit_advance_invoice_schedule",
     stripePath: "/subscriptions/{subscription-id}/edit_advance_invoice_schedule",
     resource: "subscriptions",
     operation: "action",
@@ -312,7 +312,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/discounts",
+    fastifyPath: "/subscriptions/:subscription_id/discounts",
     stripePath: "/subscriptions/{subscription-id}/discounts",
     resource: "subscriptions",
     operation: "list",
@@ -323,7 +323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/contract_terms",
+    fastifyPath: "/subscriptions/:subscription_id/contract_terms",
     stripePath: "/subscriptions/{subscription-id}/contract_terms",
     resource: "subscriptions",
     operation: "list",
@@ -334,7 +334,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/pause",
+    fastifyPath: "/subscriptions/:subscription_id/pause",
     stripePath: "/subscriptions/{subscription-id}/pause",
     resource: "subscriptions",
     operation: "action",
@@ -345,7 +345,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/scheduled_changes",
+    fastifyPath: "/subscriptions/:subscription_id/scheduled_changes",
     stripePath: "/subscriptions/{subscription-id}/scheduled_changes",
     resource: "subscriptions",
     operation: "list",
@@ -356,7 +356,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/update_scheduled_changes",
+    fastifyPath: "/subscriptions/:subscription_id/update_scheduled_changes",
     stripePath: "/subscriptions/{subscription-id}/update_scheduled_changes",
     resource: "subscriptions",
     operation: "action",
@@ -367,7 +367,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/delete",
+    fastifyPath: "/customers/:customer_id/delete",
     stripePath: "/customers/{customer-id}/delete",
     resource: "customers",
     operation: "delete",
@@ -378,7 +378,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/relationships",
+    fastifyPath: "/customers/:customer_id/relationships",
     stripePath: "/customers/{customer-id}/relationships",
     resource: "customers",
     operation: "action",
@@ -389,7 +389,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/delete_relationship",
+    fastifyPath: "/customers/:customer_id/delete_relationship",
     stripePath: "/customers/{customer-id}/delete_relationship",
     resource: "customers",
     operation: "action",
@@ -400,7 +400,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/delete_contact",
+    fastifyPath: "/customers/:customer_id/delete_contact",
     stripePath: "/customers/{customer-id}/delete_contact",
     resource: "customers",
     operation: "action",
@@ -411,7 +411,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/assign_payment_role",
+    fastifyPath: "/customers/:customer_id/assign_payment_role",
     stripePath: "/customers/{customer-id}/assign_payment_role",
     resource: "customers",
     operation: "action",
@@ -422,7 +422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/move",
+    fastifyPath: "/customers/move",
     stripePath: "/customers/move",
     resource: "customers",
     operation: "create",
@@ -432,7 +432,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/hierarchy",
+    fastifyPath: "/customers/:customer_id/hierarchy",
     stripePath: "/customers/{customer-id}/hierarchy",
     resource: "customers",
     operation: "list",
@@ -443,7 +443,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/update_payment_method",
+    fastifyPath: "/customers/:customer_id/update_payment_method",
     stripePath: "/customers/{customer-id}/update_payment_method",
     resource: "customers",
     operation: "action",
@@ -454,7 +454,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer-id}",
     resource: "customers",
     operation: "retrieve",
@@ -465,7 +465,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer-id}",
     resource: "customers",
     operation: "update",
@@ -476,7 +476,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/hierarchy_detail",
+    fastifyPath: "/customers/:customer_id/hierarchy_detail",
     stripePath: "/customers/{customer-id}/hierarchy_detail",
     resource: "customers",
     operation: "list",
@@ -487,7 +487,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/change_billing_date",
+    fastifyPath: "/customers/:customer_id/change_billing_date",
     stripePath: "/customers/{customer-id}/change_billing_date",
     resource: "customers",
     operation: "action",
@@ -498,7 +498,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "list",
@@ -508,7 +508,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "create",
@@ -518,7 +518,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/add_contact",
+    fastifyPath: "/customers/:customer_id/add_contact",
     stripePath: "/customers/{customer-id}/add_contact",
     resource: "customers",
     operation: "action",
@@ -529,7 +529,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/contacts",
+    fastifyPath: "/customers/:customer_id/contacts",
     stripePath: "/customers/{customer-id}/contacts",
     resource: "customers",
     operation: "list",
@@ -540,7 +540,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/clear_personal_data",
+    fastifyPath: "/customers/:customer_id/clear_personal_data",
     stripePath: "/customers/{customer-id}/clear_personal_data",
     resource: "customers",
     operation: "action",
@@ -551,7 +551,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/merge",
+    fastifyPath: "/customers/merge",
     stripePath: "/customers/merge",
     resource: "customers",
     operation: "create",
@@ -561,7 +561,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/collect_payment",
+    fastifyPath: "/customers/:customer_id/collect_payment",
     stripePath: "/customers/{customer-id}/collect_payment",
     resource: "customers",
     operation: "action",
@@ -572,7 +572,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/record_excess_payment",
+    fastifyPath: "/customers/:customer_id/record_excess_payment",
     stripePath: "/customers/{customer-id}/record_excess_payment",
     resource: "customers",
     operation: "action",
@@ -583,7 +583,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/update_contact",
+    fastifyPath: "/customers/:customer_id/update_contact",
     stripePath: "/customers/{customer-id}/update_contact",
     resource: "customers",
     operation: "action",
@@ -594,7 +594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/update_hierarchy_settings",
+    fastifyPath: "/customers/:customer_id/update_hierarchy_settings",
     stripePath: "/customers/{customer-id}/update_hierarchy_settings",
     resource: "customers",
     operation: "action",
@@ -605,7 +605,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/update_billing_info",
+    fastifyPath: "/customers/:customer_id/update_billing_info",
     stripePath: "/customers/{customer-id}/update_billing_info",
     resource: "customers",
     operation: "action",
@@ -616,7 +616,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/tokens/create_using_temp_token",
+    fastifyPath: "/tokens/create_using_temp_token",
     stripePath: "/tokens/create_using_temp_token",
     resource: "tokens",
     operation: "create",
@@ -626,7 +626,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/tokens/create_for_card",
+    fastifyPath: "/tokens/create_for_card",
     stripePath: "/tokens/create_for_card",
     resource: "tokens",
     operation: "create",
@@ -636,7 +636,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/tokens/:cb_token_id",
+    fastifyPath: "/tokens/:cb_token_id",
     stripePath: "/tokens/{cb-token-id}",
     resource: "tokens",
     operation: "retrieve",
@@ -647,7 +647,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_using_permanent_token",
+    fastifyPath: "/payment_sources/create_using_permanent_token",
     stripePath: "/payment_sources/create_using_permanent_token",
     resource: "payment_sources",
     operation: "create",
@@ -657,7 +657,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/delete",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/delete",
     stripePath: "/payment_sources/{cust-payment-source-id}/delete",
     resource: "payment_sources",
     operation: "delete",
@@ -668,7 +668,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_card",
+    fastifyPath: "/payment_sources/create_card",
     stripePath: "/payment_sources/create_card",
     resource: "payment_sources",
     operation: "create",
@@ -678,7 +678,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/verify_bank_account",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/verify_bank_account",
     stripePath: "/payment_sources/{cust-payment-source-id}/verify_bank_account",
     resource: "payment_sources",
     operation: "action",
@@ -689,7 +689,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/payment_sources",
+    fastifyPath: "/payment_sources",
     stripePath: "/payment_sources",
     resource: "payment_sources",
     operation: "list",
@@ -699,7 +699,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/export_payment_source",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/export_payment_source",
     stripePath: "/payment_sources/{cust-payment-source-id}/export_payment_source",
     resource: "payment_sources",
     operation: "action",
@@ -710,7 +710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_using_payment_intent",
+    fastifyPath: "/payment_sources/create_using_payment_intent",
     stripePath: "/payment_sources/create_using_payment_intent",
     resource: "payment_sources",
     operation: "create",
@@ -720,7 +720,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id",
+    fastifyPath: "/payment_sources/:cust_payment_source_id",
     stripePath: "/payment_sources/{cust-payment-source-id}",
     resource: "payment_sources",
     operation: "retrieve",
@@ -731,7 +731,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_voucher_payment_source",
+    fastifyPath: "/payment_sources/create_voucher_payment_source",
     stripePath: "/payment_sources/create_voucher_payment_source",
     resource: "payment_sources",
     operation: "create",
@@ -741,7 +741,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_using_temp_token",
+    fastifyPath: "/payment_sources/create_using_temp_token",
     stripePath: "/payment_sources/create_using_temp_token",
     resource: "payment_sources",
     operation: "create",
@@ -751,7 +751,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/update_card",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/update_card",
     stripePath: "/payment_sources/{cust-payment-source-id}/update_card",
     resource: "payment_sources",
     operation: "action",
@@ -762,7 +762,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/switch_gateway_account",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/switch_gateway_account",
     stripePath: "/payment_sources/{cust-payment-source-id}/switch_gateway_account",
     resource: "payment_sources",
     operation: "action",
@@ -773,7 +773,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_using_token",
+    fastifyPath: "/payment_sources/create_using_token",
     stripePath: "/payment_sources/create_using_token",
     resource: "payment_sources",
     operation: "create",
@@ -783,7 +783,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/delete_local",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/delete_local",
     stripePath: "/payment_sources/{cust-payment-source-id}/delete_local",
     resource: "payment_sources",
     operation: "action",
@@ -794,7 +794,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/create_bank_account",
+    fastifyPath: "/payment_sources/create_bank_account",
     stripePath: "/payment_sources/create_bank_account",
     resource: "payment_sources",
     operation: "create",
@@ -804,7 +804,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_sources/:cust_payment_source_id/update_bank_account",
+    fastifyPath: "/payment_sources/:cust_payment_source_id/update_bank_account",
     stripePath: "/payment_sources/{cust-payment-source-id}/update_bank_account",
     resource: "payment_sources",
     operation: "action",
@@ -815,7 +815,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/virtual_bank_accounts/:virtual_bank_account_id/delete_local",
+    fastifyPath: "/virtual_bank_accounts/:virtual_bank_account_id/delete_local",
     stripePath: "/virtual_bank_accounts/{virtual-bank-account-id}/delete_local",
     resource: "virtual_bank_accounts",
     operation: "action",
@@ -826,7 +826,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/virtual_bank_accounts/:virtual_bank_account_id/delete",
+    fastifyPath: "/virtual_bank_accounts/:virtual_bank_account_id/delete",
     stripePath: "/virtual_bank_accounts/{virtual-bank-account-id}/delete",
     resource: "virtual_bank_accounts",
     operation: "delete",
@@ -837,7 +837,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/virtual_bank_accounts",
+    fastifyPath: "/virtual_bank_accounts",
     stripePath: "/virtual_bank_accounts",
     resource: "virtual_bank_accounts",
     operation: "list",
@@ -847,7 +847,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/virtual_bank_accounts",
+    fastifyPath: "/virtual_bank_accounts",
     stripePath: "/virtual_bank_accounts",
     resource: "virtual_bank_accounts",
     operation: "create",
@@ -857,7 +857,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/virtual_bank_accounts/:virtual_bank_account_id",
+    fastifyPath: "/virtual_bank_accounts/:virtual_bank_account_id",
     stripePath: "/virtual_bank_accounts/{virtual-bank-account-id}",
     resource: "virtual_bank_accounts",
     operation: "retrieve",
@@ -868,7 +868,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/virtual_bank_accounts/create_using_permanent_token",
+    fastifyPath: "/virtual_bank_accounts/create_using_permanent_token",
     stripePath: "/virtual_bank_accounts/create_using_permanent_token",
     resource: "virtual_bank_accounts",
     operation: "create",
@@ -878,7 +878,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/copy_card",
+    fastifyPath: "/customers/:customer_id/copy_card",
     stripePath: "/customers/{customer-id}/copy_card",
     resource: "customers",
     operation: "action",
@@ -889,7 +889,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/cards/:customer_id",
+    fastifyPath: "/cards/:customer_id",
     stripePath: "/cards/{customer-id}",
     resource: "cards",
     operation: "retrieve",
@@ -900,7 +900,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/switch_gateway",
+    fastifyPath: "/customers/:customer_id/switch_gateway",
     stripePath: "/customers/{customer-id}/switch_gateway",
     resource: "customers",
     operation: "action",
@@ -911,7 +911,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/delete_card",
+    fastifyPath: "/customers/:customer_id/delete_card",
     stripePath: "/customers/{customer-id}/delete_card",
     resource: "customers",
     operation: "action",
@@ -922,7 +922,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/credit_card",
+    fastifyPath: "/customers/:customer_id/credit_card",
     stripePath: "/customers/{customer-id}/credit_card",
     resource: "customers",
     operation: "action",
@@ -933,7 +933,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/promotional_credits/:account_credit_id",
+    fastifyPath: "/promotional_credits/:account_credit_id",
     stripePath: "/promotional_credits/{account-credit-id}",
     resource: "promotional_credits",
     operation: "retrieve",
@@ -944,7 +944,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/promotional_credits",
+    fastifyPath: "/promotional_credits",
     stripePath: "/promotional_credits",
     resource: "promotional_credits",
     operation: "list",
@@ -954,7 +954,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/promotional_credits/deduct",
+    fastifyPath: "/promotional_credits/deduct",
     stripePath: "/promotional_credits/deduct",
     resource: "promotional_credits",
     operation: "create",
@@ -964,7 +964,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/promotional_credits/set",
+    fastifyPath: "/promotional_credits/set",
     stripePath: "/promotional_credits/set",
     resource: "promotional_credits",
     operation: "create",
@@ -974,7 +974,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/promotional_credits/add",
+    fastifyPath: "/promotional_credits/add",
     stripePath: "/promotional_credits/add",
     resource: "promotional_credits",
     operation: "create",
@@ -984,7 +984,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/delete_line_items",
+    fastifyPath: "/invoices/:invoice_id/delete_line_items",
     stripePath: "/invoices/{invoice-id}/delete_line_items",
     resource: "invoices",
     operation: "action",
@@ -995,7 +995,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/remove_credit_note",
+    fastifyPath: "/invoices/:invoice_id/remove_credit_note",
     stripePath: "/invoices/{invoice-id}/remove_credit_note",
     resource: "invoices",
     operation: "action",
@@ -1006,7 +1006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/remove_payment",
+    fastifyPath: "/invoices/:invoice_id/remove_payment",
     stripePath: "/invoices/{invoice-id}/remove_payment",
     resource: "invoices",
     operation: "action",
@@ -1017,7 +1017,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/stop_dunning",
+    fastifyPath: "/invoices/:invoice_id/stop_dunning",
     stripePath: "/invoices/{invoice-id}/stop_dunning",
     resource: "invoices",
     operation: "action",
@@ -1028,7 +1028,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/apply_payments",
+    fastifyPath: "/invoices/:invoice_id/apply_payments",
     stripePath: "/invoices/{invoice-id}/apply_payments",
     resource: "invoices",
     operation: "action",
@@ -1039,7 +1039,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/apply_payment_schedule_scheme",
+    fastifyPath: "/invoices/:invoice_id/apply_payment_schedule_scheme",
     stripePath: "/invoices/{invoice-id}/apply_payment_schedule_scheme",
     resource: "invoices",
     operation: "action",
@@ -1050,7 +1050,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/void",
+    fastifyPath: "/invoices/:invoice_id/void",
     stripePath: "/invoices/{invoice-id}/void",
     resource: "invoices",
     operation: "action",
@@ -1061,7 +1061,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/add_charge",
+    fastifyPath: "/invoices/:invoice_id/add_charge",
     stripePath: "/invoices/{invoice-id}/add_charge",
     resource: "invoices",
     operation: "action",
@@ -1072,7 +1072,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/send_einvoice",
+    fastifyPath: "/invoices/:invoice_id/send_einvoice",
     stripePath: "/invoices/{invoice-id}/send_einvoice",
     resource: "invoices",
     operation: "action",
@@ -1083,7 +1083,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/:invoice_id/payment_schedules",
+    fastifyPath: "/invoices/:invoice_id/payment_schedules",
     stripePath: "/invoices/{invoice-id}/payment_schedules",
     resource: "invoices",
     operation: "list",
@@ -1094,7 +1094,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/write_off",
+    fastifyPath: "/invoices/:invoice_id/write_off",
     stripePath: "/invoices/{invoice-id}/write_off",
     resource: "invoices",
     operation: "action",
@@ -1105,7 +1105,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/add_charge_item",
+    fastifyPath: "/invoices/:invoice_id/add_charge_item",
     stripePath: "/invoices/{invoice-id}/add_charge_item",
     resource: "invoices",
     operation: "action",
@@ -1116,7 +1116,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/pause_dunning",
+    fastifyPath: "/invoices/:invoice_id/pause_dunning",
     stripePath: "/invoices/{invoice-id}/pause_dunning",
     resource: "invoices",
     operation: "action",
@@ -1127,7 +1127,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices",
+    fastifyPath: "/invoices",
     stripePath: "/invoices",
     resource: "invoices",
     operation: "list",
@@ -1137,7 +1137,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/close",
+    fastifyPath: "/invoices/:invoice_id/close",
     stripePath: "/invoices/{invoice-id}/close",
     resource: "invoices",
     operation: "action",
@@ -1148,7 +1148,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/apply_credits",
+    fastifyPath: "/invoices/:invoice_id/apply_credits",
     stripePath: "/invoices/{invoice-id}/apply_credits",
     resource: "invoices",
     operation: "action",
@@ -1159,7 +1159,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/:invoice_id",
+    fastifyPath: "/invoices/:invoice_id",
     stripePath: "/invoices/{invoice-id}",
     resource: "invoices",
     operation: "retrieve",
@@ -1170,7 +1170,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/create_for_charge_items_and_charges",
+    fastifyPath: "/invoices/create_for_charge_items_and_charges",
     stripePath: "/invoices/create_for_charge_items_and_charges",
     resource: "invoices",
     operation: "create",
@@ -1180,7 +1180,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/update_details",
+    fastifyPath: "/invoices/:invoice_id/update_details",
     stripePath: "/invoices/{invoice-id}/update_details",
     resource: "invoices",
     operation: "action",
@@ -1191,7 +1191,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/record_payment",
+    fastifyPath: "/invoices/:invoice_id/record_payment",
     stripePath: "/invoices/{invoice-id}/record_payment",
     resource: "invoices",
     operation: "action",
@@ -1202,7 +1202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/delete",
+    fastifyPath: "/invoices/:invoice_id/delete",
     stripePath: "/invoices/{invoice-id}/delete",
     resource: "invoices",
     operation: "delete",
@@ -1213,7 +1213,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/import_invoice",
+    fastifyPath: "/invoices/import_invoice",
     stripePath: "/invoices/import_invoice",
     resource: "invoices",
     operation: "create",
@@ -1223,7 +1223,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/resume_dunning",
+    fastifyPath: "/invoices/:invoice_id/resume_dunning",
     stripePath: "/invoices/{invoice-id}/resume_dunning",
     resource: "invoices",
     operation: "action",
@@ -1234,7 +1234,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/record_tax_withheld",
+    fastifyPath: "/invoices/:invoice_id/record_tax_withheld",
     stripePath: "/invoices/{invoice-id}/record_tax_withheld",
     resource: "invoices",
     operation: "action",
@@ -1245,7 +1245,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/resend_einvoice",
+    fastifyPath: "/invoices/:invoice_id/resend_einvoice",
     stripePath: "/invoices/{invoice-id}/resend_einvoice",
     resource: "invoices",
     operation: "action",
@@ -1256,7 +1256,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/remove_tax_withheld",
+    fastifyPath: "/invoices/:invoice_id/remove_tax_withheld",
     stripePath: "/invoices/{invoice-id}/remove_tax_withheld",
     resource: "invoices",
     operation: "action",
@@ -1267,7 +1267,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/payment_reference_numbers",
+    fastifyPath: "/invoices/payment_reference_numbers",
     stripePath: "/invoices/payment_reference_numbers",
     resource: "invoices",
     operation: "list",
@@ -1277,7 +1277,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/collect_payment",
+    fastifyPath: "/invoices/:invoice_id/collect_payment",
     stripePath: "/invoices/{invoice-id}/collect_payment",
     resource: "invoices",
     operation: "action",
@@ -1288,7 +1288,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/sync_usages",
+    fastifyPath: "/invoices/:invoice_id/sync_usages",
     stripePath: "/invoices/{invoice-id}/sync_usages",
     resource: "invoices",
     operation: "action",
@@ -1299,7 +1299,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/refund",
+    fastifyPath: "/invoices/:invoice_id/refund",
     stripePath: "/invoices/{invoice-id}/refund",
     resource: "invoices",
     operation: "action",
@@ -1310,7 +1310,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/record_refund",
+    fastifyPath: "/invoices/:invoice_id/record_refund",
     stripePath: "/invoices/{invoice-id}/record_refund",
     resource: "invoices",
     operation: "action",
@@ -1321,7 +1321,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/invoices/:invoice_id/pdf",
+    fastifyPath: "/invoices/:invoice_id/pdf",
     stripePath: "/invoices/{invoice-id}/pdf",
     resource: "invoices",
     operation: "action",
@@ -1332,7 +1332,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/:invoice_id/download_einvoice",
+    fastifyPath: "/invoices/:invoice_id/download_einvoice",
     stripePath: "/invoices/{invoice-id}/download_einvoice",
     resource: "invoices",
     operation: "list",
@@ -1343,7 +1343,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/record_refund",
+    fastifyPath: "/credit_notes/:credit_note_id/record_refund",
     stripePath: "/credit_notes/{credit-note-id}/record_refund",
     resource: "credit_notes",
     operation: "action",
@@ -1354,7 +1354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/import_credit_note",
+    fastifyPath: "/credit_notes/import_credit_note",
     stripePath: "/credit_notes/import_credit_note",
     resource: "credit_notes",
     operation: "create",
@@ -1364,7 +1364,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/delete",
+    fastifyPath: "/credit_notes/:credit_note_id/delete",
     stripePath: "/credit_notes/{credit-note-id}/delete",
     resource: "credit_notes",
     operation: "delete",
@@ -1375,7 +1375,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/pdf",
+    fastifyPath: "/credit_notes/:credit_note_id/pdf",
     stripePath: "/credit_notes/{credit-note-id}/pdf",
     resource: "credit_notes",
     operation: "action",
@@ -1386,7 +1386,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/send_einvoice",
+    fastifyPath: "/credit_notes/:credit_note_id/send_einvoice",
     stripePath: "/credit_notes/{credit-note-id}/send_einvoice",
     resource: "credit_notes",
     operation: "action",
@@ -1397,7 +1397,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/void",
+    fastifyPath: "/credit_notes/:credit_note_id/void",
     stripePath: "/credit_notes/{credit-note-id}/void",
     resource: "credit_notes",
     operation: "action",
@@ -1408,7 +1408,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/refund",
+    fastifyPath: "/credit_notes/:credit_note_id/refund",
     stripePath: "/credit_notes/{credit-note-id}/refund",
     resource: "credit_notes",
     operation: "action",
@@ -1419,7 +1419,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/credit_notes",
+    fastifyPath: "/credit_notes",
     stripePath: "/credit_notes",
     resource: "credit_notes",
     operation: "list",
@@ -1429,7 +1429,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes",
+    fastifyPath: "/credit_notes",
     stripePath: "/credit_notes",
     resource: "credit_notes",
     operation: "create",
@@ -1439,7 +1439,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/download_einvoice",
+    fastifyPath: "/credit_notes/:credit_note_id/download_einvoice",
     stripePath: "/credit_notes/{credit-note-id}/download_einvoice",
     resource: "credit_notes",
     operation: "list",
@@ -1450,7 +1450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/resend_einvoice",
+    fastifyPath: "/credit_notes/:credit_note_id/resend_einvoice",
     stripePath: "/credit_notes/{credit-note-id}/resend_einvoice",
     resource: "credit_notes",
     operation: "action",
@@ -1461,7 +1461,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id/remove_tax_withheld_refund",
+    fastifyPath: "/credit_notes/:credit_note_id/remove_tax_withheld_refund",
     stripePath: "/credit_notes/{credit-note-id}/remove_tax_withheld_refund",
     resource: "credit_notes",
     operation: "action",
@@ -1472,7 +1472,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/credit_notes/:credit_note_id",
+    fastifyPath: "/credit_notes/:credit_note_id",
     stripePath: "/credit_notes/{credit-note-id}",
     resource: "credit_notes",
     operation: "retrieve",
@@ -1483,7 +1483,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/unbilled_charges/:unbilled_charge_id/delete",
+    fastifyPath: "/unbilled_charges/:unbilled_charge_id/delete",
     stripePath: "/unbilled_charges/{unbilled-charge-id}/delete",
     resource: "unbilled_charges",
     operation: "delete",
@@ -1494,7 +1494,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/unbilled_charges/invoice_now_estimate",
+    fastifyPath: "/unbilled_charges/invoice_now_estimate",
     stripePath: "/unbilled_charges/invoice_now_estimate",
     resource: "unbilled_charges",
     operation: "create",
@@ -1504,7 +1504,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/unbilled_charges/invoice_unbilled_charges",
+    fastifyPath: "/unbilled_charges/invoice_unbilled_charges",
     stripePath: "/unbilled_charges/invoice_unbilled_charges",
     resource: "unbilled_charges",
     operation: "create",
@@ -1514,7 +1514,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/unbilled_charges",
+    fastifyPath: "/unbilled_charges",
     stripePath: "/unbilled_charges",
     resource: "unbilled_charges",
     operation: "list",
@@ -1524,7 +1524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/unbilled_charges",
+    fastifyPath: "/unbilled_charges",
     stripePath: "/unbilled_charges",
     resource: "unbilled_charges",
     operation: "create",
@@ -1534,7 +1534,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/orders",
+    fastifyPath: "/orders",
     stripePath: "/orders",
     resource: "orders",
     operation: "list",
@@ -1544,7 +1544,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders",
+    fastifyPath: "/orders",
     stripePath: "/orders",
     resource: "orders",
     operation: "create",
@@ -1554,7 +1554,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/import_order",
+    fastifyPath: "/orders/import_order",
     stripePath: "/orders/import_order",
     resource: "orders",
     operation: "create",
@@ -1564,7 +1564,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/assign_order_number",
+    fastifyPath: "/orders/:order_id/assign_order_number",
     stripePath: "/orders/{order-id}/assign_order_number",
     resource: "orders",
     operation: "action",
@@ -1575,7 +1575,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/resend",
+    fastifyPath: "/orders/:order_id/resend",
     stripePath: "/orders/{order-id}/resend",
     resource: "orders",
     operation: "action",
@@ -1586,7 +1586,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/reopen",
+    fastifyPath: "/orders/:order_id/reopen",
     stripePath: "/orders/{order-id}/reopen",
     resource: "orders",
     operation: "action",
@@ -1597,7 +1597,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/cancel",
+    fastifyPath: "/orders/:order_id/cancel",
     stripePath: "/orders/{order-id}/cancel",
     resource: "orders",
     operation: "action",
@@ -1608,7 +1608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/orders/:order_id",
+    fastifyPath: "/orders/:order_id",
     stripePath: "/orders/{order-id}",
     resource: "orders",
     operation: "retrieve",
@@ -1619,7 +1619,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id",
+    fastifyPath: "/orders/:order_id",
     stripePath: "/orders/{order-id}",
     resource: "orders",
     operation: "update",
@@ -1630,7 +1630,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/delete",
+    fastifyPath: "/orders/:order_id/delete",
     stripePath: "/orders/{order-id}/delete",
     resource: "orders",
     operation: "delete",
@@ -1641,7 +1641,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/orders/:order_id/create_refundable_credit_note",
+    fastifyPath: "/orders/:order_id/create_refundable_credit_note",
     stripePath: "/orders/{order-id}/create_refundable_credit_note",
     resource: "orders",
     operation: "create",
@@ -1652,7 +1652,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/gifts/create_for_items",
+    fastifyPath: "/gifts/create_for_items",
     stripePath: "/gifts/create_for_items",
     resource: "gifts",
     operation: "create",
@@ -1662,7 +1662,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/gifts/:gift_id/cancel",
+    fastifyPath: "/gifts/:gift_id/cancel",
     stripePath: "/gifts/{gift-id}/cancel",
     resource: "gifts",
     operation: "action",
@@ -1673,7 +1673,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/gifts/:gift_id/update_gift",
+    fastifyPath: "/gifts/:gift_id/update_gift",
     stripePath: "/gifts/{gift-id}/update_gift",
     resource: "gifts",
     operation: "action",
@@ -1684,7 +1684,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/gifts",
+    fastifyPath: "/gifts",
     stripePath: "/gifts",
     resource: "gifts",
     operation: "list",
@@ -1694,7 +1694,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/gifts/:gift_id",
+    fastifyPath: "/gifts/:gift_id",
     stripePath: "/gifts/{gift-id}",
     resource: "gifts",
     operation: "retrieve",
@@ -1705,7 +1705,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/gifts/:gift_id/claim",
+    fastifyPath: "/gifts/:gift_id/claim",
     stripePath: "/gifts/{gift-id}/claim",
     resource: "gifts",
     operation: "action",
@@ -1716,7 +1716,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/transactions",
+    fastifyPath: "/transactions",
     stripePath: "/transactions",
     resource: "transactions",
     operation: "list",
@@ -1726,7 +1726,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/:transaction_id/reconcile",
+    fastifyPath: "/transactions/:transaction_id/reconcile",
     stripePath: "/transactions/{transaction-id}/reconcile",
     resource: "transactions",
     operation: "action",
@@ -1737,7 +1737,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/transactions/:transaction_id",
+    fastifyPath: "/transactions/:transaction_id",
     stripePath: "/transactions/{transaction-id}",
     resource: "transactions",
     operation: "retrieve",
@@ -1748,7 +1748,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/:transaction_id/refund",
+    fastifyPath: "/transactions/:transaction_id/refund",
     stripePath: "/transactions/{transaction-id}/refund",
     resource: "transactions",
     operation: "action",
@@ -1759,7 +1759,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/:transaction_id/record_refund",
+    fastifyPath: "/transactions/:transaction_id/record_refund",
     stripePath: "/transactions/{transaction-id}/record_refund",
     resource: "transactions",
     operation: "action",
@@ -1770,7 +1770,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/:transaction_id/void",
+    fastifyPath: "/transactions/:transaction_id/void",
     stripePath: "/transactions/{transaction-id}/void",
     resource: "transactions",
     operation: "action",
@@ -1781,7 +1781,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/create_authorization",
+    fastifyPath: "/transactions/create_authorization",
     stripePath: "/transactions/create_authorization",
     resource: "transactions",
     operation: "create",
@@ -1791,7 +1791,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/:invoice_id/payments",
+    fastifyPath: "/invoices/:invoice_id/payments",
     stripePath: "/invoices/{invoice-id}/payments",
     resource: "invoices",
     operation: "list",
@@ -1802,7 +1802,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/transactions/:transaction_id/delete_offline_transaction",
+    fastifyPath: "/transactions/:transaction_id/delete_offline_transaction",
     stripePath: "/transactions/{transaction-id}/delete_offline_transaction",
     resource: "transactions",
     operation: "action",
@@ -1813,7 +1813,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/checkout_one_time_for_items",
+    fastifyPath: "/hosted_pages/checkout_one_time_for_items",
     stripePath: "/hosted_pages/checkout_one_time_for_items",
     resource: "hosted_pages",
     operation: "create",
@@ -1823,7 +1823,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/update_payment_method",
+    fastifyPath: "/hosted_pages/update_payment_method",
     stripePath: "/hosted_pages/update_payment_method",
     resource: "hosted_pages",
     operation: "create",
@@ -1833,7 +1833,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/extend_subscription",
+    fastifyPath: "/hosted_pages/extend_subscription",
     stripePath: "/hosted_pages/extend_subscription",
     resource: "hosted_pages",
     operation: "create",
@@ -1843,7 +1843,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/events",
+    fastifyPath: "/hosted_pages/events",
     stripePath: "/hosted_pages/events",
     resource: "hosted_pages",
     operation: "create",
@@ -1853,7 +1853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/checkout_gift_for_items",
+    fastifyPath: "/hosted_pages/checkout_gift_for_items",
     stripePath: "/hosted_pages/checkout_gift_for_items",
     resource: "hosted_pages",
     operation: "create",
@@ -1863,7 +1863,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/hosted_pages",
+    fastifyPath: "/hosted_pages",
     stripePath: "/hosted_pages",
     resource: "hosted_pages",
     operation: "list",
@@ -1873,7 +1873,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/view_voucher",
+    fastifyPath: "/hosted_pages/view_voucher",
     stripePath: "/hosted_pages/view_voucher",
     resource: "hosted_pages",
     operation: "create",
@@ -1883,7 +1883,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/collect_now",
+    fastifyPath: "/hosted_pages/collect_now",
     stripePath: "/hosted_pages/collect_now",
     resource: "hosted_pages",
     operation: "create",
@@ -1893,7 +1893,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/accept_quote",
+    fastifyPath: "/hosted_pages/accept_quote",
     stripePath: "/hosted_pages/accept_quote",
     resource: "hosted_pages",
     operation: "create",
@@ -1903,7 +1903,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/checkout_new_for_items",
+    fastifyPath: "/hosted_pages/checkout_new_for_items",
     stripePath: "/hosted_pages/checkout_new_for_items",
     resource: "hosted_pages",
     operation: "create",
@@ -1913,7 +1913,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/claim_gift",
+    fastifyPath: "/hosted_pages/claim_gift",
     stripePath: "/hosted_pages/claim_gift",
     resource: "hosted_pages",
     operation: "create",
@@ -1923,7 +1923,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/checkout_existing_for_items",
+    fastifyPath: "/hosted_pages/checkout_existing_for_items",
     stripePath: "/hosted_pages/checkout_existing_for_items",
     resource: "hosted_pages",
     operation: "create",
@@ -1933,7 +1933,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/pre_cancel",
+    fastifyPath: "/hosted_pages/pre_cancel",
     stripePath: "/hosted_pages/pre_cancel",
     resource: "hosted_pages",
     operation: "create",
@@ -1943,7 +1943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/:hosted_page_id/acknowledge",
+    fastifyPath: "/hosted_pages/:hosted_page_id/acknowledge",
     stripePath: "/hosted_pages/{hosted-page-id}/acknowledge",
     resource: "hosted_pages",
     operation: "action",
@@ -1954,7 +1954,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/retrieve_agreement_pdf",
+    fastifyPath: "/hosted_pages/retrieve_agreement_pdf",
     stripePath: "/hosted_pages/retrieve_agreement_pdf",
     resource: "hosted_pages",
     operation: "create",
@@ -1964,7 +1964,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/hosted_pages/:hosted_page_id",
+    fastifyPath: "/hosted_pages/:hosted_page_id",
     stripePath: "/hosted_pages/{hosted-page-id}",
     resource: "hosted_pages",
     operation: "retrieve",
@@ -1975,7 +1975,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/hosted_pages/manage_payment_sources",
+    fastifyPath: "/hosted_pages/manage_payment_sources",
     stripePath: "/hosted_pages/manage_payment_sources",
     resource: "hosted_pages",
     operation: "create",
@@ -1985,7 +1985,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/renewal_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/renewal_estimate",
     stripePath: "/subscriptions/{subscription-id}/renewal_estimate",
     resource: "subscriptions",
     operation: "list",
@@ -1996,7 +1996,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/estimates/create_subscription_for_items",
+    fastifyPath: "/estimates/create_subscription_for_items",
     stripePath: "/estimates/create_subscription_for_items",
     resource: "estimates",
     operation: "create",
@@ -2005,7 +2005,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/estimates/payment_schedules",
+    fastifyPath: "/estimates/payment_schedules",
     stripePath: "/estimates/payment_schedules",
     resource: "estimates",
     operation: "create",
@@ -2014,7 +2014,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/cancel_subscription_for_items_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/cancel_subscription_for_items_estimate",
     stripePath: "/subscriptions/{subscription-id}/cancel_subscription_for_items_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2025,7 +2025,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/resume_subscription_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/resume_subscription_estimate",
     stripePath: "/subscriptions/{subscription-id}/resume_subscription_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2036,7 +2036,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/estimates/create_invoice_for_items",
+    fastifyPath: "/estimates/create_invoice_for_items",
     stripePath: "/estimates/create_invoice_for_items",
     resource: "estimates",
     operation: "create",
@@ -2045,7 +2045,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/estimates/gift_subscription_for_items",
+    fastifyPath: "/estimates/gift_subscription_for_items",
     stripePath: "/estimates/gift_subscription_for_items",
     resource: "estimates",
     operation: "create",
@@ -2054,7 +2054,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/estimates/update_subscription_for_items",
+    fastifyPath: "/estimates/update_subscription_for_items",
     stripePath: "/estimates/update_subscription_for_items",
     resource: "estimates",
     operation: "create",
@@ -2063,7 +2063,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/upcoming_invoices_estimate",
+    fastifyPath: "/customers/:customer_id/upcoming_invoices_estimate",
     stripePath: "/customers/{customer-id}/upcoming_invoices_estimate",
     resource: "customers",
     operation: "list",
@@ -2074,7 +2074,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/regenerate_invoice_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/regenerate_invoice_estimate",
     stripePath: "/subscriptions/{subscription-id}/regenerate_invoice_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2085,7 +2085,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/create_subscription_for_items_estimate",
+    fastifyPath: "/customers/:customer_id/create_subscription_for_items_estimate",
     stripePath: "/customers/{customer-id}/create_subscription_for_items_estimate",
     resource: "customers",
     operation: "create",
@@ -2096,7 +2096,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/change_term_end_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/change_term_end_estimate",
     stripePath: "/subscriptions/{subscription-id}/change_term_end_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2107,7 +2107,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/pause_subscription_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/pause_subscription_estimate",
     stripePath: "/subscriptions/{subscription-id}/pause_subscription_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2118,7 +2118,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/advance_invoice_estimate",
+    fastifyPath: "/subscriptions/:subscription_id/advance_invoice_estimate",
     stripePath: "/subscriptions/{subscription-id}/advance_invoice_estimate",
     resource: "subscriptions",
     operation: "action",
@@ -2129,7 +2129,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/customers/:customer_id/create_subscription_quote_for_items",
+    fastifyPath: "/customers/:customer_id/create_subscription_quote_for_items",
     stripePath: "/customers/{customer-id}/create_subscription_quote_for_items",
     resource: "customers",
     operation: "create",
@@ -2140,7 +2140,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/quotes/:quote_id",
+    fastifyPath: "/quotes/:quote_id",
     stripePath: "/quotes/{quote-id}",
     resource: "quotes",
     operation: "retrieve",
@@ -2151,7 +2151,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/edit_create_subscription_quote_for_items",
+    fastifyPath: "/quotes/:quote_id/edit_create_subscription_quote_for_items",
     stripePath: "/quotes/{quote-id}/edit_create_subscription_quote_for_items",
     resource: "quotes",
     operation: "action",
@@ -2162,7 +2162,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/update_status",
+    fastifyPath: "/quotes/:quote_id/update_status",
     stripePath: "/quotes/{quote-id}/update_status",
     resource: "quotes",
     operation: "action",
@@ -2173,7 +2173,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/update_subscription_quote_for_items",
+    fastifyPath: "/quotes/update_subscription_quote_for_items",
     stripePath: "/quotes/update_subscription_quote_for_items",
     resource: "quotes",
     operation: "create",
@@ -2183,7 +2183,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/quotes/:quote_id/quote_line_groups",
+    fastifyPath: "/quotes/:quote_id/quote_line_groups",
     stripePath: "/quotes/{quote-id}/quote_line_groups",
     resource: "quotes",
     operation: "list",
@@ -2194,7 +2194,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/extend_expiry_date",
+    fastifyPath: "/quotes/:quote_id/extend_expiry_date",
     stripePath: "/quotes/{quote-id}/extend_expiry_date",
     resource: "quotes",
     operation: "action",
@@ -2205,7 +2205,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/edit_for_charge_items_and_charges",
+    fastifyPath: "/quotes/:quote_id/edit_for_charge_items_and_charges",
     stripePath: "/quotes/{quote-id}/edit_for_charge_items_and_charges",
     resource: "quotes",
     operation: "action",
@@ -2216,7 +2216,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/edit_update_subscription_quote_for_items",
+    fastifyPath: "/quotes/:quote_id/edit_update_subscription_quote_for_items",
     stripePath: "/quotes/{quote-id}/edit_update_subscription_quote_for_items",
     resource: "quotes",
     operation: "action",
@@ -2227,7 +2227,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/quotes",
+    fastifyPath: "/quotes",
     stripePath: "/quotes",
     resource: "quotes",
     operation: "list",
@@ -2237,7 +2237,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/pdf",
+    fastifyPath: "/quotes/:quote_id/pdf",
     stripePath: "/quotes/{quote-id}/pdf",
     resource: "quotes",
     operation: "action",
@@ -2248,7 +2248,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/convert",
+    fastifyPath: "/quotes/:quote_id/convert",
     stripePath: "/quotes/{quote-id}/convert",
     resource: "quotes",
     operation: "action",
@@ -2259,7 +2259,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/create_for_charge_items_and_charges",
+    fastifyPath: "/quotes/create_for_charge_items_and_charges",
     stripePath: "/quotes/create_for_charge_items_and_charges",
     resource: "quotes",
     operation: "create",
@@ -2269,7 +2269,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/quotes/:quote_id/delete",
+    fastifyPath: "/quotes/:quote_id/delete",
     stripePath: "/quotes/{quote-id}/delete",
     resource: "quotes",
     operation: "delete",
@@ -2280,7 +2280,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupons",
+    fastifyPath: "/coupons",
     stripePath: "/coupons",
     resource: "coupons",
     operation: "list",
@@ -2290,7 +2290,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupons/:coupon_id/update_for_items",
+    fastifyPath: "/coupons/:coupon_id/update_for_items",
     stripePath: "/coupons/{coupon-id}/update_for_items",
     resource: "coupons",
     operation: "action",
@@ -2301,7 +2301,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupons/:coupon_id/unarchive",
+    fastifyPath: "/coupons/:coupon_id/unarchive",
     stripePath: "/coupons/{coupon-id}/unarchive",
     resource: "coupons",
     operation: "action",
@@ -2312,7 +2312,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupons/:coupon_id/delete",
+    fastifyPath: "/coupons/:coupon_id/delete",
     stripePath: "/coupons/{coupon-id}/delete",
     resource: "coupons",
     operation: "delete",
@@ -2323,7 +2323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupons/copy",
+    fastifyPath: "/coupons/copy",
     stripePath: "/coupons/copy",
     resource: "coupons",
     operation: "create",
@@ -2333,7 +2333,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupons/:coupon_id",
+    fastifyPath: "/coupons/:coupon_id",
     stripePath: "/coupons/{coupon-id}",
     resource: "coupons",
     operation: "retrieve",
@@ -2344,7 +2344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupons/create_for_items",
+    fastifyPath: "/coupons/create_for_items",
     stripePath: "/coupons/create_for_items",
     resource: "coupons",
     operation: "create",
@@ -2354,7 +2354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupon_sets",
+    fastifyPath: "/coupon_sets",
     stripePath: "/coupon_sets",
     resource: "coupon_sets",
     operation: "list",
@@ -2364,7 +2364,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_sets",
+    fastifyPath: "/coupon_sets",
     stripePath: "/coupon_sets",
     resource: "coupon_sets",
     operation: "create",
@@ -2374,7 +2374,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_sets/:coupon_set_id/update",
+    fastifyPath: "/coupon_sets/:coupon_set_id/update",
     stripePath: "/coupon_sets/{coupon-set-id}/update",
     resource: "coupon_sets",
     operation: "action",
@@ -2385,7 +2385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupon_sets/:coupon_set_id",
+    fastifyPath: "/coupon_sets/:coupon_set_id",
     stripePath: "/coupon_sets/{coupon-set-id}",
     resource: "coupon_sets",
     operation: "retrieve",
@@ -2396,7 +2396,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_sets/:coupon_set_id/add_coupon_codes",
+    fastifyPath: "/coupon_sets/:coupon_set_id/add_coupon_codes",
     stripePath: "/coupon_sets/{coupon-set-id}/add_coupon_codes",
     resource: "coupon_sets",
     operation: "action",
@@ -2407,7 +2407,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_sets/:coupon_set_id/delete_unused_coupon_codes",
+    fastifyPath: "/coupon_sets/:coupon_set_id/delete_unused_coupon_codes",
     stripePath: "/coupon_sets/{coupon-set-id}/delete_unused_coupon_codes",
     resource: "coupon_sets",
     operation: "action",
@@ -2418,7 +2418,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_sets/:coupon_set_id/delete",
+    fastifyPath: "/coupon_sets/:coupon_set_id/delete",
     stripePath: "/coupon_sets/{coupon-set-id}/delete",
     resource: "coupon_sets",
     operation: "delete",
@@ -2429,7 +2429,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupon_codes",
+    fastifyPath: "/coupon_codes",
     stripePath: "/coupon_codes",
     resource: "coupon_codes",
     operation: "list",
@@ -2439,7 +2439,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/coupon_codes/:coupon_code_code",
+    fastifyPath: "/coupon_codes/:coupon_code_code",
     stripePath: "/coupon_codes/{coupon-code-code}",
     resource: "coupon_codes",
     operation: "retrieve",
@@ -2450,7 +2450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/coupon_codes/:coupon_code_code/archive",
+    fastifyPath: "/coupon_codes/:coupon_code_code/archive",
     stripePath: "/coupon_codes/{coupon-code-code}/archive",
     resource: "coupon_codes",
     operation: "action",
@@ -2461,7 +2461,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/addresses",
+    fastifyPath: "/addresses",
     stripePath: "/addresses",
     resource: "addresses",
     operation: "list",
@@ -2471,7 +2471,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/addresses",
+    fastifyPath: "/addresses",
     stripePath: "/addresses",
     resource: "addresses",
     operation: "create",
@@ -2481,7 +2481,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/usages/pdf",
+    fastifyPath: "/usages/pdf",
     stripePath: "/usages/pdf",
     resource: "usages",
     operation: "create",
@@ -2491,7 +2491,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/usages",
+    fastifyPath: "/subscriptions/:subscription_id/usages",
     stripePath: "/subscriptions/{subscription-id}/usages",
     resource: "subscriptions",
     operation: "list",
@@ -2502,7 +2502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/usages",
+    fastifyPath: "/subscriptions/:subscription_id/usages",
     stripePath: "/subscriptions/{subscription-id}/usages",
     resource: "subscriptions",
     operation: "create",
@@ -2513,7 +2513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/delete_usage",
+    fastifyPath: "/subscriptions/:subscription_id/delete_usage",
     stripePath: "/subscriptions/{subscription-id}/delete_usage",
     resource: "subscriptions",
     operation: "action",
@@ -2524,7 +2524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/usages",
+    fastifyPath: "/usages",
     stripePath: "/usages",
     resource: "usages",
     operation: "list",
@@ -2534,7 +2534,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/events",
+    fastifyPath: "/events",
     stripePath: "/events",
     resource: "events",
     operation: "list",
@@ -2544,7 +2544,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/events/:event_id",
+    fastifyPath: "/events/:event_id",
     stripePath: "/events/{event-id}",
     resource: "events",
     operation: "retrieve",
@@ -2555,7 +2555,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/comments/:comment_id/delete",
+    fastifyPath: "/comments/:comment_id/delete",
     stripePath: "/comments/{comment-id}/delete",
     resource: "comments",
     operation: "delete",
@@ -2566,7 +2566,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/comments/:comment_id",
+    fastifyPath: "/comments/:comment_id",
     stripePath: "/comments/{comment-id}",
     resource: "comments",
     operation: "retrieve",
@@ -2577,7 +2577,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/comments",
+    fastifyPath: "/comments",
     stripePath: "/comments",
     resource: "comments",
     operation: "list",
@@ -2587,7 +2587,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/comments",
+    fastifyPath: "/comments",
     stripePath: "/comments",
     resource: "comments",
     operation: "create",
@@ -2597,7 +2597,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/portal_sessions",
+    fastifyPath: "/portal_sessions",
     stripePath: "/portal_sessions",
     resource: "portal_sessions",
     operation: "create",
@@ -2607,7 +2607,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/portal_sessions/:portal_session_id/activate",
+    fastifyPath: "/portal_sessions/:portal_session_id/activate",
     stripePath: "/portal_sessions/{portal-session-id}/activate",
     resource: "portal_sessions",
     operation: "action",
@@ -2618,7 +2618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/portal_sessions/:portal_session_id/logout",
+    fastifyPath: "/portal_sessions/:portal_session_id/logout",
     stripePath: "/portal_sessions/{portal-session-id}/logout",
     resource: "portal_sessions",
     operation: "action",
@@ -2629,7 +2629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/portal_sessions/:portal_session_id",
+    fastifyPath: "/portal_sessions/:portal_session_id",
     stripePath: "/portal_sessions/{portal-session-id}",
     resource: "portal_sessions",
     operation: "retrieve",
@@ -2640,7 +2640,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/site_migration_details",
+    fastifyPath: "/site_migration_details",
     stripePath: "/site_migration_details",
     resource: "site_migration_details",
     operation: "list",
@@ -2649,7 +2649,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/resource_migrations/retrieve_latest",
+    fastifyPath: "/resource_migrations/retrieve_latest",
     stripePath: "/resource_migrations/retrieve_latest",
     resource: "resource_migrations",
     operation: "list",
@@ -2658,7 +2658,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/time_machines/:time_machine_name",
+    fastifyPath: "/time_machines/:time_machine_name",
     stripePath: "/time_machines/{time-machine-name}",
     resource: "time_machines",
     operation: "retrieve",
@@ -2668,7 +2668,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/time_machines/:time_machine_name/travel_forward",
+    fastifyPath: "/time_machines/:time_machine_name/travel_forward",
     stripePath: "/time_machines/{time-machine-name}/travel_forward",
     resource: "time_machines",
     operation: "action",
@@ -2678,7 +2678,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/time_machines/:time_machine_name/start_afresh",
+    fastifyPath: "/time_machines/:time_machine_name/start_afresh",
     stripePath: "/time_machines/{time-machine-name}/start_afresh",
     resource: "time_machines",
     operation: "action",
@@ -2688,7 +2688,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/customers",
+    fastifyPath: "/exports/customers",
     stripePath: "/exports/customers",
     resource: "exports",
     operation: "create",
@@ -2697,7 +2697,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/attached_items",
+    fastifyPath: "/exports/attached_items",
     stripePath: "/exports/attached_items",
     resource: "exports",
     operation: "create",
@@ -2706,7 +2706,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/transactions",
+    fastifyPath: "/exports/transactions",
     stripePath: "/exports/transactions",
     resource: "exports",
     operation: "create",
@@ -2715,7 +2715,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/differential_prices",
+    fastifyPath: "/exports/differential_prices",
     stripePath: "/exports/differential_prices",
     resource: "exports",
     operation: "create",
@@ -2724,7 +2724,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/item_families",
+    fastifyPath: "/exports/item_families",
     stripePath: "/exports/item_families",
     resource: "exports",
     operation: "create",
@@ -2733,7 +2733,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/invoices",
+    fastifyPath: "/exports/invoices",
     stripePath: "/exports/invoices",
     resource: "exports",
     operation: "create",
@@ -2742,7 +2742,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/exports/:export_id",
+    fastifyPath: "/exports/:export_id",
     stripePath: "/exports/{export-id}",
     resource: "exports",
     operation: "retrieve",
@@ -2752,7 +2752,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/price_variants",
+    fastifyPath: "/exports/price_variants",
     stripePath: "/exports/price_variants",
     resource: "exports",
     operation: "create",
@@ -2761,7 +2761,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/items",
+    fastifyPath: "/exports/items",
     stripePath: "/exports/items",
     resource: "exports",
     operation: "create",
@@ -2770,7 +2770,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/deferred_revenue",
+    fastifyPath: "/exports/deferred_revenue",
     stripePath: "/exports/deferred_revenue",
     resource: "exports",
     operation: "create",
@@ -2779,7 +2779,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/revenue_recognition",
+    fastifyPath: "/exports/revenue_recognition",
     stripePath: "/exports/revenue_recognition",
     resource: "exports",
     operation: "create",
@@ -2788,7 +2788,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/credit_notes",
+    fastifyPath: "/exports/credit_notes",
     stripePath: "/exports/credit_notes",
     resource: "exports",
     operation: "create",
@@ -2797,7 +2797,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/coupons",
+    fastifyPath: "/exports/coupons",
     stripePath: "/exports/coupons",
     resource: "exports",
     operation: "create",
@@ -2806,7 +2806,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/orders",
+    fastifyPath: "/exports/orders",
     stripePath: "/exports/orders",
     resource: "exports",
     operation: "create",
@@ -2815,7 +2815,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/item_prices",
+    fastifyPath: "/exports/item_prices",
     stripePath: "/exports/item_prices",
     resource: "exports",
     operation: "create",
@@ -2824,7 +2824,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/exports/subscriptions",
+    fastifyPath: "/exports/subscriptions",
     stripePath: "/exports/subscriptions",
     resource: "exports",
     operation: "create",
@@ -2833,7 +2833,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/full_exports/status",
+    fastifyPath: "/full_exports/status",
     stripePath: "/full_exports/status",
     resource: "full_exports",
     operation: "list",
@@ -2842,7 +2842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/payment_intents/:payment_intent_id",
+    fastifyPath: "/payment_intents/:payment_intent_id",
     stripePath: "/payment_intents/{payment-intent-id}",
     resource: "payment_intents",
     operation: "retrieve",
@@ -2853,7 +2853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_intents/:payment_intent_id",
+    fastifyPath: "/payment_intents/:payment_intent_id",
     stripePath: "/payment_intents/{payment-intent-id}",
     resource: "payment_intents",
     operation: "update",
@@ -2864,7 +2864,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_intents",
+    fastifyPath: "/payment_intents",
     stripePath: "/payment_intents",
     resource: "payment_intents",
     operation: "create",
@@ -2874,7 +2874,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/custom_field_configs/retrieve",
+    fastifyPath: "/custom_field_configs/retrieve",
     stripePath: "/custom_field_configs/retrieve",
     resource: "custom_field_configs",
     operation: "list",
@@ -2883,7 +2883,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/custom_field_configs",
+    fastifyPath: "/custom_field_configs",
     stripePath: "/custom_field_configs",
     resource: "custom_field_configs",
     operation: "list",
@@ -2892,7 +2892,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_families/:item_family_id/delete",
+    fastifyPath: "/item_families/:item_family_id/delete",
     stripePath: "/item_families/{item-family-id}/delete",
     resource: "item_families",
     operation: "delete",
@@ -2903,7 +2903,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_families",
+    fastifyPath: "/item_families",
     stripePath: "/item_families",
     resource: "item_families",
     operation: "list",
@@ -2913,7 +2913,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_families",
+    fastifyPath: "/item_families",
     stripePath: "/item_families",
     resource: "item_families",
     operation: "create",
@@ -2923,7 +2923,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_families/:item_family_id",
+    fastifyPath: "/item_families/:item_family_id",
     stripePath: "/item_families/{item-family-id}",
     resource: "item_families",
     operation: "retrieve",
@@ -2934,7 +2934,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_families/:item_family_id",
+    fastifyPath: "/item_families/:item_family_id",
     stripePath: "/item_families/{item-family-id}",
     resource: "item_families",
     operation: "update",
@@ -2945,7 +2945,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/products/:product_id",
+    fastifyPath: "/products/:product_id",
     stripePath: "/products/{product-id}",
     resource: "products",
     operation: "retrieve",
@@ -2956,7 +2956,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/products/:product_id",
+    fastifyPath: "/products/:product_id",
     stripePath: "/products/{product-id}",
     resource: "products",
     operation: "update",
@@ -2967,7 +2967,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/products/:product_id/delete",
+    fastifyPath: "/products/:product_id/delete",
     stripePath: "/products/{product-id}/delete",
     resource: "products",
     operation: "delete",
@@ -2978,7 +2978,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/products/:product_id/update_options",
+    fastifyPath: "/products/:product_id/update_options",
     stripePath: "/products/{product-id}/update_options",
     resource: "products",
     operation: "action",
@@ -2989,7 +2989,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/products",
+    fastifyPath: "/products",
     stripePath: "/products",
     resource: "products",
     operation: "list",
@@ -2999,7 +2999,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/products",
+    fastifyPath: "/products",
     stripePath: "/products",
     resource: "products",
     operation: "create",
@@ -3009,7 +3009,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/products/:product_id/variants",
+    fastifyPath: "/products/:product_id/variants",
     stripePath: "/products/{product-id}/variants",
     resource: "products",
     operation: "list",
@@ -3020,7 +3020,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/products/:product_id/variants",
+    fastifyPath: "/products/:product_id/variants",
     stripePath: "/products/{product-id}/variants",
     resource: "products",
     operation: "create",
@@ -3031,7 +3031,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/variants/:product_variant_id",
+    fastifyPath: "/variants/:product_variant_id",
     stripePath: "/variants/{product-variant-id}",
     resource: "variants",
     operation: "retrieve",
@@ -3042,7 +3042,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/variants/:product_variant_id",
+    fastifyPath: "/variants/:product_variant_id",
     stripePath: "/variants/{product-variant-id}",
     resource: "variants",
     operation: "update",
@@ -3053,7 +3053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/variants/:product_variant_id/delete",
+    fastifyPath: "/variants/:product_variant_id/delete",
     stripePath: "/variants/{product-variant-id}/delete",
     resource: "variants",
     operation: "delete",
@@ -3064,7 +3064,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/items",
+    fastifyPath: "/items",
     stripePath: "/items",
     resource: "items",
     operation: "list",
@@ -3074,7 +3074,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/items",
+    fastifyPath: "/items",
     stripePath: "/items",
     resource: "items",
     operation: "create",
@@ -3084,7 +3084,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/items/:item_id/delete",
+    fastifyPath: "/items/:item_id/delete",
     stripePath: "/items/{item-id}/delete",
     resource: "items",
     operation: "delete",
@@ -3095,7 +3095,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/items/:item_id",
+    fastifyPath: "/items/:item_id",
     stripePath: "/items/{item-id}",
     resource: "items",
     operation: "retrieve",
@@ -3106,7 +3106,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/items/:item_id",
+    fastifyPath: "/items/:item_id",
     stripePath: "/items/{item-id}",
     resource: "items",
     operation: "update",
@@ -3117,7 +3117,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/price_variants/:price_variant_id/delete",
+    fastifyPath: "/price_variants/:price_variant_id/delete",
     stripePath: "/price_variants/{price-variant-id}/delete",
     resource: "price_variants",
     operation: "delete",
@@ -3128,7 +3128,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/price_variants",
+    fastifyPath: "/price_variants",
     stripePath: "/price_variants",
     resource: "price_variants",
     operation: "list",
@@ -3138,7 +3138,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/price_variants",
+    fastifyPath: "/price_variants",
     stripePath: "/price_variants",
     resource: "price_variants",
     operation: "create",
@@ -3148,7 +3148,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/price_variants/:price_variant_id",
+    fastifyPath: "/price_variants/:price_variant_id",
     stripePath: "/price_variants/{price-variant-id}",
     resource: "price_variants",
     operation: "retrieve",
@@ -3159,7 +3159,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/price_variants/:price_variant_id",
+    fastifyPath: "/price_variants/:price_variant_id",
     stripePath: "/price_variants/{price-variant-id}",
     resource: "price_variants",
     operation: "update",
@@ -3170,7 +3170,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_prices/:item_price_id",
+    fastifyPath: "/item_prices/:item_price_id",
     stripePath: "/item_prices/{item-price-id}",
     resource: "item_prices",
     operation: "retrieve",
@@ -3181,7 +3181,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_prices/:item_price_id",
+    fastifyPath: "/item_prices/:item_price_id",
     stripePath: "/item_prices/{item-price-id}",
     resource: "item_prices",
     operation: "update",
@@ -3192,7 +3192,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_prices/:item_price_id/delete",
+    fastifyPath: "/item_prices/:item_price_id/delete",
     stripePath: "/item_prices/{item-price-id}/delete",
     resource: "item_prices",
     operation: "delete",
@@ -3203,7 +3203,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_prices/:item_price_id/applicable_item_prices",
+    fastifyPath: "/item_prices/:item_price_id/applicable_item_prices",
     stripePath: "/item_prices/{item-price-id}/applicable_item_prices",
     resource: "item_prices",
     operation: "list",
@@ -3214,7 +3214,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_prices/:item_price_id/applicable_items",
+    fastifyPath: "/item_prices/:item_price_id/applicable_items",
     stripePath: "/item_prices/{item-price-id}/applicable_items",
     resource: "item_prices",
     operation: "list",
@@ -3225,7 +3225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/item_prices",
+    fastifyPath: "/item_prices",
     stripePath: "/item_prices",
     resource: "item_prices",
     operation: "list",
@@ -3235,7 +3235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_prices",
+    fastifyPath: "/item_prices",
     stripePath: "/item_prices",
     resource: "item_prices",
     operation: "create",
@@ -3245,7 +3245,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/attached_items/:attached_item_id",
+    fastifyPath: "/attached_items/:attached_item_id",
     stripePath: "/attached_items/{attached-item-id}",
     resource: "attached_items",
     operation: "retrieve",
@@ -3256,7 +3256,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/attached_items/:attached_item_id",
+    fastifyPath: "/attached_items/:attached_item_id",
     stripePath: "/attached_items/{attached-item-id}",
     resource: "attached_items",
     operation: "update",
@@ -3267,7 +3267,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/items/:item_id/attached_items",
+    fastifyPath: "/items/:item_id/attached_items",
     stripePath: "/items/{item-id}/attached_items",
     resource: "items",
     operation: "list",
@@ -3278,7 +3278,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/items/:item_id/attached_items",
+    fastifyPath: "/items/:item_id/attached_items",
     stripePath: "/items/{item-id}/attached_items",
     resource: "items",
     operation: "create",
@@ -3289,7 +3289,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/attached_items/:attached_item_id/delete",
+    fastifyPath: "/attached_items/:attached_item_id/delete",
     stripePath: "/attached_items/{attached-item-id}/delete",
     resource: "attached_items",
     operation: "delete",
@@ -3300,7 +3300,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/differential_prices/:differential_price_id/delete",
+    fastifyPath: "/differential_prices/:differential_price_id/delete",
     stripePath: "/differential_prices/{differential-price-id}/delete",
     resource: "differential_prices",
     operation: "delete",
@@ -3311,7 +3311,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/item_prices/:item_price_id/differential_prices",
+    fastifyPath: "/item_prices/:item_price_id/differential_prices",
     stripePath: "/item_prices/{item-price-id}/differential_prices",
     resource: "item_prices",
     operation: "create",
@@ -3322,7 +3322,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/differential_prices",
+    fastifyPath: "/differential_prices",
     stripePath: "/differential_prices",
     resource: "differential_prices",
     operation: "list",
@@ -3332,7 +3332,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/differential_prices/:differential_price_id",
+    fastifyPath: "/differential_prices/:differential_price_id",
     stripePath: "/differential_prices/{differential-price-id}",
     resource: "differential_prices",
     operation: "retrieve",
@@ -3343,7 +3343,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/differential_prices/:differential_price_id",
+    fastifyPath: "/differential_prices/:differential_price_id",
     stripePath: "/differential_prices/{differential-price-id}",
     resource: "differential_prices",
     operation: "update",
@@ -3354,7 +3354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/configurations",
+    fastifyPath: "/configurations",
     stripePath: "/configurations",
     resource: "configurations",
     operation: "list",
@@ -3363,7 +3363,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/features",
+    fastifyPath: "/features",
     stripePath: "/features",
     resource: "features",
     operation: "list",
@@ -3373,7 +3373,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features",
+    fastifyPath: "/features",
     stripePath: "/features",
     resource: "features",
     operation: "create",
@@ -3383,7 +3383,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id/delete",
+    fastifyPath: "/features/:feature_id/delete",
     stripePath: "/features/{feature-id}/delete",
     resource: "features",
     operation: "delete",
@@ -3394,7 +3394,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/features/:feature_id",
+    fastifyPath: "/features/:feature_id",
     stripePath: "/features/{feature-id}",
     resource: "features",
     operation: "retrieve",
@@ -3405,7 +3405,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id",
+    fastifyPath: "/features/:feature_id",
     stripePath: "/features/{feature-id}",
     resource: "features",
     operation: "update",
@@ -3416,7 +3416,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id/archive_command",
+    fastifyPath: "/features/:feature_id/archive_command",
     stripePath: "/features/{feature-id}/archive_command",
     resource: "features",
     operation: "action",
@@ -3427,7 +3427,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id/activate_command",
+    fastifyPath: "/features/:feature_id/activate_command",
     stripePath: "/features/{feature-id}/activate_command",
     resource: "features",
     operation: "action",
@@ -3438,7 +3438,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id/reactivate_command",
+    fastifyPath: "/features/:feature_id/reactivate_command",
     stripePath: "/features/{feature-id}/reactivate_command",
     resource: "features",
     operation: "action",
@@ -3449,7 +3449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/subscription_entitlements/set_availability",
+    fastifyPath: "/subscriptions/:subscription_id/subscription_entitlements/set_availability",
     stripePath: "/subscriptions/{subscription-id}/subscription_entitlements/set_availability",
     resource: "subscriptions",
     operation: "action",
@@ -3460,7 +3460,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/subscription_entitlements",
+    fastifyPath: "/subscriptions/:subscription_id/subscription_entitlements",
     stripePath: "/subscriptions/{subscription-id}/subscription_entitlements",
     resource: "subscriptions",
     operation: "list",
@@ -3471,7 +3471,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/customer_entitlements",
+    fastifyPath: "/customers/:customer_id/customer_entitlements",
     stripePath: "/customers/{customer-id}/customer_entitlements",
     resource: "customers",
     operation: "list",
@@ -3482,7 +3482,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/features/:feature_id/item_entitlements",
+    fastifyPath: "/features/:feature_id/item_entitlements",
     stripePath: "/features/{feature-id}/item_entitlements",
     resource: "features",
     operation: "list",
@@ -3493,7 +3493,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/features/:feature_id/item_entitlements",
+    fastifyPath: "/features/:feature_id/item_entitlements",
     stripePath: "/features/{feature-id}/item_entitlements",
     resource: "features",
     operation: "action",
@@ -3504,7 +3504,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/items/:item_id/item_entitlements",
+    fastifyPath: "/items/:item_id/item_entitlements",
     stripePath: "/items/{item-id}/item_entitlements",
     resource: "items",
     operation: "list",
@@ -3515,7 +3515,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/items/:item_id/item_entitlements",
+    fastifyPath: "/items/:item_id/item_entitlements",
     stripePath: "/items/{item-id}/item_entitlements",
     resource: "items",
     operation: "action",
@@ -3526,7 +3526,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/entitlements",
+    fastifyPath: "/entitlements",
     stripePath: "/entitlements",
     resource: "entitlements",
     operation: "list",
@@ -3535,7 +3535,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/entitlements",
+    fastifyPath: "/entitlements",
     stripePath: "/entitlements",
     resource: "entitlements",
     operation: "create",
@@ -3544,7 +3544,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/in_app_subscriptions/:in_app_subscription_app_id/retrieve",
+    fastifyPath: "/in_app_subscriptions/:in_app_subscription_app_id/retrieve",
     stripePath: "/in_app_subscriptions/{in-app-subscription-app-id}/retrieve",
     resource: "in_app_subscriptions",
     operation: "action",
@@ -3554,7 +3554,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/in_app_subscriptions/:in_app_subscription_app_id/import_receipt",
+    fastifyPath: "/in_app_subscriptions/:in_app_subscription_app_id/import_receipt",
     stripePath: "/in_app_subscriptions/{in-app-subscription-app-id}/import_receipt",
     resource: "in_app_subscriptions",
     operation: "action",
@@ -3564,7 +3564,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/in_app_subscriptions/:in_app_subscription_app_id/import_subscription",
+    fastifyPath: "/in_app_subscriptions/:in_app_subscription_app_id/import_subscription",
     stripePath: "/in_app_subscriptions/{in-app-subscription-app-id}/import_subscription",
     resource: "in_app_subscriptions",
     operation: "action",
@@ -3574,7 +3574,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/in_app_subscriptions/:in_app_subscription_app_id/process_purchase_command",
+    fastifyPath: "/in_app_subscriptions/:in_app_subscription_app_id/process_purchase_command",
     stripePath: "/in_app_subscriptions/{in-app-subscription-app-id}/process_purchase_command",
     resource: "in_app_subscriptions",
     operation: "action",
@@ -3584,7 +3584,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/non_subscriptions/:non_subscription_app_id/one_time_purchase",
+    fastifyPath: "/non_subscriptions/:non_subscription_app_id/one_time_purchase",
     stripePath: "/non_subscriptions/{non-subscription-app-id}/one_time_purchase",
     resource: "non_subscriptions",
     operation: "action",
@@ -3594,7 +3594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/entitlement_overrides",
+    fastifyPath: "/subscriptions/:subscription_id/entitlement_overrides",
     stripePath: "/subscriptions/{subscription-id}/entitlement_overrides",
     resource: "subscriptions",
     operation: "list",
@@ -3605,7 +3605,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/entitlement_overrides",
+    fastifyPath: "/subscriptions/:subscription_id/entitlement_overrides",
     stripePath: "/subscriptions/{subscription-id}/entitlement_overrides",
     resource: "subscriptions",
     operation: "action",
@@ -3616,7 +3616,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/business_entities/transfers",
+    fastifyPath: "/business_entities/transfers",
     stripePath: "/business_entities/transfers",
     resource: "business_entities",
     operation: "list",
@@ -3625,7 +3625,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/business_entities/transfers",
+    fastifyPath: "/business_entities/transfers",
     stripePath: "/business_entities/transfers",
     resource: "business_entities",
     operation: "create",
@@ -3634,7 +3634,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/purchases",
+    fastifyPath: "/purchases",
     stripePath: "/purchases",
     resource: "purchases",
     operation: "create",
@@ -3643,7 +3643,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/purchases/estimate",
+    fastifyPath: "/purchases/estimate",
     stripePath: "/purchases/estimate",
     resource: "purchases",
     operation: "create",
@@ -3652,7 +3652,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/customers/:customer_id/payment_vouchers",
+    fastifyPath: "/customers/:customer_id/payment_vouchers",
     stripePath: "/customers/{customer-id}/payment_vouchers",
     resource: "customers",
     operation: "list",
@@ -3663,7 +3663,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/invoices/:invoice_id/payment_vouchers",
+    fastifyPath: "/invoices/:invoice_id/payment_vouchers",
     stripePath: "/invoices/{invoice-id}/payment_vouchers",
     resource: "invoices",
     operation: "list",
@@ -3674,7 +3674,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/payment_vouchers/:payment_voucher_id",
+    fastifyPath: "/payment_vouchers/:payment_voucher_id",
     stripePath: "/payment_vouchers/{payment-voucher-id}",
     resource: "payment_vouchers",
     operation: "retrieve",
@@ -3684,7 +3684,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_vouchers",
+    fastifyPath: "/payment_vouchers",
     stripePath: "/payment_vouchers",
     resource: "payment_vouchers",
     operation: "create",
@@ -3693,7 +3693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/csv_tax_rules",
+    fastifyPath: "/csv_tax_rules",
     stripePath: "/csv_tax_rules",
     resource: "csv_tax_rules",
     operation: "create",
@@ -3702,7 +3702,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/currencies/:site_currency_id/add_schedule",
+    fastifyPath: "/currencies/:site_currency_id/add_schedule",
     stripePath: "/currencies/{site-currency-id}/add_schedule",
     resource: "currencies",
     operation: "action",
@@ -3712,7 +3712,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/currencies",
+    fastifyPath: "/currencies",
     stripePath: "/currencies",
     resource: "currencies",
     operation: "create",
@@ -3721,7 +3721,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/currencies/:site_currency_id",
+    fastifyPath: "/currencies/:site_currency_id",
     stripePath: "/currencies/{site-currency-id}",
     resource: "currencies",
     operation: "retrieve",
@@ -3731,7 +3731,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/currencies/:site_currency_id",
+    fastifyPath: "/currencies/:site_currency_id",
     stripePath: "/currencies/{site-currency-id}",
     resource: "currencies",
     operation: "update",
@@ -3741,7 +3741,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/currencies/:site_currency_id/remove_schedule",
+    fastifyPath: "/currencies/:site_currency_id/remove_schedule",
     stripePath: "/currencies/{site-currency-id}/remove_schedule",
     resource: "currencies",
     operation: "action",
@@ -3751,7 +3751,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/currencies/list",
+    fastifyPath: "/currencies/list",
     stripePath: "/currencies/list",
     resource: "currencies",
     operation: "list",
@@ -3760,7 +3760,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/ramps/:ramp_id",
+    fastifyPath: "/ramps/:ramp_id",
     stripePath: "/ramps/{ramp-id}",
     resource: "ramps",
     operation: "retrieve",
@@ -3771,7 +3771,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/subscriptions/:subscription_id/create_ramp",
+    fastifyPath: "/subscriptions/:subscription_id/create_ramp",
     stripePath: "/subscriptions/{subscription-id}/create_ramp",
     resource: "subscriptions",
     operation: "create",
@@ -3782,7 +3782,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/ramps",
+    fastifyPath: "/ramps",
     stripePath: "/ramps",
     resource: "ramps",
     operation: "list",
@@ -3792,7 +3792,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/ramps/:ramp_id/update",
+    fastifyPath: "/ramps/:ramp_id/update",
     stripePath: "/ramps/{ramp-id}/update",
     resource: "ramps",
     operation: "action",
@@ -3803,7 +3803,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/ramps/:ramp_id/delete",
+    fastifyPath: "/ramps/:ramp_id/delete",
     stripePath: "/ramps/{ramp-id}/delete",
     resource: "ramps",
     operation: "delete",
@@ -3814,7 +3814,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/payment_schedule_schemes/:payment_schedule_scheme_id",
+    fastifyPath: "/payment_schedule_schemes/:payment_schedule_scheme_id",
     stripePath: "/payment_schedule_schemes/{payment-schedule-scheme-id}",
     resource: "payment_schedule_schemes",
     operation: "retrieve",
@@ -3824,7 +3824,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_schedule_schemes",
+    fastifyPath: "/payment_schedule_schemes",
     stripePath: "/payment_schedule_schemes",
     resource: "payment_schedule_schemes",
     operation: "create",
@@ -3833,7 +3833,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/payment_schedule_schemes/:payment_schedule_scheme_id/delete",
+    fastifyPath: "/payment_schedule_schemes/:payment_schedule_scheme_id/delete",
     stripePath: "/payment_schedule_schemes/{payment-schedule-scheme-id}/delete",
     resource: "payment_schedule_schemes",
     operation: "delete",
@@ -3843,7 +3843,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migrations/:pc2_migration_id/contact_support",
+    fastifyPath: "/pc2_migrations/:pc2_migration_id/contact_support",
     stripePath: "/pc2_migrations/{pc2-migration-id}/contact_support",
     resource: "pc2_migrations",
     operation: "action",
@@ -3853,7 +3853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migrations/:pc2_migration_id",
+    fastifyPath: "/pc2_migrations/:pc2_migration_id",
     stripePath: "/pc2_migrations/{pc2-migration-id}",
     resource: "pc2_migrations",
     operation: "retrieve",
@@ -3863,7 +3863,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migrations",
+    fastifyPath: "/pc2_migrations",
     stripePath: "/pc2_migrations",
     resource: "pc2_migrations",
     operation: "create",
@@ -3872,7 +3872,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migrations/:pc2_migration_id/initiate",
+    fastifyPath: "/pc2_migrations/:pc2_migration_id/initiate",
     stripePath: "/pc2_migrations/{pc2-migration-id}/initiate",
     resource: "pc2_migrations",
     operation: "action",
@@ -3882,7 +3882,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_item_families/:pc2_migration_item_family_id/delete",
+    fastifyPath: "/pc2_migration_item_families/:pc2_migration_item_family_id/delete",
     stripePath: "/pc2_migration_item_families/{pc2-migration-item-family-id}/delete",
     resource: "pc2_migration_item_families",
     operation: "delete",
@@ -3892,7 +3892,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_item_families/:pc2_migration_item_family_id",
+    fastifyPath: "/pc2_migration_item_families/:pc2_migration_item_family_id",
     stripePath: "/pc2_migration_item_families/{pc2-migration-item-family-id}",
     resource: "pc2_migration_item_families",
     operation: "retrieve",
@@ -3902,7 +3902,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_item_families/:pc2_migration_item_family_id",
+    fastifyPath: "/pc2_migration_item_families/:pc2_migration_item_family_id",
     stripePath: "/pc2_migration_item_families/{pc2-migration-item-family-id}",
     resource: "pc2_migration_item_families",
     operation: "update",
@@ -3912,7 +3912,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_item_families",
+    fastifyPath: "/pc2_migration_item_families",
     stripePath: "/pc2_migration_item_families",
     resource: "pc2_migration_item_families",
     operation: "list",
@@ -3921,7 +3921,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_item_families",
+    fastifyPath: "/pc2_migration_item_families",
     stripePath: "/pc2_migration_item_families",
     resource: "pc2_migration_item_families",
     operation: "create",
@@ -3930,7 +3930,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_items/:pc2_migration_item_id",
+    fastifyPath: "/pc2_migration_items/:pc2_migration_item_id",
     stripePath: "/pc2_migration_items/{pc2-migration-item-id}",
     resource: "pc2_migration_items",
     operation: "retrieve",
@@ -3940,7 +3940,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_items/:pc2_migration_item_id",
+    fastifyPath: "/pc2_migration_items/:pc2_migration_item_id",
     stripePath: "/pc2_migration_items/{pc2-migration-item-id}",
     resource: "pc2_migration_items",
     operation: "update",
@@ -3950,7 +3950,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_items/:pc2_migration_item_id/delete",
+    fastifyPath: "/pc2_migration_items/:pc2_migration_item_id/delete",
     stripePath: "/pc2_migration_items/{pc2-migration-item-id}/delete",
     resource: "pc2_migration_items",
     operation: "delete",
@@ -3960,7 +3960,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_items",
+    fastifyPath: "/pc2_migration_items",
     stripePath: "/pc2_migration_items",
     resource: "pc2_migration_items",
     operation: "list",
@@ -3969,7 +3969,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_items",
+    fastifyPath: "/pc2_migration_items",
     stripePath: "/pc2_migration_items",
     resource: "pc2_migration_items",
     operation: "create",
@@ -3978,7 +3978,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_items/applicable_items",
+    fastifyPath: "/pc2_migration_items/applicable_items",
     stripePath: "/pc2_migration_items/applicable_items",
     resource: "pc2_migration_items",
     operation: "list",
@@ -3987,7 +3987,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_item_prices",
+    fastifyPath: "/pc2_migration_item_prices",
     stripePath: "/pc2_migration_item_prices",
     resource: "pc2_migration_item_prices",
     operation: "list",
@@ -3996,7 +3996,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_item_prices/:pc2_migration_item_price_id/delete",
+    fastifyPath: "/pc2_migration_item_prices/:pc2_migration_item_price_id/delete",
     stripePath: "/pc2_migration_item_prices/{pc2-migration-item-price-id}/delete",
     resource: "pc2_migration_item_prices",
     operation: "delete",
@@ -4006,7 +4006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/pc2_migration_item_prices/:pc2_migration_item_price_id",
+    fastifyPath: "/pc2_migration_item_prices/:pc2_migration_item_price_id",
     stripePath: "/pc2_migration_item_prices/{pc2-migration-item-price-id}",
     resource: "pc2_migration_item_prices",
     operation: "retrieve",
@@ -4016,7 +4016,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pc2_migration_item_prices/:pc2_migration_item_price_id",
+    fastifyPath: "/pc2_migration_item_prices/:pc2_migration_item_price_id",
     stripePath: "/pc2_migration_item_prices/{pc2-migration-item-price-id}",
     resource: "pc2_migration_item_prices",
     operation: "update",
@@ -4026,7 +4026,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pricing_page_sessions/create_for_existing_subscription",
+    fastifyPath: "/pricing_page_sessions/create_for_existing_subscription",
     stripePath: "/pricing_page_sessions/create_for_existing_subscription",
     resource: "pricing_page_sessions",
     operation: "create",
@@ -4035,7 +4035,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/pricing_page_sessions/create_for_new_subscription",
+    fastifyPath: "/pricing_page_sessions/create_for_new_subscription",
     stripePath: "/pricing_page_sessions/create_for_new_subscription",
     resource: "pricing_page_sessions",
     operation: "create",
@@ -4044,7 +4044,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/site_pc_meta_records",
+    fastifyPath: "/site_pc_meta_records",
     stripePath: "/site_pc_meta_records",
     resource: "site_pc_meta_records",
     operation: "list",
@@ -4053,7 +4053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/omnichannel_subscriptions/:omnichannel_subscription_id/move",
+    fastifyPath: "/omnichannel_subscriptions/:omnichannel_subscription_id/move",
     stripePath: "/omnichannel_subscriptions/{omnichannel-subscription-id}/move",
     resource: "omnichannel_subscriptions",
     operation: "action",
@@ -4063,7 +4063,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_subscriptions/:omnichannel_subscription_id",
+    fastifyPath: "/omnichannel_subscriptions/:omnichannel_subscription_id",
     stripePath: "/omnichannel_subscriptions/{omnichannel-subscription-id}",
     resource: "omnichannel_subscriptions",
     operation: "retrieve",
@@ -4073,7 +4073,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_subscriptions/:omnichannel_subscription_id/omnichannel_transactions",
+    fastifyPath: "/omnichannel_subscriptions/:omnichannel_subscription_id/omnichannel_transactions",
     stripePath: "/omnichannel_subscriptions/{omnichannel-subscription-id}/omnichannel_transactions",
     resource: "omnichannel_subscriptions",
     operation: "list",
@@ -4083,7 +4083,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_subscriptions",
+    fastifyPath: "/omnichannel_subscriptions",
     stripePath: "/omnichannel_subscriptions",
     resource: "omnichannel_subscriptions",
     operation: "list",
@@ -4092,7 +4092,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_subscription_items/:omnichannel_subscription_item_id/scheduled_changes",
+    fastifyPath: "/omnichannel_subscription_items/:omnichannel_subscription_item_id/scheduled_changes",
     stripePath: "/omnichannel_subscription_items/{omnichannel-subscription-item-id}/scheduled_changes",
     resource: "omnichannel_subscription_items",
     operation: "list",
@@ -4102,7 +4102,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/recorded_purchases/:recorded_purchase_id",
+    fastifyPath: "/recorded_purchases/:recorded_purchase_id",
     stripePath: "/recorded_purchases/{recorded-purchase-id}",
     resource: "recorded_purchases",
     operation: "retrieve",
@@ -4112,7 +4112,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/recorded_purchases",
+    fastifyPath: "/recorded_purchases",
     stripePath: "/recorded_purchases",
     resource: "recorded_purchases",
     operation: "create",
@@ -4121,7 +4121,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_one_time_orders",
+    fastifyPath: "/omnichannel_one_time_orders",
     stripePath: "/omnichannel_one_time_orders",
     resource: "omnichannel_one_time_orders",
     operation: "list",
@@ -4130,7 +4130,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/omnichannel_one_time_orders/:omnichannel_one_time_order_id",
+    fastifyPath: "/omnichannel_one_time_orders/:omnichannel_one_time_order_id",
     stripePath: "/omnichannel_one_time_orders/{omnichannel-one-time-order-id}",
     resource: "omnichannel_one_time_orders",
     operation: "retrieve",
@@ -4140,7 +4140,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/rules/:rule_id",
+    fastifyPath: "/rules/:rule_id",
     stripePath: "/rules/{rule-id}",
     resource: "rules",
     operation: "retrieve",
@@ -4150,7 +4150,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/usage_events",
+    fastifyPath: "/usage_events",
     stripePath: "/usage_events",
     resource: "usage_events",
     operation: "create",
@@ -4159,7 +4159,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/batch/usage_events",
+    fastifyPath: "/batch/usage_events",
     stripePath: "/batch/usage_events",
     resource: "batch",
     operation: "create",
@@ -4168,7 +4168,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/usage_files/:usage_file_id/processing_status",
+    fastifyPath: "/usage_files/:usage_file_id/processing_status",
     stripePath: "/usage_files/{usage-file-id}/processing_status",
     resource: "usage_files",
     operation: "list",
@@ -4178,7 +4178,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/usage_files/upload_url",
+    fastifyPath: "/usage_files/upload_url",
     stripePath: "/usage_files/upload_url",
     resource: "usage_files",
     operation: "create",
@@ -4187,7 +4187,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/personalized_offers",
+    fastifyPath: "/personalized_offers",
     stripePath: "/personalized_offers",
     resource: "personalized_offers",
     operation: "create",
@@ -4196,7 +4196,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/offer_fulfillments",
+    fastifyPath: "/offer_fulfillments",
     stripePath: "/offer_fulfillments",
     resource: "offer_fulfillments",
     operation: "create",
@@ -4205,7 +4205,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/offer_fulfillments/:offer_fulfillment_id",
+    fastifyPath: "/offer_fulfillments/:offer_fulfillment_id",
     stripePath: "/offer_fulfillments/{offer-fulfillment-id}",
     resource: "offer_fulfillments",
     operation: "retrieve",
@@ -4215,7 +4215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/offer_fulfillments/:offer_fulfillment_id",
+    fastifyPath: "/offer_fulfillments/:offer_fulfillment_id",
     stripePath: "/offer_fulfillments/{offer-fulfillment-id}",
     resource: "offer_fulfillments",
     operation: "update",
@@ -4225,7 +4225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/offer_events",
+    fastifyPath: "/offer_events",
     stripePath: "/offer_events",
     resource: "offer_events",
     operation: "create",
@@ -4234,7 +4234,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/webhook_endpoints/:webhook_endpoint_id/delete",
+    fastifyPath: "/webhook_endpoints/:webhook_endpoint_id/delete",
     stripePath: "/webhook_endpoints/{webhook-endpoint-id}/delete",
     resource: "webhook_endpoints",
     operation: "delete",
@@ -4244,7 +4244,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/webhook_endpoints/:webhook_endpoint_id",
+    fastifyPath: "/webhook_endpoints/:webhook_endpoint_id",
     stripePath: "/webhook_endpoints/{webhook-endpoint-id}",
     resource: "webhook_endpoints",
     operation: "retrieve",
@@ -4254,7 +4254,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/webhook_endpoints/:webhook_endpoint_id",
+    fastifyPath: "/webhook_endpoints/:webhook_endpoint_id",
     stripePath: "/webhook_endpoints/{webhook-endpoint-id}",
     resource: "webhook_endpoints",
     operation: "update",
@@ -4264,7 +4264,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/chargebee/webhook_endpoints",
+    fastifyPath: "/webhook_endpoints",
     stripePath: "/webhook_endpoints",
     resource: "webhook_endpoints",
     operation: "list",
@@ -4273,7 +4273,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/chargebee/webhook_endpoints",
+    fastifyPath: "/webhook_endpoints",
     stripePath: "/webhook_endpoints",
     resource: "webhook_endpoints",
     operation: "create",

--- a/packages/adapters/adapter-chargebee/src/mcp.ts
+++ b/packages/adapters/adapter-chargebee/src/mcp.ts
@@ -41,7 +41,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     limit: z.number().optional().describe('Max results (1-100)'),
     offset: z.string().optional().describe('Pagination offset'),
   }, async ({ limit, offset }) => {
-    const data = await call('GET', `/chargebee/customers${qs({ limit, offset })}`);
+    const data = await call('GET', `/customers${qs({ limit, offset })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -52,14 +52,14 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     email: z.string().optional().describe('Email'),
     company: z.string().optional().describe('Company name'),
   }, async (params) => {
-    const data = await call('POST', '/chargebee/customers', params);
+    const data = await call('POST', '/customers', params);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('retrieve_customer', 'Retrieve a Chargebee customer', {
     id: z.string().describe('Customer ID'),
   }, async ({ id }) => {
-    const data = await call('GET', `/chargebee/customers/${id}`);
+    const data = await call('GET', `/customers/${id}`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -70,14 +70,14 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     email: z.string().optional(),
     company: z.string().optional(),
   }, async ({ id, ...params }) => {
-    const data = await call('POST', `/chargebee/customers/${id}`, params);
+    const data = await call('POST', `/customers/${id}`, params);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('delete_customer', 'Delete a Chargebee customer', {
     id: z.string().describe('Customer ID'),
   }, async ({ id }) => {
-    const data = await call('POST', `/chargebee/customers/${id}/delete`);
+    const data = await call('POST', `/customers/${id}/delete`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -86,14 +86,14 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     limit: z.number().optional(),
     offset: z.string().optional(),
   }, async ({ limit, offset }) => {
-    const data = await call('GET', `/chargebee/subscriptions${qs({ limit, offset })}`);
+    const data = await call('GET', `/subscriptions${qs({ limit, offset })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('retrieve_subscription', 'Retrieve a Chargebee subscription', {
     id: z.string().describe('Subscription ID'),
   }, async ({ id }) => {
-    const data = await call('GET', `/chargebee/subscriptions/${id}`);
+    const data = await call('GET', `/subscriptions/${id}`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -101,14 +101,14 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     id: z.string().describe('Subscription ID'),
     end_of_term: z.boolean().optional().describe('Cancel at end of term'),
   }, async ({ id, end_of_term }) => {
-    const data = await call('POST', `/chargebee/subscriptions/${id}/cancel`, { end_of_term: String(end_of_term ?? false) });
+    const data = await call('POST', `/subscriptions/${id}/cancel`, { end_of_term: String(end_of_term ?? false) });
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('reactivate_subscription', 'Reactivate a cancelled subscription', {
     id: z.string().describe('Subscription ID'),
   }, async ({ id }) => {
-    const data = await call('POST', `/chargebee/subscriptions/${id}/reactivate`);
+    const data = await call('POST', `/subscriptions/${id}/reactivate`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -117,21 +117,21 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     limit: z.number().optional(),
     offset: z.string().optional(),
   }, async ({ limit, offset }) => {
-    const data = await call('GET', `/chargebee/invoices${qs({ limit, offset })}`);
+    const data = await call('GET', `/invoices${qs({ limit, offset })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('retrieve_invoice', 'Retrieve a Chargebee invoice', {
     id: z.string().describe('Invoice ID'),
   }, async ({ id }) => {
-    const data = await call('GET', `/chargebee/invoices/${id}`);
+    const data = await call('GET', `/invoices/${id}`);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('void_invoice', 'Void a Chargebee invoice', {
     id: z.string().describe('Invoice ID'),
   }, async ({ id }) => {
-    const data = await call('POST', `/chargebee/invoices/${id}/void`);
+    const data = await call('POST', `/invoices/${id}/void`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -139,7 +139,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     id: z.string().describe('Invoice ID'),
     amount: z.number().optional().describe('Payment amount in cents'),
   }, async ({ id, amount }) => {
-    const data = await call('POST', `/chargebee/invoices/${id}/record_payment`, amount ? { amount: String(amount) } : undefined);
+    const data = await call('POST', `/invoices/${id}/record_payment`, amount ? { amount: String(amount) } : undefined);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -147,7 +147,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
   server.tool('list_items', 'List Chargebee items (products)', {
     limit: z.number().optional(),
   }, async ({ limit }) => {
-    const data = await call('GET', `/chargebee/items${qs({ limit })}`);
+    const data = await call('GET', `/items${qs({ limit })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -156,7 +156,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     name: z.string().describe('Item name'),
     type: z.enum(['plan', 'addon', 'charge']).describe('Item type'),
   }, async (params) => {
-    const data = await call('POST', '/chargebee/items', params);
+    const data = await call('POST', '/items', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -164,7 +164,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
   server.tool('list_item_prices', 'List Chargebee item prices', {
     limit: z.number().optional(),
   }, async ({ limit }) => {
-    const data = await call('GET', `/chargebee/item_prices${qs({ limit })}`);
+    const data = await call('GET', `/item_prices${qs({ limit })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -177,7 +177,7 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
     period: z.number().optional().describe('Billing period'),
     period_unit: z.enum(['day', 'week', 'month', 'year']).optional(),
   }, async (params) => {
-    const data = await call('POST', '/chargebee/item_prices', params);
+    const data = await call('POST', '/item_prices', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -185,13 +185,13 @@ export function registerChargebeeTools(server: McpServer, baseUrl: string): void
   server.tool('list_coupons', 'List Chargebee coupons', {
     limit: z.number().optional(),
   }, async ({ limit }) => {
-    const data = await call('GET', `/chargebee/coupons${qs({ limit })}`);
+    const data = await call('GET', `/coupons${qs({ limit })}`);
     return text(JSON.stringify(data, null, 2));
   });
 
   // ── Mimic-specific tools ──
   server.tool('mimic_list_endpoints', 'List all available Chargebee mock endpoints', {}, async () => {
-    const data = await call('GET', '/chargebee/endpoints');
+    const data = await call('GET', '/endpoints');
     return text(JSON.stringify(data, null, 2));
   });
 }

--- a/packages/adapters/adapter-gocardless/adapter.json
+++ b/packages/adapters/adapter-gocardless/adapter.json
@@ -3,7 +3,7 @@
   "name": "GoCardless API",
   "description": "GoCardless Direct Debit payments, mandates, and subscriptions mock adapter",
   "type": "api-mock",
-  "basePath": "/gocardless",
+  "basePath": "",
   "versions": ["2015-07-06"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://developer.gocardless.com",

--- a/packages/adapters/adapter-gocardless/scripts/gocardless-codegen.ts
+++ b/packages/adapters/adapter-gocardless/scripts/gocardless-codegen.ts
@@ -492,7 +492,7 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const httpMethod = method.toUpperCase() as ExtractedRoute['method'];
       const description = operation.summary ?? operation.description ?? '';
 
-      const fastifyPath = '/gocardless' + specPath.replace(/\{([^}]+)\}/g, ':$1');
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, ':$1');
       const resource = detectGCResource(specPath);
       const op = detectGCOperation(specPath, method);
 

--- a/packages/adapters/adapter-gocardless/src/__tests__/gocardless-adapter.test.ts
+++ b/packages/adapters/adapter-gocardless/src/__tests__/gocardless-adapter.test.ts
@@ -18,7 +18,7 @@ describe('GoCardlessAdapter', () => {
   // ── Metadata ────────────────────────────────────────────────────────────────
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('gocardless');
-    expect(adapter.basePath).toBe('/gocardless');
+    expect(adapter.basePath).toBe('');
   });
 
   it('should return endpoint definitions', () => {
@@ -34,7 +34,7 @@ describe('GoCardlessAdapter', () => {
   it('should create a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'test@example.com', given_name: 'Test', family_name: 'User' }),
     });
@@ -49,7 +49,7 @@ describe('GoCardlessAdapter', () => {
   it('should list customers', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/gocardless/customers',
+      url: '/customers',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -63,7 +63,7 @@ describe('GoCardlessAdapter', () => {
   it('should retrieve a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'retrieve@example.com', given_name: 'Retrieve' }),
     });
@@ -71,7 +71,7 @@ describe('GoCardlessAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/gocardless/customers/${customerId}`,
+      url: `/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -82,7 +82,7 @@ describe('GoCardlessAdapter', () => {
   it('should update a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'update@example.com', given_name: 'Before' }),
     });
@@ -90,7 +90,7 @@ describe('GoCardlessAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'PUT',
-      url: `/gocardless/customers/${customerId}`,
+      url: `/customers/${customerId}`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ given_name: 'After' }),
     });
@@ -101,7 +101,7 @@ describe('GoCardlessAdapter', () => {
   it('should delete a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'delete@example.com' }),
     });
@@ -109,7 +109,7 @@ describe('GoCardlessAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'DELETE',
-      url: `/gocardless/customers/${customerId}`,
+      url: `/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
   });
@@ -117,7 +117,7 @@ describe('GoCardlessAdapter', () => {
   it('should return 404 for non-existent customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/gocardless/customers/CU_nonexistent',
+      url: '/customers/CU_nonexistent',
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -128,7 +128,7 @@ describe('GoCardlessAdapter', () => {
   it('should create and list payments', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/payments',
+      url: '/payments',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         amount: 5000,
@@ -144,7 +144,7 @@ describe('GoCardlessAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/gocardless/payments',
+      url: '/payments',
     });
     expect(listRes.json().payments.length).toBeGreaterThan(0);
   });
@@ -153,7 +153,7 @@ describe('GoCardlessAdapter', () => {
   it('should create a mandate and cancel it', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/mandates',
+      url: '/mandates',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ scheme: 'bacs' }),
     });
@@ -163,7 +163,7 @@ describe('GoCardlessAdapter', () => {
     // Cancel
     const cancelRes = await ts.server.inject({
       method: 'POST',
-      url: `/gocardless/mandates/${mandateId}/actions/cancel`,
+      url: `/mandates/${mandateId}/actions/cancel`,
     });
     expect(cancelRes.statusCode).toBe(200);
     expect(cancelRes.json().mandates.status).toBe('cancelled');
@@ -171,7 +171,7 @@ describe('GoCardlessAdapter', () => {
     // Reinstate
     const reinstateRes = await ts.server.inject({
       method: 'POST',
-      url: `/gocardless/mandates/${mandateId}/actions/reinstate`,
+      url: `/mandates/${mandateId}/actions/reinstate`,
     });
     expect(reinstateRes.statusCode).toBe(200);
     expect(reinstateRes.json().mandates.status).toBe('active');
@@ -181,7 +181,7 @@ describe('GoCardlessAdapter', () => {
   it('should create and cancel a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         amount: 1000,
@@ -196,7 +196,7 @@ describe('GoCardlessAdapter', () => {
     // Cancel
     const cancelRes = await ts.server.inject({
       method: 'POST',
-      url: `/gocardless/subscriptions/${subId}/actions/cancel`,
+      url: `/subscriptions/${subId}/actions/cancel`,
     });
     expect(cancelRes.statusCode).toBe(200);
     expect(cancelRes.json().subscriptions.status).toBe('cancelled');
@@ -205,7 +205,7 @@ describe('GoCardlessAdapter', () => {
   it('should pause and resume a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         amount: 2000,
@@ -219,7 +219,7 @@ describe('GoCardlessAdapter', () => {
     // Pause
     const pauseRes = await ts.server.inject({
       method: 'POST',
-      url: `/gocardless/subscriptions/${subId}/actions/pause`,
+      url: `/subscriptions/${subId}/actions/pause`,
     });
     expect(pauseRes.statusCode).toBe(200);
     expect(pauseRes.json().subscriptions.status).toBe('paused');
@@ -227,7 +227,7 @@ describe('GoCardlessAdapter', () => {
     // Resume
     const resumeRes = await ts.server.inject({
       method: 'POST',
-      url: `/gocardless/subscriptions/${subId}/actions/resume`,
+      url: `/subscriptions/${subId}/actions/resume`,
     });
     expect(resumeRes.statusCode).toBe(200);
     expect(resumeRes.json().subscriptions.status).toBe('active');
@@ -237,7 +237,7 @@ describe('GoCardlessAdapter', () => {
   it('should create a refund', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/gocardless/refunds',
+      url: '/refunds',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         amount: 500,
@@ -265,7 +265,7 @@ describe('GoCardlessAdapter', () => {
     }]]) as any;
 
     const seededTs = await buildTestServer(adapter, seedData);
-    const res = await seededTs.server.inject({ method: 'GET', url: '/gocardless/customers' });
+    const res = await seededTs.server.inject({ method: 'GET', url: '/customers' });
     const customers = res.json().customers;
     expect(customers).toContainEqual(expect.objectContaining({ id: 'CU_seed1' }));
     await seededTs.close();

--- a/packages/adapters/adapter-gocardless/src/generated/meta.ts
+++ b/packages/adapters/adapter-gocardless/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-gocardless generate
 // GoCardless OpenAPI spec version: 2015-07-06
-// Generated at: 2026-03-13T10:59:55.399Z
+// Generated at: 2026-03-20T11:03:13.779Z
 
 export const GC_SPEC_VERSION = "2015-07-06";
-export const GC_SPEC_GENERATED_AT = "2026-03-13T10:59:55.399Z";
+export const GC_SPEC_GENERATED_AT = "2026-03-20T11:03:13.779Z";

--- a/packages/adapters/adapter-gocardless/src/generated/routes.ts
+++ b/packages/adapters/adapter-gocardless/src/generated/routes.ts
@@ -19,7 +19,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/gocardless/balances",
+    fastifyPath: "/balances",
     stripePath: "/balances",
     resource: "balances",
     operation: "list",
@@ -28,7 +28,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/bank_account_details/:customer_bank_account_id",
+    fastifyPath: "/bank_account_details/:customer_bank_account_id",
     stripePath: "/bank_account_details/{customer_bank_account_id}",
     resource: "bank_account_details",
     operation: "retrieve",
@@ -38,7 +38,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/bank_account_holder_verifications",
+    fastifyPath: "/bank_account_holder_verifications",
     stripePath: "/bank_account_holder_verifications",
     resource: "bank_account_holder_verifications",
     operation: "create",
@@ -47,7 +47,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/bank_account_holder_verifications/:bank_account_holder_verification_id",
+    fastifyPath: "/bank_account_holder_verifications/:bank_account_holder_verification_id",
     stripePath: "/bank_account_holder_verifications/{bank_account_holder_verification_id}",
     resource: "bank_account_holder_verifications",
     operation: "retrieve",
@@ -57,7 +57,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/bank_authorisations",
+    fastifyPath: "/bank_authorisations",
     stripePath: "/bank_authorisations",
     resource: "bank_authorisations",
     operation: "create",
@@ -66,7 +66,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/bank_authorisations/:bank_authorisation_id",
+    fastifyPath: "/bank_authorisations/:bank_authorisation_id",
     stripePath: "/bank_authorisations/{bank_authorisation_id}",
     resource: "bank_authorisations",
     operation: "retrieve",
@@ -76,7 +76,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/bank_details_lookups",
+    fastifyPath: "/bank_details_lookups",
     stripePath: "/bank_details_lookups",
     resource: "bank_details_lookups",
     operation: "create",
@@ -85,7 +85,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/billing_requests",
+    fastifyPath: "/billing_requests",
     stripePath: "/billing_requests",
     resource: "billing_requests",
     operation: "list",
@@ -95,7 +95,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests",
+    fastifyPath: "/billing_requests",
     stripePath: "/billing_requests",
     resource: "billing_requests",
     operation: "create",
@@ -105,7 +105,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/collect_customer_details",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/collect_customer_details",
     stripePath: "/billing_requests/{billing_request_id}/actions/collect_customer_details",
     resource: "billing_requests",
     operation: "action",
@@ -116,7 +116,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/collect_bank_account",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/collect_bank_account",
     stripePath: "/billing_requests/{billing_request_id}/actions/collect_bank_account",
     resource: "billing_requests",
     operation: "action",
@@ -127,7 +127,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/confirm_payer_details",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/confirm_payer_details",
     stripePath: "/billing_requests/{billing_request_id}/actions/confirm_payer_details",
     resource: "billing_requests",
     operation: "action",
@@ -138,7 +138,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/fulfil",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/fulfil",
     stripePath: "/billing_requests/{billing_request_id}/actions/fulfil",
     resource: "billing_requests",
     operation: "action",
@@ -149,7 +149,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/cancel",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/cancel",
     stripePath: "/billing_requests/{billing_request_id}/actions/cancel",
     resource: "billing_requests",
     operation: "action",
@@ -160,7 +160,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id",
+    fastifyPath: "/billing_requests/:billing_request_id",
     stripePath: "/billing_requests/{billing_request_id}",
     resource: "billing_requests",
     operation: "retrieve",
@@ -171,7 +171,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/notify",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/notify",
     stripePath: "/billing_requests/{billing_request_id}/actions/notify",
     resource: "billing_requests",
     operation: "action",
@@ -182,7 +182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/fallback",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/fallback",
     stripePath: "/billing_requests/{billing_request_id}/actions/fallback",
     resource: "billing_requests",
     operation: "action",
@@ -193,7 +193,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/choose_currency",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/choose_currency",
     stripePath: "/billing_requests/{billing_request_id}/actions/choose_currency",
     resource: "billing_requests",
     operation: "action",
@@ -204,7 +204,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/actions/select_institution",
+    fastifyPath: "/billing_requests/:billing_request_id/actions/select_institution",
     stripePath: "/billing_requests/{billing_request_id}/actions/select_institution",
     resource: "billing_requests",
     operation: "action",
@@ -215,7 +215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_request_flows",
+    fastifyPath: "/billing_request_flows",
     stripePath: "/billing_request_flows",
     resource: "billing_request_flows",
     operation: "create",
@@ -224,7 +224,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_request_flows/:billing_request_flow_id/actions/initialise",
+    fastifyPath: "/billing_request_flows/:billing_request_flow_id/actions/initialise",
     stripePath: "/billing_request_flows/{billing_request_flow_id}/actions/initialise",
     resource: "billing_request_flows",
     operation: "action",
@@ -234,7 +234,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/billing_request_templates",
+    fastifyPath: "/billing_request_templates",
     stripePath: "/billing_request_templates",
     resource: "billing_request_templates",
     operation: "list",
@@ -243,7 +243,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_request_templates",
+    fastifyPath: "/billing_request_templates",
     stripePath: "/billing_request_templates",
     resource: "billing_request_templates",
     operation: "create",
@@ -252,7 +252,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/billing_request_templates/:billing_request_template_id",
+    fastifyPath: "/billing_request_templates/:billing_request_template_id",
     stripePath: "/billing_request_templates/{billing_request_template_id}",
     resource: "billing_request_templates",
     operation: "retrieve",
@@ -262,7 +262,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/billing_request_templates/:billing_request_template_id",
+    fastifyPath: "/billing_request_templates/:billing_request_template_id",
     stripePath: "/billing_request_templates/{billing_request_template_id}",
     resource: "billing_request_templates",
     operation: "update",
@@ -272,7 +272,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/billing_requests/create_with_actions",
+    fastifyPath: "/billing_requests/create_with_actions",
     stripePath: "/billing_requests/create_with_actions",
     resource: "billing_requests",
     operation: "action",
@@ -282,7 +282,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/blocks",
+    fastifyPath: "/blocks",
     stripePath: "/blocks",
     resource: "blocks",
     operation: "list",
@@ -291,7 +291,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/blocks",
+    fastifyPath: "/blocks",
     stripePath: "/blocks",
     resource: "blocks",
     operation: "create",
@@ -300,7 +300,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/blocks/:block_id",
+    fastifyPath: "/blocks/:block_id",
     stripePath: "/blocks/{block_id}",
     resource: "blocks",
     operation: "retrieve",
@@ -310,7 +310,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/blocks/:block_id/actions/disable",
+    fastifyPath: "/blocks/:block_id/actions/disable",
     stripePath: "/blocks/{block_id}/actions/disable",
     resource: "blocks",
     operation: "action",
@@ -320,7 +320,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/blocks/:block_id/actions/enable",
+    fastifyPath: "/blocks/:block_id/actions/enable",
     stripePath: "/blocks/{block_id}/actions/enable",
     resource: "blocks",
     operation: "action",
@@ -330,7 +330,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/blocks/block_by_ref",
+    fastifyPath: "/blocks/block_by_ref",
     stripePath: "/blocks/block_by_ref",
     resource: "blocks",
     operation: "action",
@@ -339,7 +339,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/creditors",
+    fastifyPath: "/creditors",
     stripePath: "/creditors",
     resource: "creditors",
     operation: "list",
@@ -349,7 +349,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/creditors",
+    fastifyPath: "/creditors",
     stripePath: "/creditors",
     resource: "creditors",
     operation: "create",
@@ -359,7 +359,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/creditors/:creditor_id",
+    fastifyPath: "/creditors/:creditor_id",
     stripePath: "/creditors/{creditor_id}",
     resource: "creditors",
     operation: "retrieve",
@@ -370,7 +370,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/creditors/:creditor_id",
+    fastifyPath: "/creditors/:creditor_id",
     stripePath: "/creditors/{creditor_id}",
     resource: "creditors",
     operation: "update",
@@ -381,7 +381,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/creditor_bank_accounts",
+    fastifyPath: "/creditor_bank_accounts",
     stripePath: "/creditor_bank_accounts",
     resource: "creditor_bank_accounts",
     operation: "list",
@@ -391,7 +391,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/creditor_bank_accounts",
+    fastifyPath: "/creditor_bank_accounts",
     stripePath: "/creditor_bank_accounts",
     resource: "creditor_bank_accounts",
     operation: "create",
@@ -401,7 +401,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/creditor_bank_accounts/:creditor_bank_account_id",
+    fastifyPath: "/creditor_bank_accounts/:creditor_bank_account_id",
     stripePath: "/creditor_bank_accounts/{creditor_bank_account_id}",
     resource: "creditor_bank_accounts",
     operation: "retrieve",
@@ -412,7 +412,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/creditor_bank_accounts/:creditor_bank_account_id/actions/disable",
+    fastifyPath: "/creditor_bank_accounts/:creditor_bank_account_id/actions/disable",
     stripePath: "/creditor_bank_accounts/{creditor_bank_account_id}/actions/disable",
     resource: "creditor_bank_accounts",
     operation: "action",
@@ -423,7 +423,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/currency_exchange_rates",
+    fastifyPath: "/currency_exchange_rates",
     stripePath: "/currency_exchange_rates",
     resource: "currency_exchange_rates",
     operation: "list",
@@ -432,7 +432,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "list",
@@ -442,7 +442,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "create",
@@ -452,7 +452,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer_id}",
     resource: "customers",
     operation: "retrieve",
@@ -463,7 +463,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer_id}",
     resource: "customers",
     operation: "update",
@@ -474,7 +474,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/gocardless/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer_id}",
     resource: "customers",
     operation: "delete",
@@ -485,7 +485,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/customer_bank_accounts",
+    fastifyPath: "/customer_bank_accounts",
     stripePath: "/customer_bank_accounts",
     resource: "customer_bank_accounts",
     operation: "list",
@@ -495,7 +495,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/customer_bank_accounts",
+    fastifyPath: "/customer_bank_accounts",
     stripePath: "/customer_bank_accounts",
     resource: "customer_bank_accounts",
     operation: "create",
@@ -505,7 +505,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/customer_bank_accounts/:customer_bank_account_id",
+    fastifyPath: "/customer_bank_accounts/:customer_bank_account_id",
     stripePath: "/customer_bank_accounts/{customer_bank_account_id}",
     resource: "customer_bank_accounts",
     operation: "retrieve",
@@ -516,7 +516,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/customer_bank_accounts/:customer_bank_account_id",
+    fastifyPath: "/customer_bank_accounts/:customer_bank_account_id",
     stripePath: "/customer_bank_accounts/{customer_bank_account_id}",
     resource: "customer_bank_accounts",
     operation: "update",
@@ -527,7 +527,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/customer_bank_accounts/:customer_bank_account_id/actions/disable",
+    fastifyPath: "/customer_bank_accounts/:customer_bank_account_id/actions/disable",
     stripePath: "/customer_bank_accounts/{customer_bank_account_id}/actions/disable",
     resource: "customer_bank_accounts",
     operation: "action",
@@ -538,7 +538,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/customer_notifications/:customer_notification_id/actions/handle",
+    fastifyPath: "/customer_notifications/:customer_notification_id/actions/handle",
     stripePath: "/customer_notifications/{customer_notification_id}/actions/handle",
     resource: "customer_notifications",
     operation: "action",
@@ -548,7 +548,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/events",
+    fastifyPath: "/events",
     stripePath: "/events",
     resource: "events",
     operation: "list",
@@ -558,7 +558,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/events/:event_id",
+    fastifyPath: "/events/:event_id",
     stripePath: "/events/{event_id}",
     resource: "events",
     operation: "retrieve",
@@ -569,7 +569,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/exports/:export_id",
+    fastifyPath: "/exports/:export_id",
     stripePath: "/exports/{export_id}",
     resource: "exports",
     operation: "retrieve",
@@ -579,7 +579,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/exports",
+    fastifyPath: "/exports",
     stripePath: "/exports",
     resource: "exports",
     operation: "list",
@@ -588,7 +588,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/funds_availability/:mandate_id",
+    fastifyPath: "/funds_availability/:mandate_id",
     stripePath: "/funds_availability/{mandate_id}",
     resource: "funds_availability",
     operation: "retrieve",
@@ -598,7 +598,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/instalment_schedules",
+    fastifyPath: "/instalment_schedules",
     stripePath: "/instalment_schedules",
     resource: "instalment_schedules",
     operation: "list",
@@ -608,7 +608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/instalment_schedules",
+    fastifyPath: "/instalment_schedules",
     stripePath: "/instalment_schedules",
     resource: "instalment_schedules",
     operation: "create",
@@ -618,7 +618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/instalment_schedules/:instalment_schedule_id",
+    fastifyPath: "/instalment_schedules/:instalment_schedule_id",
     stripePath: "/instalment_schedules/{instalment_schedule_id}",
     resource: "instalment_schedules",
     operation: "retrieve",
@@ -629,7 +629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/instalment_schedules/:instalment_schedule_id",
+    fastifyPath: "/instalment_schedules/:instalment_schedule_id",
     stripePath: "/instalment_schedules/{instalment_schedule_id}",
     resource: "instalment_schedules",
     operation: "update",
@@ -640,7 +640,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/instalment_schedules/:instalment_schedule_id/actions/cancel",
+    fastifyPath: "/instalment_schedules/:instalment_schedule_id/actions/cancel",
     stripePath: "/instalment_schedules/{instalment_schedule_id}/actions/cancel",
     resource: "instalment_schedules",
     operation: "action",
@@ -651,7 +651,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/institutions",
+    fastifyPath: "/institutions",
     stripePath: "/institutions",
     resource: "institutions",
     operation: "action",
@@ -660,7 +660,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/billing_requests/:billing_request_id/institutions",
+    fastifyPath: "/billing_requests/:billing_request_id/institutions",
     stripePath: "/billing_requests/{billing_request_id}/institutions",
     resource: "billing_requests",
     operation: "action",
@@ -671,7 +671,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/branding/logos",
+    fastifyPath: "/branding/logos",
     stripePath: "/branding/logos",
     resource: "branding",
     operation: "create",
@@ -680,7 +680,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/mandates",
+    fastifyPath: "/mandates",
     stripePath: "/mandates",
     resource: "mandates",
     operation: "list",
@@ -690,7 +690,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandates",
+    fastifyPath: "/mandates",
     stripePath: "/mandates",
     resource: "mandates",
     operation: "create",
@@ -700,7 +700,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/mandates/:mandate_id",
+    fastifyPath: "/mandates/:mandate_id",
     stripePath: "/mandates/{mandate_id}",
     resource: "mandates",
     operation: "retrieve",
@@ -711,7 +711,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/mandates/:mandate_id",
+    fastifyPath: "/mandates/:mandate_id",
     stripePath: "/mandates/{mandate_id}",
     resource: "mandates",
     operation: "update",
@@ -722,7 +722,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandates/:mandate_id/actions/cancel",
+    fastifyPath: "/mandates/:mandate_id/actions/cancel",
     stripePath: "/mandates/{mandate_id}/actions/cancel",
     resource: "mandates",
     operation: "action",
@@ -733,7 +733,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandates/:mandate_id/actions/reinstate",
+    fastifyPath: "/mandates/:mandate_id/actions/reinstate",
     stripePath: "/mandates/{mandate_id}/actions/reinstate",
     resource: "mandates",
     operation: "action",
@@ -744,7 +744,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandate_imports",
+    fastifyPath: "/mandate_imports",
     stripePath: "/mandate_imports",
     resource: "mandate_imports",
     operation: "create",
@@ -753,7 +753,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/mandate_imports/:mandate_import_id",
+    fastifyPath: "/mandate_imports/:mandate_import_id",
     stripePath: "/mandate_imports/{mandate_import_id}",
     resource: "mandate_imports",
     operation: "retrieve",
@@ -763,7 +763,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandate_imports/:mandate_import_id/actions/submit",
+    fastifyPath: "/mandate_imports/:mandate_import_id/actions/submit",
     stripePath: "/mandate_imports/{mandate_import_id}/actions/submit",
     resource: "mandate_imports",
     operation: "action",
@@ -773,7 +773,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandate_imports/:mandate_import_id/actions/cancel",
+    fastifyPath: "/mandate_imports/:mandate_import_id/actions/cancel",
     stripePath: "/mandate_imports/{mandate_import_id}/actions/cancel",
     resource: "mandate_imports",
     operation: "action",
@@ -783,7 +783,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/mandate_import_entries",
+    fastifyPath: "/mandate_import_entries",
     stripePath: "/mandate_import_entries",
     resource: "mandate_import_entries",
     operation: "list",
@@ -792,7 +792,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandate_import_entries",
+    fastifyPath: "/mandate_import_entries",
     stripePath: "/mandate_import_entries",
     resource: "mandate_import_entries",
     operation: "create",
@@ -801,7 +801,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/mandate_pdfs",
+    fastifyPath: "/mandate_pdfs",
     stripePath: "/mandate_pdfs",
     resource: "mandate_pdfs",
     operation: "create",
@@ -810,7 +810,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/negative_balance_limits",
+    fastifyPath: "/negative_balance_limits",
     stripePath: "/negative_balance_limits",
     resource: "negative_balance_limits",
     operation: "list",
@@ -819,7 +819,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/outbound_payments",
+    fastifyPath: "/outbound_payments",
     stripePath: "/outbound_payments",
     resource: "outbound_payments",
     operation: "list",
@@ -828,7 +828,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/outbound_payments",
+    fastifyPath: "/outbound_payments",
     stripePath: "/outbound_payments",
     resource: "outbound_payments",
     operation: "create",
@@ -837,7 +837,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/outbound_payments/withdrawal",
+    fastifyPath: "/outbound_payments/withdrawal",
     stripePath: "/outbound_payments/withdrawal",
     resource: "outbound_payments",
     operation: "create",
@@ -846,7 +846,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/outbound_payments/:outbound_payment_id/actions/cancel",
+    fastifyPath: "/outbound_payments/:outbound_payment_id/actions/cancel",
     stripePath: "/outbound_payments/{outbound_payment_id}/actions/cancel",
     resource: "outbound_payments",
     operation: "action",
@@ -856,7 +856,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/outbound_payments/:outbound_payment_id/actions/approve",
+    fastifyPath: "/outbound_payments/:outbound_payment_id/actions/approve",
     stripePath: "/outbound_payments/{outbound_payment_id}/actions/approve",
     resource: "outbound_payments",
     operation: "action",
@@ -866,7 +866,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/outbound_payments/:outbound_payment_id",
+    fastifyPath: "/outbound_payments/:outbound_payment_id",
     stripePath: "/outbound_payments/{outbound_payment_id}",
     resource: "outbound_payments",
     operation: "retrieve",
@@ -876,7 +876,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/outbound_payments/:outbound_payment_id",
+    fastifyPath: "/outbound_payments/:outbound_payment_id",
     stripePath: "/outbound_payments/{outbound_payment_id}",
     resource: "outbound_payments",
     operation: "update",
@@ -886,7 +886,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/outbound_payments/stats",
+    fastifyPath: "/outbound_payments/stats",
     stripePath: "/outbound_payments/stats",
     resource: "outbound_payments",
     operation: "action",
@@ -895,7 +895,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payer_authorisations/:payer_authorisation_id",
+    fastifyPath: "/payer_authorisations/:payer_authorisation_id",
     stripePath: "/payer_authorisations/{payer_authorisation_id}",
     resource: "payer_authorisations",
     operation: "retrieve",
@@ -905,7 +905,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/payer_authorisations/:payer_authorisation_id",
+    fastifyPath: "/payer_authorisations/:payer_authorisation_id",
     stripePath: "/payer_authorisations/{payer_authorisation_id}",
     resource: "payer_authorisations",
     operation: "update",
@@ -915,7 +915,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payer_authorisations",
+    fastifyPath: "/payer_authorisations",
     stripePath: "/payer_authorisations",
     resource: "payer_authorisations",
     operation: "create",
@@ -924,7 +924,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payer_authorisations/:payer_authorisation_id/actions/submit",
+    fastifyPath: "/payer_authorisations/:payer_authorisation_id/actions/submit",
     stripePath: "/payer_authorisations/{payer_authorisation_id}/actions/submit",
     resource: "payer_authorisations",
     operation: "action",
@@ -934,7 +934,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payer_authorisations/:payer_authorisation_id/actions/confirm",
+    fastifyPath: "/payer_authorisations/:payer_authorisation_id/actions/confirm",
     stripePath: "/payer_authorisations/{payer_authorisation_id}/actions/confirm",
     resource: "payer_authorisations",
     operation: "action",
@@ -944,7 +944,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/branding/payer_themes",
+    fastifyPath: "/branding/payer_themes",
     stripePath: "/branding/payer_themes",
     resource: "branding",
     operation: "create",
@@ -953,7 +953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payments",
+    fastifyPath: "/payments",
     stripePath: "/payments",
     resource: "payments",
     operation: "list",
@@ -963,7 +963,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payments",
+    fastifyPath: "/payments",
     stripePath: "/payments",
     resource: "payments",
     operation: "create",
@@ -973,7 +973,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payments/:payment_id",
+    fastifyPath: "/payments/:payment_id",
     stripePath: "/payments/{payment_id}",
     resource: "payments",
     operation: "retrieve",
@@ -984,7 +984,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/payments/:payment_id",
+    fastifyPath: "/payments/:payment_id",
     stripePath: "/payments/{payment_id}",
     resource: "payments",
     operation: "update",
@@ -995,7 +995,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payments/:payment_id/actions/cancel",
+    fastifyPath: "/payments/:payment_id/actions/cancel",
     stripePath: "/payments/{payment_id}/actions/cancel",
     resource: "payments",
     operation: "action",
@@ -1006,7 +1006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/payments/:payment_id/actions/retry",
+    fastifyPath: "/payments/:payment_id/actions/retry",
     stripePath: "/payments/{payment_id}/actions/retry",
     resource: "payments",
     operation: "action",
@@ -1017,7 +1017,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payment_accounts/:payment_account_id",
+    fastifyPath: "/payment_accounts/:payment_account_id",
     stripePath: "/payment_accounts/{payment_account_id}",
     resource: "payment_accounts",
     operation: "retrieve",
@@ -1027,7 +1027,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payment_accounts",
+    fastifyPath: "/payment_accounts",
     stripePath: "/payment_accounts",
     resource: "payment_accounts",
     operation: "list",
@@ -1036,7 +1036,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payment_account_transactions/:payment_account_transaction_id",
+    fastifyPath: "/payment_account_transactions/:payment_account_transaction_id",
     stripePath: "/payment_account_transactions/{payment_account_transaction_id}",
     resource: "payment_account_transactions",
     operation: "retrieve",
@@ -1046,7 +1046,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payment_accounts/:payment_account_transaction_id/transactions",
+    fastifyPath: "/payment_accounts/:payment_account_transaction_id/transactions",
     stripePath: "/payment_accounts/{payment_account_transaction_id}/transactions",
     resource: "payment_accounts",
     operation: "action",
@@ -1056,7 +1056,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payouts",
+    fastifyPath: "/payouts",
     stripePath: "/payouts",
     resource: "payouts",
     operation: "list",
@@ -1066,7 +1066,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payouts/:payout_id",
+    fastifyPath: "/payouts/:payout_id",
     stripePath: "/payouts/{payout_id}",
     resource: "payouts",
     operation: "retrieve",
@@ -1077,7 +1077,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/payouts/:payout_id",
+    fastifyPath: "/payouts/:payout_id",
     stripePath: "/payouts/{payout_id}",
     resource: "payouts",
     operation: "update",
@@ -1088,7 +1088,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/payout_items",
+    fastifyPath: "/payout_items",
     stripePath: "/payout_items",
     resource: "payout_items",
     operation: "list",
@@ -1098,7 +1098,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/redirect_flows",
+    fastifyPath: "/redirect_flows",
     stripePath: "/redirect_flows",
     resource: "redirect_flows",
     operation: "create",
@@ -1108,7 +1108,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/redirect_flows/:redirect_flow_id",
+    fastifyPath: "/redirect_flows/:redirect_flow_id",
     stripePath: "/redirect_flows/{redirect_flow_id}",
     resource: "redirect_flows",
     operation: "retrieve",
@@ -1119,7 +1119,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/redirect_flows/:redirect_flow_id/actions/complete",
+    fastifyPath: "/redirect_flows/:redirect_flow_id/actions/complete",
     stripePath: "/redirect_flows/{redirect_flow_id}/actions/complete",
     resource: "redirect_flows",
     operation: "action",
@@ -1130,7 +1130,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/refunds",
+    fastifyPath: "/refunds",
     stripePath: "/refunds",
     resource: "refunds",
     operation: "list",
@@ -1140,7 +1140,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/refunds",
+    fastifyPath: "/refunds",
     stripePath: "/refunds",
     resource: "refunds",
     operation: "create",
@@ -1150,7 +1150,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/refunds/:refund_id",
+    fastifyPath: "/refunds/:refund_id",
     stripePath: "/refunds/{refund_id}",
     resource: "refunds",
     operation: "retrieve",
@@ -1161,7 +1161,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/refunds/:refund_id",
+    fastifyPath: "/refunds/:refund_id",
     stripePath: "/refunds/{refund_id}",
     resource: "refunds",
     operation: "update",
@@ -1172,7 +1172,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/scenario_simulators/:scenario_simulator_id/actions/run",
+    fastifyPath: "/scenario_simulators/:scenario_simulator_id/actions/run",
     stripePath: "/scenario_simulators/{scenario_simulator_id}/actions/run",
     resource: "scenario_simulators",
     operation: "action",
@@ -1182,7 +1182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/scheme_identifiers",
+    fastifyPath: "/scheme_identifiers",
     stripePath: "/scheme_identifiers",
     resource: "scheme_identifiers",
     operation: "list",
@@ -1192,7 +1192,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/scheme_identifiers",
+    fastifyPath: "/scheme_identifiers",
     stripePath: "/scheme_identifiers",
     resource: "scheme_identifiers",
     operation: "create",
@@ -1202,7 +1202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/scheme_identifiers/:scheme_identifier_id",
+    fastifyPath: "/scheme_identifiers/:scheme_identifier_id",
     stripePath: "/scheme_identifiers/{scheme_identifier_id}",
     resource: "scheme_identifiers",
     operation: "retrieve",
@@ -1213,7 +1213,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -1223,7 +1223,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -1233,7 +1233,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1244,7 +1244,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/gocardless/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "update",
@@ -1255,7 +1255,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/subscriptions/:subscription_id/actions/pause",
+    fastifyPath: "/subscriptions/:subscription_id/actions/pause",
     stripePath: "/subscriptions/{subscription_id}/actions/pause",
     resource: "subscriptions",
     operation: "action",
@@ -1266,7 +1266,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/subscriptions/:subscription_id/actions/resume",
+    fastifyPath: "/subscriptions/:subscription_id/actions/resume",
     stripePath: "/subscriptions/{subscription_id}/actions/resume",
     resource: "subscriptions",
     operation: "action",
@@ -1277,7 +1277,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/subscriptions/:subscription_id/actions/cancel",
+    fastifyPath: "/subscriptions/:subscription_id/actions/cancel",
     stripePath: "/subscriptions/{subscription_id}/actions/cancel",
     resource: "subscriptions",
     operation: "action",
@@ -1288,7 +1288,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/tax_rates",
+    fastifyPath: "/tax_rates",
     stripePath: "/tax_rates",
     resource: "tax_rates",
     operation: "list",
@@ -1297,7 +1297,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/tax_rates/:tax_rate_id",
+    fastifyPath: "/tax_rates/:tax_rate_id",
     stripePath: "/tax_rates/{tax_rate_id}",
     resource: "tax_rates",
     operation: "retrieve",
@@ -1307,7 +1307,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/transferred_mandates/:mandate_id",
+    fastifyPath: "/transferred_mandates/:mandate_id",
     stripePath: "/transferred_mandates/{mandate_id}",
     resource: "transferred_mandates",
     operation: "retrieve",
@@ -1317,7 +1317,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/verification_details",
+    fastifyPath: "/verification_details",
     stripePath: "/verification_details",
     resource: "verification_details",
     operation: "list",
@@ -1326,7 +1326,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/verification_details",
+    fastifyPath: "/verification_details",
     stripePath: "/verification_details",
     resource: "verification_details",
     operation: "create",
@@ -1335,7 +1335,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/webhooks",
+    fastifyPath: "/webhooks",
     stripePath: "/webhooks",
     resource: "webhooks",
     operation: "list",
@@ -1344,7 +1344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/gocardless/webhooks/:webhook_id",
+    fastifyPath: "/webhooks/:webhook_id",
     stripePath: "/webhooks/{webhook_id}",
     resource: "webhooks",
     operation: "retrieve",
@@ -1354,7 +1354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/gocardless/webhooks/:webhook_id/actions/retry",
+    fastifyPath: "/webhooks/:webhook_id/actions/retry",
     stripePath: "/webhooks/{webhook_id}/actions/retry",
     resource: "webhooks",
     operation: "action",

--- a/packages/adapters/adapter-gocardless/src/gocardless-adapter.ts
+++ b/packages/adapters/adapter-gocardless/src/gocardless-adapter.ts
@@ -53,7 +53,7 @@ export class GoCardlessAdapter extends OpenApiMockAdapter<GoCardlessConfig> {
           if (wk in p) return payload;
         }
         // Derive wrapper key from URL path
-        const url = request.url.replace('/gocardless/', '');
+        const url = request.url.replace('/', '');
         const segments = url.split('/');
         const wrapperKey = segments[0] ?? 'unknown';
         return { [wrapperKey]: payload };
@@ -164,23 +164,23 @@ export class GoCardlessAdapter extends OpenApiMockAdapter<GoCardlessConfig> {
 
   private mountOverrides(store: StateStore): void {
     // Mandate lifecycle
-    this.registerOverride('POST', '/gocardless/mandates/:mandate_id/actions/cancel',
+    this.registerOverride('POST', '/mandates/:mandate_id/actions/cancel',
       mandateOverrides.buildCancelHandler(store));
-    this.registerOverride('POST', '/gocardless/mandates/:mandate_id/actions/reinstate',
+    this.registerOverride('POST', '/mandates/:mandate_id/actions/reinstate',
       mandateOverrides.buildReinstateHandler(store));
 
     // Payment lifecycle
-    this.registerOverride('POST', '/gocardless/payments/:payment_id/actions/cancel',
+    this.registerOverride('POST', '/payments/:payment_id/actions/cancel',
       paymentOverrides.buildCancelHandler(store));
-    this.registerOverride('POST', '/gocardless/payments/:payment_id/actions/retry',
+    this.registerOverride('POST', '/payments/:payment_id/actions/retry',
       paymentOverrides.buildRetryHandler(store));
 
     // Subscription lifecycle
-    this.registerOverride('POST', '/gocardless/subscriptions/:subscription_id/actions/cancel',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/actions/cancel',
       subscriptionOverrides.buildCancelHandler(store));
-    this.registerOverride('POST', '/gocardless/subscriptions/:subscription_id/actions/pause',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/actions/pause',
       subscriptionOverrides.buildPauseHandler(store));
-    this.registerOverride('POST', '/gocardless/subscriptions/:subscription_id/actions/resume',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/actions/resume',
       subscriptionOverrides.buildResumeHandler(store));
   }
 }

--- a/packages/adapters/adapter-gocardless/src/mcp.ts
+++ b/packages/adapters/adapter-gocardless/src/mcp.ts
@@ -37,7 +37,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
   server.tool('list_customers', 'List GoCardless customers', {
     limit: z.number().optional().describe('Max results (1-500)'),
   }, async ({ limit }) => {
-    const data = await call('GET', `/gocardless/customers${qs({ limit: limit ?? 50 })}`) as any;
+    const data = await call('GET', `/customers${qs({ limit: limit ?? 50 })}`) as any;
     if (!data.customers?.length) return text('No customers found.');
     const lines = data.customers.map((c: any) => `- ${c.id} — ${c.given_name ?? ''} ${c.family_name ?? ''} (${c.email ?? 'no email'})`);
     return text(`Customers (${data.customers.length}):\n${lines.join('\n')}`);
@@ -50,7 +50,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     country_code: z.string().optional().describe('ISO country code'),
     metadata: z.record(z.string()).optional(),
   }, async (params) => {
-    const data = await call('POST', '/gocardless/customers', { customers: params }) as any;
+    const data = await call('POST', '/customers', { customers: params }) as any;
     const c = data.customers;
     return text(`Created customer ${c.id}: ${c.given_name ?? ''} ${c.family_name ?? ''}`);
   });
@@ -60,7 +60,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     customer: z.string().optional().describe('Filter by customer ID'),
     status: z.string().optional().describe('Filter by status'),
   }, async ({ customer, status }) => {
-    const data = await call('GET', `/gocardless/mandates${qs({ customer, status })}`) as any;
+    const data = await call('GET', `/mandates${qs({ customer, status })}`) as any;
     if (!data.mandates?.length) return text('No mandates found.');
     const lines = data.mandates.map((m: any) => `- ${m.id} — ${m.scheme} [${m.status}]`);
     return text(`Mandates (${data.mandates.length}):\n${lines.join('\n')}`);
@@ -70,14 +70,14 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     scheme: z.string().describe('Direct Debit scheme (e.g. bacs, sepa_core, ach)'),
     metadata: z.record(z.string()).optional(),
   }, async (params) => {
-    const data = await call('POST', '/gocardless/mandates', { mandates: params }) as any;
+    const data = await call('POST', '/mandates', { mandates: params }) as any;
     return text(`Created mandate ${data.mandates.id} [${data.mandates.status}]`);
   });
 
   server.tool('cancel_mandate', 'Cancel a Direct Debit mandate', {
     mandate_id: z.string().describe('Mandate ID'),
   }, async ({ mandate_id }) => {
-    const data = await call('POST', `/gocardless/mandates/${mandate_id}/actions/cancel`) as any;
+    const data = await call('POST', `/mandates/${mandate_id}/actions/cancel`) as any;
     return text(`Cancelled mandate ${data.mandates.id} [${data.mandates.status}]`);
   });
 
@@ -87,7 +87,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     mandate: z.string().optional(),
     status: z.string().optional(),
   }, async ({ customer, mandate, status }) => {
-    const data = await call('GET', `/gocardless/payments${qs({ customer, mandate, status })}`) as any;
+    const data = await call('GET', `/payments${qs({ customer, mandate, status })}`) as any;
     if (!data.payments?.length) return text('No payments found.');
     const lines = data.payments.map((p: any) => `- ${p.id} — ${p.amount} ${p.currency} [${p.status}]`);
     return text(`Payments (${data.payments.length}):\n${lines.join('\n')}`);
@@ -100,14 +100,14 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     mandate: z.string().describe('Mandate ID to charge'),
     metadata: z.record(z.string()).optional(),
   }, async ({ mandate, ...rest }) => {
-    const data = await call('POST', '/gocardless/payments', { payments: { ...rest, links: { mandate } } }) as any;
+    const data = await call('POST', '/payments', { payments: { ...rest, links: { mandate } } }) as any;
     return text(`Created payment ${data.payments.id} — ${data.payments.amount} ${data.payments.currency} [${data.payments.status}]`);
   });
 
   server.tool('cancel_payment', 'Cancel a payment', {
     payment_id: z.string().describe('Payment ID'),
   }, async ({ payment_id }) => {
-    const data = await call('POST', `/gocardless/payments/${payment_id}/actions/cancel`) as any;
+    const data = await call('POST', `/payments/${payment_id}/actions/cancel`) as any;
     return text(`Cancelled payment ${data.payments.id} [${data.payments.status}]`);
   });
 
@@ -117,7 +117,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     mandate: z.string().optional(),
     status: z.string().optional(),
   }, async ({ customer, mandate, status }) => {
-    const data = await call('GET', `/gocardless/subscriptions${qs({ customer, mandate, status })}`) as any;
+    const data = await call('GET', `/subscriptions${qs({ customer, mandate, status })}`) as any;
     if (!data.subscriptions?.length) return text('No subscriptions found.');
     const lines = data.subscriptions.map((s: any) => `- ${s.id} — ${s.amount} ${s.currency} every ${s.interval} ${s.interval_unit}(s) [${s.status}]`);
     return text(`Subscriptions (${data.subscriptions.length}):\n${lines.join('\n')}`);
@@ -132,14 +132,14 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     name: z.string().optional(),
     metadata: z.record(z.string()).optional(),
   }, async ({ mandate, ...rest }) => {
-    const data = await call('POST', '/gocardless/subscriptions', { subscriptions: { ...rest, links: { mandate } } }) as any;
+    const data = await call('POST', '/subscriptions', { subscriptions: { ...rest, links: { mandate } } }) as any;
     return text(`Created subscription ${data.subscriptions.id} [${data.subscriptions.status}]`);
   });
 
   server.tool('cancel_subscription', 'Cancel a subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('POST', `/gocardless/subscriptions/${subscription_id}/actions/cancel`) as any;
+    const data = await call('POST', `/subscriptions/${subscription_id}/actions/cancel`) as any;
     return text(`Cancelled subscription ${data.subscriptions.id} [${data.subscriptions.status}]`);
   });
 
@@ -150,7 +150,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
     total_amount_confirmation: z.number().int().describe('Total amount of payment for confirmation'),
     metadata: z.record(z.string()).optional(),
   }, async ({ payment, total_amount_confirmation, ...rest }) => {
-    const data = await call('POST', '/gocardless/refunds', { refunds: { ...rest, total_amount_confirmation, links: { payment } } }) as any;
+    const data = await call('POST', '/refunds', { refunds: { ...rest, total_amount_confirmation, links: { payment } } }) as any;
     return text(`Created refund ${data.refunds.id} — ${data.refunds.amount} ${data.refunds.currency} [${data.refunds.status}]`);
   });
 
@@ -164,7 +164,7 @@ export function registerGoCardlessTools(server: McpServer, baseUrl: string = 'ht
 
     for (const type of types) {
       try {
-        const data = await call('GET', `/gocardless/${type}`) as any;
+        const data = await call('GET', `/${type}`) as any;
         const items = data[type] ?? [];
         if (!items.length) continue;
         const matches = items.filter((item: any) => {

--- a/packages/adapters/adapter-lemonsqueezy/adapter.json
+++ b/packages/adapters/adapter-lemonsqueezy/adapter.json
@@ -3,7 +3,7 @@
   "name": "Lemon Squeezy",
   "description": "Lemon Squeezy payment and subscription platform mock adapter",
   "type": "api-mock",
-  "basePath": "/lemonsqueezy",
+  "basePath": "",
   "versions": ["v1"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://docs.lemonsqueezy.com/api",

--- a/packages/adapters/adapter-lemonsqueezy/scripts/lemonsqueezy-codegen.ts
+++ b/packages/adapters/adapter-lemonsqueezy/scripts/lemonsqueezy-codegen.ts
@@ -849,7 +849,7 @@ function generateRoutesTs(): string {
 
   for (const res of RESOURCES) {
     for (const ep of res.endpoints) {
-      const fastifyPath = '/lemonsqueezy' + ep.path;
+      const fastifyPath = ep.path;
       lines.push(`  {`);
       lines.push(`    method: ${JSON.stringify(ep.method)},`);
       lines.push(`    fastifyPath: ${JSON.stringify(fastifyPath)},`);

--- a/packages/adapters/adapter-lemonsqueezy/src/__tests__/lemonsqueezy-adapter.test.ts
+++ b/packages/adapters/adapter-lemonsqueezy/src/__tests__/lemonsqueezy-adapter.test.ts
@@ -19,7 +19,7 @@ describe('LemonSqueezyAdapter', () => {
 
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('lemonsqueezy');
-    expect(adapter.basePath).toBe('/lemonsqueezy');
+    expect(adapter.basePath).toBe('');
     expect(adapter.name).toBe('Lemon Squeezy');
   });
 
@@ -37,7 +37,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should create a customer (JSON:API format)', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/customers',
+      url: '/v1/customers',
       headers: { 'content-type': 'application/vnd.api+json' },
       payload: JSON.stringify({
         data: {
@@ -59,7 +59,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should create a customer (plain body)', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/customers',
+      url: '/v1/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'John Smith', email: 'john@example.com' }),
     });
@@ -71,7 +71,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should list customers', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/customers',
+      url: '/v1/customers',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -85,7 +85,7 @@ describe('LemonSqueezyAdapter', () => {
     // Create first
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/customers',
+      url: '/v1/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'Retrieve Test', email: 'retrieve@test.com' }),
     });
@@ -93,7 +93,7 @@ describe('LemonSqueezyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/lemonsqueezy/v1/customers/${customerId}`,
+      url: `/v1/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -105,7 +105,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should update a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/customers',
+      url: '/v1/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'Update Test', email: 'update@test.com' }),
     });
@@ -113,7 +113,7 @@ describe('LemonSqueezyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'PATCH',
-      url: `/lemonsqueezy/v1/customers/${customerId}`,
+      url: `/v1/customers/${customerId}`,
       headers: { 'content-type': 'application/vnd.api+json' },
       payload: JSON.stringify({
         data: { type: 'customers', id: customerId, attributes: { city: 'San Francisco' } },
@@ -126,7 +126,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should return 404 for non-existent customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/customers/nonexistent',
+      url: '/v1/customers/nonexistent',
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -138,7 +138,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should list products (empty initially)', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/products',
+      url: '/v1/products',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().data).toBeInstanceOf(Array);
@@ -150,7 +150,7 @@ describe('LemonSqueezyAdapter', () => {
     // Create
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/subscriptions',
+      url: '/v1/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ product_name: 'Pro Plan', status: 'active' }),
     });
@@ -160,7 +160,7 @@ describe('LemonSqueezyAdapter', () => {
     // Cancel (DELETE)
     const cancelRes = await ts.server.inject({
       method: 'DELETE',
-      url: `/lemonsqueezy/v1/subscriptions/${subId}`,
+      url: `/v1/subscriptions/${subId}`,
     });
     expect(cancelRes.statusCode).toBe(200);
     expect(cancelRes.json().data.attributes.status).toBe('cancelled');
@@ -171,7 +171,7 @@ describe('LemonSqueezyAdapter', () => {
     // Create
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/subscriptions',
+      url: '/v1/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ product_name: 'Pause Test', status: 'active' }),
     });
@@ -180,7 +180,7 @@ describe('LemonSqueezyAdapter', () => {
     // Pause via PATCH
     const pauseRes = await ts.server.inject({
       method: 'PATCH',
-      url: `/lemonsqueezy/v1/subscriptions/${subId}`,
+      url: `/v1/subscriptions/${subId}`,
       headers: { 'content-type': 'application/vnd.api+json' },
       payload: JSON.stringify({
         data: { type: 'subscriptions', id: subId, attributes: { pause: { mode: 'void' } } },
@@ -192,7 +192,7 @@ describe('LemonSqueezyAdapter', () => {
     // Resume via PATCH (set pause to null)
     const resumeRes = await ts.server.inject({
       method: 'PATCH',
-      url: `/lemonsqueezy/v1/subscriptions/${subId}`,
+      url: `/v1/subscriptions/${subId}`,
       headers: { 'content-type': 'application/vnd.api+json' },
       payload: JSON.stringify({
         data: { type: 'subscriptions', id: subId, attributes: { pause: null } },
@@ -205,7 +205,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should list subscriptions', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/subscriptions',
+      url: '/v1/subscriptions',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().data.length).toBeGreaterThan(0);
@@ -217,7 +217,7 @@ describe('LemonSqueezyAdapter', () => {
     // Create
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/discounts',
+      url: '/v1/discounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'Summer Sale', code: 'SUMMER20', amount: 20, amount_type: 'percent' }),
     });
@@ -227,7 +227,7 @@ describe('LemonSqueezyAdapter', () => {
     // List
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/discounts',
+      url: '/v1/discounts',
     });
     expect(listRes.statusCode).toBe(200);
     expect(listRes.json().data.length).toBeGreaterThan(0);
@@ -235,7 +235,7 @@ describe('LemonSqueezyAdapter', () => {
     // Delete (204 No Content)
     const deleteRes = await ts.server.inject({
       method: 'DELETE',
-      url: `/lemonsqueezy/v1/discounts/${discountId}`,
+      url: `/v1/discounts/${discountId}`,
     });
     expect(deleteRes.statusCode).toBe(204);
   });
@@ -246,7 +246,7 @@ describe('LemonSqueezyAdapter', () => {
     // Create
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/webhooks',
+      url: '/v1/webhooks',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ url: 'https://example.com/webhook', events: ['order_created'] }),
     });
@@ -256,7 +256,7 @@ describe('LemonSqueezyAdapter', () => {
     // Update
     const updateRes = await ts.server.inject({
       method: 'PATCH',
-      url: `/lemonsqueezy/v1/webhooks/${webhookId}`,
+      url: `/v1/webhooks/${webhookId}`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ events: ['order_created', 'subscription_created'] }),
     });
@@ -265,7 +265,7 @@ describe('LemonSqueezyAdapter', () => {
     // Delete
     const deleteRes = await ts.server.inject({
       method: 'DELETE',
-      url: `/lemonsqueezy/v1/webhooks/${webhookId}`,
+      url: `/v1/webhooks/${webhookId}`,
     });
     expect(deleteRes.statusCode).toBe(204);
   });
@@ -275,7 +275,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should create a checkout', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/lemonsqueezy/v1/checkouts',
+      url: '/v1/checkouts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ store_id: 1, variant_id: 1 }),
     });
@@ -288,7 +288,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should retrieve the authenticated user', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/users/me',
+      url: '/v1/users/me',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -303,7 +303,7 @@ describe('LemonSqueezyAdapter', () => {
     for (let i = 0; i < 3; i++) {
       await ts.server.inject({
         method: 'POST',
-        url: '/lemonsqueezy/v1/customers',
+        url: '/v1/customers',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ name: `Page Test ${i}`, email: `page${i}@test.com` }),
       });
@@ -312,7 +312,7 @@ describe('LemonSqueezyAdapter', () => {
     // Request page 1 with size 2
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/customers?page[size]=2&page[number]=1',
+      url: '/v1/customers?page[size]=2&page[number]=1',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -326,7 +326,7 @@ describe('LemonSqueezyAdapter', () => {
   it('should list license keys (empty initially)', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/lemonsqueezy/v1/license-keys',
+      url: '/v1/license-keys',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().data).toBeInstanceOf(Array);
@@ -363,7 +363,7 @@ describe('LemonSqueezyAdapter', () => {
 
     const seededAdapter = new LemonSqueezyAdapter();
     const seededTs = await buildTestServer(seededAdapter, seedData);
-    const res = await seededTs.server.inject({ method: 'GET', url: '/lemonsqueezy/v1/customers' });
+    const res = await seededTs.server.inject({ method: 'GET', url: '/v1/customers' });
     const items = res.json().data;
     expect(items).toContainEqual(
       expect.objectContaining({

--- a/packages/adapters/adapter-lemonsqueezy/src/generated/meta.ts
+++ b/packages/adapters/adapter-lemonsqueezy/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-lemonsqueezy generate
 // Lemon Squeezy API docs: https://docs.lemonsqueezy.com/api
-// Generated at: 2026-03-13T10:59:53.134Z
+// Generated at: 2026-03-20T11:03:17.220Z
 
 export const LEMONSQUEEZY_SPEC_VERSION = 'v1';
-export const LEMONSQUEEZY_SPEC_GENERATED_AT = "2026-03-13T10:59:53.134Z";
+export const LEMONSQUEEZY_SPEC_GENERATED_AT = "2026-03-20T11:03:17.220Z";

--- a/packages/adapters/adapter-lemonsqueezy/src/generated/routes.ts
+++ b/packages/adapters/adapter-lemonsqueezy/src/generated/routes.ts
@@ -18,7 +18,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/users/me",
+    fastifyPath: "/v1/users/me",
     stripePath: "/v1/users/me",
     resource: "users",
     operation: "retrieve",
@@ -29,7 +29,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/stores/:id",
+    fastifyPath: "/v1/stores/:id",
     stripePath: "/v1/stores/:id",
     resource: "stores",
     operation: "retrieve",
@@ -40,7 +40,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/stores",
+    fastifyPath: "/v1/stores",
     stripePath: "/v1/stores",
     resource: "stores",
     operation: "list",
@@ -50,7 +50,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/customers",
+    fastifyPath: "/v1/customers",
     stripePath: "/v1/customers",
     resource: "customers",
     operation: "create",
@@ -60,7 +60,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/customers/:id",
+    fastifyPath: "/v1/customers/:id",
     stripePath: "/v1/customers/:id",
     resource: "customers",
     operation: "retrieve",
@@ -71,7 +71,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/lemonsqueezy/v1/customers/:id",
+    fastifyPath: "/v1/customers/:id",
     stripePath: "/v1/customers/:id",
     resource: "customers",
     operation: "update",
@@ -82,7 +82,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/customers",
+    fastifyPath: "/v1/customers",
     stripePath: "/v1/customers",
     resource: "customers",
     operation: "list",
@@ -92,7 +92,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/products/:id",
+    fastifyPath: "/v1/products/:id",
     stripePath: "/v1/products/:id",
     resource: "products",
     operation: "retrieve",
@@ -103,7 +103,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/products",
+    fastifyPath: "/v1/products",
     stripePath: "/v1/products",
     resource: "products",
     operation: "list",
@@ -113,7 +113,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/variants/:id",
+    fastifyPath: "/v1/variants/:id",
     stripePath: "/v1/variants/:id",
     resource: "variants",
     operation: "retrieve",
@@ -124,7 +124,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/variants",
+    fastifyPath: "/v1/variants",
     stripePath: "/v1/variants",
     resource: "variants",
     operation: "list",
@@ -134,7 +134,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/prices/:id",
+    fastifyPath: "/v1/prices/:id",
     stripePath: "/v1/prices/:id",
     resource: "prices",
     operation: "retrieve",
@@ -145,7 +145,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/prices",
+    fastifyPath: "/v1/prices",
     stripePath: "/v1/prices",
     resource: "prices",
     operation: "list",
@@ -155,7 +155,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/orders",
+    fastifyPath: "/v1/orders",
     stripePath: "/v1/orders",
     resource: "orders",
     operation: "create",
@@ -165,7 +165,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/orders/:id",
+    fastifyPath: "/v1/orders/:id",
     stripePath: "/v1/orders/:id",
     resource: "orders",
     operation: "retrieve",
@@ -176,7 +176,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/orders",
+    fastifyPath: "/v1/orders",
     stripePath: "/v1/orders",
     resource: "orders",
     operation: "list",
@@ -186,7 +186,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/subscriptions",
+    fastifyPath: "/v1/subscriptions",
     stripePath: "/v1/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -196,7 +196,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscriptions/:id",
+    fastifyPath: "/v1/subscriptions/:id",
     stripePath: "/v1/subscriptions/:id",
     resource: "subscriptions",
     operation: "retrieve",
@@ -207,7 +207,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/lemonsqueezy/v1/subscriptions/:id",
+    fastifyPath: "/v1/subscriptions/:id",
     stripePath: "/v1/subscriptions/:id",
     resource: "subscriptions",
     operation: "update",
@@ -218,7 +218,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/lemonsqueezy/v1/subscriptions/:id",
+    fastifyPath: "/v1/subscriptions/:id",
     stripePath: "/v1/subscriptions/:id",
     resource: "subscriptions",
     operation: "delete",
@@ -229,7 +229,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscriptions",
+    fastifyPath: "/v1/subscriptions",
     stripePath: "/v1/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -239,7 +239,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/discounts",
+    fastifyPath: "/v1/discounts",
     stripePath: "/v1/discounts",
     resource: "discounts",
     operation: "create",
@@ -249,7 +249,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/discounts/:id",
+    fastifyPath: "/v1/discounts/:id",
     stripePath: "/v1/discounts/:id",
     resource: "discounts",
     operation: "retrieve",
@@ -260,7 +260,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/lemonsqueezy/v1/discounts/:id",
+    fastifyPath: "/v1/discounts/:id",
     stripePath: "/v1/discounts/:id",
     resource: "discounts",
     operation: "delete",
@@ -271,7 +271,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/discounts",
+    fastifyPath: "/v1/discounts",
     stripePath: "/v1/discounts",
     resource: "discounts",
     operation: "list",
@@ -281,7 +281,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/checkouts",
+    fastifyPath: "/v1/checkouts",
     stripePath: "/v1/checkouts",
     resource: "checkouts",
     operation: "create",
@@ -291,7 +291,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/checkouts/:id",
+    fastifyPath: "/v1/checkouts/:id",
     stripePath: "/v1/checkouts/:id",
     resource: "checkouts",
     operation: "retrieve",
@@ -302,7 +302,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/checkouts",
+    fastifyPath: "/v1/checkouts",
     stripePath: "/v1/checkouts",
     resource: "checkouts",
     operation: "list",
@@ -312,7 +312,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/files/:id",
+    fastifyPath: "/v1/files/:id",
     stripePath: "/v1/files/:id",
     resource: "files",
     operation: "retrieve",
@@ -323,7 +323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/files",
+    fastifyPath: "/v1/files",
     stripePath: "/v1/files",
     resource: "files",
     operation: "list",
@@ -333,7 +333,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/order-items/:id",
+    fastifyPath: "/v1/order-items/:id",
     stripePath: "/v1/order-items/:id",
     resource: "order-items",
     operation: "retrieve",
@@ -344,7 +344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/order-items",
+    fastifyPath: "/v1/order-items",
     stripePath: "/v1/order-items",
     resource: "order-items",
     operation: "list",
@@ -354,7 +354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscription-invoices/:id",
+    fastifyPath: "/v1/subscription-invoices/:id",
     stripePath: "/v1/subscription-invoices/:id",
     resource: "subscription-invoices",
     operation: "retrieve",
@@ -365,7 +365,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscription-invoices",
+    fastifyPath: "/v1/subscription-invoices",
     stripePath: "/v1/subscription-invoices",
     resource: "subscription-invoices",
     operation: "list",
@@ -375,7 +375,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscription-items/:id",
+    fastifyPath: "/v1/subscription-items/:id",
     stripePath: "/v1/subscription-items/:id",
     resource: "subscription-items",
     operation: "retrieve",
@@ -386,7 +386,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/lemonsqueezy/v1/subscription-items/:id",
+    fastifyPath: "/v1/subscription-items/:id",
     stripePath: "/v1/subscription-items/:id",
     resource: "subscription-items",
     operation: "update",
@@ -397,7 +397,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/subscription-items",
+    fastifyPath: "/v1/subscription-items",
     stripePath: "/v1/subscription-items",
     resource: "subscription-items",
     operation: "list",
@@ -407,7 +407,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/usage-records",
+    fastifyPath: "/v1/usage-records",
     stripePath: "/v1/usage-records",
     resource: "usage-records",
     operation: "create",
@@ -417,7 +417,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/usage-records/:id",
+    fastifyPath: "/v1/usage-records/:id",
     stripePath: "/v1/usage-records/:id",
     resource: "usage-records",
     operation: "retrieve",
@@ -428,7 +428,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/usage-records",
+    fastifyPath: "/v1/usage-records",
     stripePath: "/v1/usage-records",
     resource: "usage-records",
     operation: "list",
@@ -438,7 +438,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/discount-redemptions/:id",
+    fastifyPath: "/v1/discount-redemptions/:id",
     stripePath: "/v1/discount-redemptions/:id",
     resource: "discount-redemptions",
     operation: "retrieve",
@@ -449,7 +449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/discount-redemptions",
+    fastifyPath: "/v1/discount-redemptions",
     stripePath: "/v1/discount-redemptions",
     resource: "discount-redemptions",
     operation: "list",
@@ -459,7 +459,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/license-keys/:id",
+    fastifyPath: "/v1/license-keys/:id",
     stripePath: "/v1/license-keys/:id",
     resource: "license-keys",
     operation: "retrieve",
@@ -470,7 +470,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/lemonsqueezy/v1/license-keys/:id",
+    fastifyPath: "/v1/license-keys/:id",
     stripePath: "/v1/license-keys/:id",
     resource: "license-keys",
     operation: "update",
@@ -481,7 +481,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/license-keys",
+    fastifyPath: "/v1/license-keys",
     stripePath: "/v1/license-keys",
     resource: "license-keys",
     operation: "list",
@@ -491,7 +491,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/license-key-instances/:id",
+    fastifyPath: "/v1/license-key-instances/:id",
     stripePath: "/v1/license-key-instances/:id",
     resource: "license-key-instances",
     operation: "retrieve",
@@ -502,7 +502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/license-key-instances",
+    fastifyPath: "/v1/license-key-instances",
     stripePath: "/v1/license-key-instances",
     resource: "license-key-instances",
     operation: "list",
@@ -512,7 +512,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/lemonsqueezy/v1/webhooks",
+    fastifyPath: "/v1/webhooks",
     stripePath: "/v1/webhooks",
     resource: "webhooks",
     operation: "create",
@@ -522,7 +522,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/webhooks/:id",
+    fastifyPath: "/v1/webhooks/:id",
     stripePath: "/v1/webhooks/:id",
     resource: "webhooks",
     operation: "retrieve",
@@ -533,7 +533,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/lemonsqueezy/v1/webhooks/:id",
+    fastifyPath: "/v1/webhooks/:id",
     stripePath: "/v1/webhooks/:id",
     resource: "webhooks",
     operation: "update",
@@ -544,7 +544,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/lemonsqueezy/v1/webhooks/:id",
+    fastifyPath: "/v1/webhooks/:id",
     stripePath: "/v1/webhooks/:id",
     resource: "webhooks",
     operation: "delete",
@@ -555,7 +555,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/lemonsqueezy/v1/webhooks",
+    fastifyPath: "/v1/webhooks",
     stripePath: "/v1/webhooks",
     resource: "webhooks",
     operation: "list",

--- a/packages/adapters/adapter-lemonsqueezy/src/lemonsqueezy-adapter.ts
+++ b/packages/adapters/adapter-lemonsqueezy/src/lemonsqueezy-adapter.ts
@@ -206,27 +206,27 @@ export class LemonSqueezyAdapter extends OpenApiMockAdapter<LemonSqueezyConfig> 
     // ── Subscriptions ─────────────────────────────────────────────────────
     // Cancel via DELETE sets status to 'cancelled'
     this.registerOverride(
-      'DELETE', '/lemonsqueezy/v1/subscriptions/:id',
+      'DELETE', '/v1/subscriptions/:id',
       subOverrides.buildCancelHandler(store),
     );
 
     // Update via PATCH handles pause/unpause, cancel/uncancel
     this.registerOverride(
-      'PATCH', '/lemonsqueezy/v1/subscriptions/:id',
+      'PATCH', '/v1/subscriptions/:id',
       subOverrides.buildUpdateHandler(store),
     );
 
     // ── Discounts ─────────────────────────────────────────────────────────
     // DELETE returns 204 No Content
     this.registerOverride(
-      'DELETE', '/lemonsqueezy/v1/discounts/:id',
+      'DELETE', '/v1/discounts/:id',
       this.buildNoContentDeleteHandler(store, 'discounts'),
     );
 
     // ── Webhooks ──────────────────────────────────────────────────────────
     // DELETE returns 204 No Content
     this.registerOverride(
-      'DELETE', '/lemonsqueezy/v1/webhooks/:id',
+      'DELETE', '/v1/webhooks/:id',
       this.buildNoContentDeleteHandler(store, 'webhooks'),
     );
 

--- a/packages/adapters/adapter-lemonsqueezy/src/mcp.ts
+++ b/packages/adapters/adapter-lemonsqueezy/src/mcp.ts
@@ -54,7 +54,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   // ── Stores ──────────────────────────────────────────────────────────
 
   server.tool('list_stores', 'List Lemon Squeezy stores', {}, async () => {
-    const data = await call('GET', '/lemonsqueezy/v1/stores');
+    const data = await call('GET', '/v1/stores');
     const items = extractListData(data);
     if (!items.length) return text('No stores found.');
     const lines = items.map((s: any) => `• ${s.id} — ${s.name} (${s.currency})`);
@@ -64,7 +64,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('get_store', 'Get a specific store', {
     store_id: z.string().describe('Store ID'),
   }, async ({ store_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/stores/${store_id}`);
+    const data = await call('GET', `/v1/stores/${store_id}`);
     return text(JSON.stringify(extractData(data), null, 2));
   });
 
@@ -78,7 +78,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     region: z.string().optional().describe('Region'),
     country: z.string().optional().describe('Country (ISO 3166-1 alpha-2)'),
   }, async ({ name, email, store_id, city, region, country }) => {
-    const data = await call('POST', '/lemonsqueezy/v1/customers', {
+    const data = await call('POST', '/v1/customers', {
       data: { type: 'customers', attributes: { name, email, city, region, country }, relationships: { store: { data: { type: 'stores', id: store_id } } } },
     });
     const item = extractData(data);
@@ -89,7 +89,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     store_id: z.string().optional().describe('Filter by store ID'),
     limit: z.number().int().min(1).max(100).optional().describe('Max results'),
   }, async ({ store_id, limit }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/customers${qs({ 'page[size]': limit ?? 10, store_id })}`);
+    const data = await call('GET', `/v1/customers${qs({ 'page[size]': limit ?? 10, store_id })}`);
     const items = extractListData(data);
     if (!items.length) return text('No customers found.');
     const lines = items.map((c: any) => `• ${c.id} — ${c.name} (${c.email}) [${c.status}]`);
@@ -99,7 +99,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('get_customer', 'Get a specific customer', {
     customer_id: z.string().describe('Customer ID'),
   }, async ({ customer_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/customers/${customer_id}`);
+    const data = await call('GET', `/v1/customers/${customer_id}`);
     return text(JSON.stringify(extractData(data), null, 2));
   });
 
@@ -108,7 +108,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('list_products', 'List products', {
     store_id: z.string().optional().describe('Filter by store ID'),
   }, async ({ store_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/products${qs({ store_id })}`);
+    const data = await call('GET', `/v1/products${qs({ store_id })}`);
     const items = extractListData(data);
     if (!items.length) return text('No products found.');
     const lines = items.map((p: any) => `• ${p.id} — ${p.name} [${p.status}] ${p.price_formatted}`);
@@ -121,7 +121,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     store_id: z.string().optional().describe('Filter by store ID'),
     limit: z.number().int().min(1).max(100).optional().describe('Max results'),
   }, async ({ store_id, limit }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/orders${qs({ 'page[size]': limit ?? 10, store_id })}`);
+    const data = await call('GET', `/v1/orders${qs({ 'page[size]': limit ?? 10, store_id })}`);
     const items = extractListData(data);
     if (!items.length) return text('No orders found.');
     const lines = items.map((o: any) => `• ${o.id} — ${o.user_name} ${o.total_formatted} [${o.status}]`);
@@ -131,7 +131,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('get_order', 'Get a specific order', {
     order_id: z.string().describe('Order ID'),
   }, async ({ order_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/orders/${order_id}`);
+    const data = await call('GET', `/v1/orders/${order_id}`);
     return text(JSON.stringify(extractData(data), null, 2));
   });
 
@@ -142,7 +142,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     status: z.enum(['on_trial', 'active', 'paused', 'past_due', 'unpaid', 'cancelled', 'expired']).optional().describe('Filter by status'),
     limit: z.number().int().min(1).max(100).optional().describe('Max results'),
   }, async ({ store_id, status, limit }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/subscriptions${qs({ 'page[size]': limit ?? 10, store_id, status })}`);
+    const data = await call('GET', `/v1/subscriptions${qs({ 'page[size]': limit ?? 10, store_id, status })}`);
     const items = extractListData(data);
     if (!items.length) return text('No subscriptions found.');
     const lines = items.map((s: any) => `• ${s.id} — ${s.product_name} [${s.status}]`);
@@ -152,14 +152,14 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('get_subscription', 'Get a specific subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/subscriptions/${subscription_id}`);
+    const data = await call('GET', `/v1/subscriptions/${subscription_id}`);
     return text(JSON.stringify(extractData(data), null, 2));
   });
 
   server.tool('cancel_subscription', 'Cancel a subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('DELETE', `/lemonsqueezy/v1/subscriptions/${subscription_id}`);
+    const data = await call('DELETE', `/v1/subscriptions/${subscription_id}`);
     const item = extractData(data);
     return text(`Cancelled subscription ${item.id} [${item.status}]`);
   });
@@ -168,7 +168,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     subscription_id: z.string().describe('Subscription ID'),
     mode: z.enum(['void', 'free']).optional().describe('Pause mode (default: void)'),
   }, async ({ subscription_id, mode }) => {
-    const data = await call('PATCH', `/lemonsqueezy/v1/subscriptions/${subscription_id}`, {
+    const data = await call('PATCH', `/v1/subscriptions/${subscription_id}`, {
       data: { type: 'subscriptions', id: subscription_id, attributes: { pause: { mode: mode ?? 'void' } } },
     });
     const item = extractData(data);
@@ -178,7 +178,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('resume_subscription', 'Resume a paused subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('PATCH', `/lemonsqueezy/v1/subscriptions/${subscription_id}`, {
+    const data = await call('PATCH', `/v1/subscriptions/${subscription_id}`, {
       data: { type: 'subscriptions', id: subscription_id, attributes: { pause: null } },
     });
     const item = extractData(data);
@@ -194,7 +194,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     amount_type: z.enum(['percent', 'fixed']).describe('Amount type'),
     store_id: z.string().describe('Store ID'),
   }, async ({ name, code, amount, amount_type, store_id }) => {
-    const data = await call('POST', '/lemonsqueezy/v1/discounts', {
+    const data = await call('POST', '/v1/discounts', {
       data: {
         type: 'discounts',
         attributes: { name, code, amount, amount_type },
@@ -208,7 +208,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('list_discounts', 'List discounts', {
     store_id: z.string().optional().describe('Filter by store ID'),
   }, async ({ store_id }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/discounts${qs({ store_id })}`);
+    const data = await call('GET', `/v1/discounts${qs({ store_id })}`);
     const items = extractListData(data);
     if (!items.length) return text('No discounts found.');
     const lines = items.map((d: any) => `• ${d.id} — ${d.name} (${d.code}) [${d.status}]`);
@@ -218,7 +218,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
   server.tool('delete_discount', 'Delete a discount', {
     discount_id: z.string().describe('Discount ID'),
   }, async ({ discount_id }) => {
-    await call('DELETE', `/lemonsqueezy/v1/discounts/${discount_id}`);
+    await call('DELETE', `/v1/discounts/${discount_id}`);
     return text(`Deleted discount ${discount_id}`);
   });
 
@@ -228,7 +228,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     store_id: z.string().optional().describe('Filter by store ID'),
     status: z.enum(['inactive', 'active', 'expired', 'disabled']).optional().describe('Filter by status'),
   }, async ({ store_id, status }) => {
-    const data = await call('GET', `/lemonsqueezy/v1/license-keys${qs({ store_id, status })}`);
+    const data = await call('GET', `/v1/license-keys${qs({ store_id, status })}`);
     const items = extractListData(data);
     if (!items.length) return text('No license keys found.');
     const lines = items.map((l: any) => `• ${l.id} — ${l.key_short} [${l.status}]`);
@@ -242,7 +242,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
     variant_id: z.string().describe('Variant ID'),
     custom_price: z.number().optional().describe('Custom price in cents'),
   }, async ({ store_id, variant_id, custom_price }) => {
-    const data = await call('POST', '/lemonsqueezy/v1/checkouts', {
+    const data = await call('POST', '/v1/checkouts', {
       data: {
         type: 'checkouts',
         attributes: { custom_price },
@@ -267,7 +267,7 @@ export function registerLemonSqueezyTools(server: McpServer, baseUrl: string = '
 
     for (const type of types) {
       try {
-        const data = await call('GET', `/lemonsqueezy/v1/${type}`) as any;
+        const data = await call('GET', `/v1/${type}`) as any;
         const items = extractListData(data);
         const matches = items.filter((item: any) => {
           const str = JSON.stringify(item).toLowerCase();

--- a/packages/adapters/adapter-paddle/adapter.json
+++ b/packages/adapters/adapter-paddle/adapter.json
@@ -3,7 +3,7 @@
   "name": "Paddle API",
   "description": "Paddle Billing subscriptions, transactions, and revenue management mock adapter",
   "type": "api-mock",
-  "basePath": "/paddle",
+  "basePath": "",
   "versions": ["1"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://developer.paddle.com",

--- a/packages/adapters/adapter-paddle/scripts/paddle-codegen.ts
+++ b/packages/adapters/adapter-paddle/scripts/paddle-codegen.ts
@@ -584,7 +584,7 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const description = operation.summary ?? operation.description ?? '';
 
       // Convert {param} to :param for Fastify
-      const fastifyPath = '/paddle' + specPath.replace(/\{([^}]+)\}/g, ':$1');
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, ':$1');
 
       const resource = detectPaddleResource(specPath);
       const op = detectPaddleOperation(specPath, method);

--- a/packages/adapters/adapter-paddle/src/__tests__/paddle-adapter.test.ts
+++ b/packages/adapters/adapter-paddle/src/__tests__/paddle-adapter.test.ts
@@ -18,7 +18,7 @@ describe('PaddleAdapter', () => {
   // ── Metadata ────────────────────────────────────────────────────────────────
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('paddle');
-    expect(adapter.basePath).toBe('/paddle');
+    expect(adapter.basePath).toBe('');
   });
 
   it('should return endpoint definitions', () => {
@@ -34,7 +34,7 @@ describe('PaddleAdapter', () => {
   it('should create a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'test@example.com', name: 'Test User' }),
     });
@@ -51,7 +51,7 @@ describe('PaddleAdapter', () => {
   it('should list customers', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/paddle/customers',
+      url: '/customers',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -66,7 +66,7 @@ describe('PaddleAdapter', () => {
     // Create first
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'retrieve@example.com', name: 'Retrieve Test' }),
     });
@@ -75,7 +75,7 @@ describe('PaddleAdapter', () => {
     // Retrieve
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/paddle/customers/${customerId}`,
+      url: `/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -86,7 +86,7 @@ describe('PaddleAdapter', () => {
   it('should update a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/customers',
+      url: '/customers',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ email: 'update@example.com', name: 'Before Update' }),
     });
@@ -94,7 +94,7 @@ describe('PaddleAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'PATCH',
-      url: `/paddle/customers/${customerId}`,
+      url: `/customers/${customerId}`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'After Update' }),
     });
@@ -107,7 +107,7 @@ describe('PaddleAdapter', () => {
   it('should return 404 for non-existent customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/paddle/customers/ctm_nonexistent',
+      url: '/customers/ctm_nonexistent',
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -118,7 +118,7 @@ describe('PaddleAdapter', () => {
   it('should create and list products', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/products',
+      url: '/products',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'Test Product', description: 'A test product', tax_category: 'standard' }),
     });
@@ -129,7 +129,7 @@ describe('PaddleAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/paddle/products',
+      url: '/products',
     });
     expect(listRes.json().data.length).toBeGreaterThan(0);
   });
@@ -138,7 +138,7 @@ describe('PaddleAdapter', () => {
   it('should create a price', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/prices',
+      url: '/prices',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         product_id: 'pro_test',
@@ -158,7 +158,7 @@ describe('PaddleAdapter', () => {
     // Create a subscription
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ customer_id: 'ctm_test', address_id: 'add_test', items: [] }),
     });
@@ -172,7 +172,7 @@ describe('PaddleAdapter', () => {
     // Cancel
     const cancelRes = await ts.server.inject({
       method: 'POST',
-      url: `/paddle/subscriptions/${subId}/cancel`,
+      url: `/subscriptions/${subId}/cancel`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ effective_from: 'immediately' }),
     });
@@ -184,7 +184,7 @@ describe('PaddleAdapter', () => {
   it('should pause and resume a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ customer_id: 'ctm_test', address_id: 'add_test', items: [], status: 'active' }),
     });
@@ -194,7 +194,7 @@ describe('PaddleAdapter', () => {
     // Pause
     const pauseRes = await ts.server.inject({
       method: 'POST',
-      url: `/paddle/subscriptions/${subId}/pause`,
+      url: `/subscriptions/${subId}/pause`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ effective_from: 'immediately' }),
     });
@@ -204,7 +204,7 @@ describe('PaddleAdapter', () => {
     // Resume
     const resumeRes = await ts.server.inject({
       method: 'POST',
-      url: `/paddle/subscriptions/${subId}/resume`,
+      url: `/subscriptions/${subId}/resume`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ effective_from: 'immediately' }),
     });
@@ -216,7 +216,7 @@ describe('PaddleAdapter', () => {
   it('should create and retrieve a discount', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/discounts',
+      url: '/discounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         description: '20% off',
@@ -233,7 +233,7 @@ describe('PaddleAdapter', () => {
     // Retrieve
     const getRes = await ts.server.inject({
       method: 'GET',
-      url: `/paddle/discounts/${discount.id}`,
+      url: `/discounts/${discount.id}`,
     });
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().data.id).toBe(discount.id);
@@ -243,7 +243,7 @@ describe('PaddleAdapter', () => {
   it('should create a transaction', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/paddle/transactions',
+      url: '/transactions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         items: [{ price_id: 'pri_test', quantity: 1 }],
@@ -271,7 +271,7 @@ describe('PaddleAdapter', () => {
     }]]) as any;
 
     const seededTs = await buildTestServer(adapter, seedData);
-    const res = await seededTs.server.inject({ method: 'GET', url: '/paddle/customers' });
+    const res = await seededTs.server.inject({ method: 'GET', url: '/customers' });
     const customers = res.json().data;
     expect(customers).toContainEqual(expect.objectContaining({ id: 'ctm_seed1' }));
     await seededTs.close();

--- a/packages/adapters/adapter-paddle/src/generated/meta.ts
+++ b/packages/adapters/adapter-paddle/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-paddle generate
 // Paddle OpenAPI spec version: 1.0
-// Generated at: 2026-03-13T10:59:54.876Z
+// Generated at: 2026-03-20T11:03:12.324Z
 
 export const PADDLE_SPEC_VERSION = "1.0";
-export const PADDLE_SPEC_GENERATED_AT = "2026-03-13T10:59:54.876Z";
+export const PADDLE_SPEC_GENERATED_AT = "2026-03-20T11:03:12.324Z";

--- a/packages/adapters/adapter-paddle/src/generated/routes.ts
+++ b/packages/adapters/adapter-paddle/src/generated/routes.ts
@@ -19,7 +19,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/addresses",
+    fastifyPath: "/customers/:customer_id/addresses",
     stripePath: "/customers/{customer_id}/addresses",
     resource: "addresses",
     operation: "list",
@@ -30,7 +30,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/customers/:customer_id/addresses",
+    fastifyPath: "/customers/:customer_id/addresses",
     stripePath: "/customers/{customer_id}/addresses",
     resource: "addresses",
     operation: "create",
@@ -41,7 +41,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/addresses/:address_id",
+    fastifyPath: "/customers/:customer_id/addresses/:address_id",
     stripePath: "/customers/{customer_id}/addresses/{address_id}",
     resource: "addresses",
     operation: "retrieve",
@@ -52,7 +52,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/customers/:customer_id/addresses/:address_id",
+    fastifyPath: "/customers/:customer_id/addresses/:address_id",
     stripePath: "/customers/{customer_id}/addresses/{address_id}",
     resource: "addresses",
     operation: "update",
@@ -63,7 +63,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/adjustments",
+    fastifyPath: "/adjustments",
     stripePath: "/adjustments",
     resource: "adjustments",
     operation: "list",
@@ -73,7 +73,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/adjustments",
+    fastifyPath: "/adjustments",
     stripePath: "/adjustments",
     resource: "adjustments",
     operation: "create",
@@ -83,7 +83,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/adjustments/:adjustment_id/credit-note",
+    fastifyPath: "/adjustments/:adjustment_id/credit-note",
     stripePath: "/adjustments/{adjustment_id}/credit-note",
     resource: "adjustments",
     operation: "action",
@@ -94,7 +94,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/businesses",
+    fastifyPath: "/customers/:customer_id/businesses",
     stripePath: "/customers/{customer_id}/businesses",
     resource: "businesses",
     operation: "list",
@@ -105,7 +105,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/customers/:customer_id/businesses",
+    fastifyPath: "/customers/:customer_id/businesses",
     stripePath: "/customers/{customer_id}/businesses",
     resource: "businesses",
     operation: "create",
@@ -116,7 +116,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/businesses/:business_id",
+    fastifyPath: "/customers/:customer_id/businesses/:business_id",
     stripePath: "/customers/{customer_id}/businesses/{business_id}",
     resource: "businesses",
     operation: "retrieve",
@@ -127,7 +127,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/customers/:customer_id/businesses/:business_id",
+    fastifyPath: "/customers/:customer_id/businesses/:business_id",
     stripePath: "/customers/{customer_id}/businesses/{business_id}",
     resource: "businesses",
     operation: "update",
@@ -138,7 +138,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/client-tokens",
+    fastifyPath: "/client-tokens",
     stripePath: "/client-tokens",
     resource: "client_tokens",
     operation: "list",
@@ -148,7 +148,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/client-tokens",
+    fastifyPath: "/client-tokens",
     stripePath: "/client-tokens",
     resource: "client_tokens",
     operation: "create",
@@ -158,7 +158,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/client-tokens/:client_token_id",
+    fastifyPath: "/client-tokens/:client_token_id",
     stripePath: "/client-tokens/{client_token_id}",
     resource: "client_tokens",
     operation: "retrieve",
@@ -169,7 +169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/client-tokens/:client_token_id",
+    fastifyPath: "/client-tokens/:client_token_id",
     stripePath: "/client-tokens/{client_token_id}",
     resource: "client_tokens",
     operation: "update",
@@ -180,7 +180,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "list",
@@ -190,7 +190,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/customers",
+    fastifyPath: "/customers",
     stripePath: "/customers",
     resource: "customers",
     operation: "create",
@@ -200,7 +200,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer_id}",
     resource: "customers",
     operation: "retrieve",
@@ -211,7 +211,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/customers/:customer_id",
+    fastifyPath: "/customers/:customer_id",
     stripePath: "/customers/{customer_id}",
     resource: "customers",
     operation: "update",
@@ -222,7 +222,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/credit-balances",
+    fastifyPath: "/customers/:customer_id/credit-balances",
     stripePath: "/customers/{customer_id}/credit-balances",
     resource: "credit_balances",
     operation: "list",
@@ -232,7 +232,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/customers/:customer_id/auth-token",
+    fastifyPath: "/customers/:customer_id/auth-token",
     stripePath: "/customers/{customer_id}/auth-token",
     resource: "customers",
     operation: "action",
@@ -243,7 +243,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/customers/:customer_id/portal-sessions",
+    fastifyPath: "/customers/:customer_id/portal-sessions",
     stripePath: "/customers/{customer_id}/portal-sessions",
     resource: "portal_sessions",
     operation: "action",
@@ -253,7 +253,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/discount-groups",
+    fastifyPath: "/discount-groups",
     stripePath: "/discount-groups",
     resource: "discount_groups",
     operation: "list",
@@ -263,7 +263,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/discount-groups",
+    fastifyPath: "/discount-groups",
     stripePath: "/discount-groups",
     resource: "discount_groups",
     operation: "create",
@@ -273,7 +273,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/discount-groups/:discount_group_id",
+    fastifyPath: "/discount-groups/:discount_group_id",
     stripePath: "/discount-groups/{discount_group_id}",
     resource: "discount_groups",
     operation: "retrieve",
@@ -284,7 +284,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/discount-groups/:discount_group_id",
+    fastifyPath: "/discount-groups/:discount_group_id",
     stripePath: "/discount-groups/{discount_group_id}",
     resource: "discount_groups",
     operation: "update",
@@ -295,7 +295,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/discounts",
+    fastifyPath: "/discounts",
     stripePath: "/discounts",
     resource: "discounts",
     operation: "list",
@@ -305,7 +305,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/discounts",
+    fastifyPath: "/discounts",
     stripePath: "/discounts",
     resource: "discounts",
     operation: "create",
@@ -315,7 +315,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/discounts/:discount_id",
+    fastifyPath: "/discounts/:discount_id",
     stripePath: "/discounts/{discount_id}",
     resource: "discounts",
     operation: "retrieve",
@@ -326,7 +326,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/discounts/:discount_id",
+    fastifyPath: "/discounts/:discount_id",
     stripePath: "/discounts/{discount_id}",
     resource: "discounts",
     operation: "update",
@@ -337,7 +337,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/event-types",
+    fastifyPath: "/event-types",
     stripePath: "/event-types",
     resource: "event_types",
     operation: "list",
@@ -346,7 +346,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/events",
+    fastifyPath: "/events",
     stripePath: "/events",
     resource: "events",
     operation: "list",
@@ -356,7 +356,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/ips",
+    fastifyPath: "/ips",
     stripePath: "/ips",
     resource: "ips",
     operation: "list",
@@ -365,7 +365,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/notification-settings",
+    fastifyPath: "/notification-settings",
     stripePath: "/notification-settings",
     resource: "notification_settings",
     operation: "list",
@@ -375,7 +375,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/notification-settings",
+    fastifyPath: "/notification-settings",
     stripePath: "/notification-settings",
     resource: "notification_settings",
     operation: "create",
@@ -385,7 +385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/notification-settings/:notification_setting_id",
+    fastifyPath: "/notification-settings/:notification_setting_id",
     stripePath: "/notification-settings/{notification_setting_id}",
     resource: "notification_settings",
     operation: "retrieve",
@@ -396,7 +396,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/notification-settings/:notification_setting_id",
+    fastifyPath: "/notification-settings/:notification_setting_id",
     stripePath: "/notification-settings/{notification_setting_id}",
     resource: "notification_settings",
     operation: "update",
@@ -407,7 +407,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/paddle/notification-settings/:notification_setting_id",
+    fastifyPath: "/notification-settings/:notification_setting_id",
     stripePath: "/notification-settings/{notification_setting_id}",
     resource: "notification_settings",
     operation: "delete",
@@ -418,7 +418,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/notifications",
+    fastifyPath: "/notifications",
     stripePath: "/notifications",
     resource: "notifications",
     operation: "list",
@@ -428,7 +428,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/notifications/:notification_id",
+    fastifyPath: "/notifications/:notification_id",
     stripePath: "/notifications/{notification_id}",
     resource: "notifications",
     operation: "retrieve",
@@ -439,7 +439,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/notifications/:notification_id/logs",
+    fastifyPath: "/notifications/:notification_id/logs",
     stripePath: "/notifications/{notification_id}/logs",
     resource: "notifications",
     operation: "list",
@@ -450,7 +450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/notifications/:notification_id/replay",
+    fastifyPath: "/notifications/:notification_id/replay",
     stripePath: "/notifications/{notification_id}/replay",
     resource: "notifications",
     operation: "action",
@@ -461,7 +461,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/payment-methods",
+    fastifyPath: "/customers/:customer_id/payment-methods",
     stripePath: "/customers/{customer_id}/payment-methods",
     resource: "payment_methods",
     operation: "list",
@@ -471,7 +471,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/customers/:customer_id/payment-methods/:payment_method_id",
+    fastifyPath: "/customers/:customer_id/payment-methods/:payment_method_id",
     stripePath: "/customers/{customer_id}/payment-methods/{payment_method_id}",
     resource: "payment_methods",
     operation: "retrieve",
@@ -481,7 +481,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/paddle/customers/:customer_id/payment-methods/:payment_method_id",
+    fastifyPath: "/customers/:customer_id/payment-methods/:payment_method_id",
     stripePath: "/customers/{customer_id}/payment-methods/{payment_method_id}",
     resource: "payment_methods",
     operation: "delete",
@@ -491,7 +491,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/prices",
+    fastifyPath: "/prices",
     stripePath: "/prices",
     resource: "prices",
     operation: "list",
@@ -501,7 +501,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/prices",
+    fastifyPath: "/prices",
     stripePath: "/prices",
     resource: "prices",
     operation: "create",
@@ -511,7 +511,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/prices/:price_id",
+    fastifyPath: "/prices/:price_id",
     stripePath: "/prices/{price_id}",
     resource: "prices",
     operation: "retrieve",
@@ -522,7 +522,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/prices/:price_id",
+    fastifyPath: "/prices/:price_id",
     stripePath: "/prices/{price_id}",
     resource: "prices",
     operation: "update",
@@ -533,7 +533,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/pricing-preview",
+    fastifyPath: "/pricing-preview",
     stripePath: "/pricing-preview",
     resource: "pricing_preview",
     operation: "create",
@@ -542,7 +542,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/products",
+    fastifyPath: "/products",
     stripePath: "/products",
     resource: "products",
     operation: "list",
@@ -552,7 +552,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/products",
+    fastifyPath: "/products",
     stripePath: "/products",
     resource: "products",
     operation: "create",
@@ -562,7 +562,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/products/:product_id",
+    fastifyPath: "/products/:product_id",
     stripePath: "/products/{product_id}",
     resource: "products",
     operation: "retrieve",
@@ -573,7 +573,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/products/:product_id",
+    fastifyPath: "/products/:product_id",
     stripePath: "/products/{product_id}",
     resource: "products",
     operation: "update",
@@ -584,7 +584,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/reports",
+    fastifyPath: "/reports",
     stripePath: "/reports",
     resource: "reports",
     operation: "list",
@@ -594,7 +594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/reports",
+    fastifyPath: "/reports",
     stripePath: "/reports",
     resource: "reports",
     operation: "create",
@@ -604,7 +604,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/reports/:report_id",
+    fastifyPath: "/reports/:report_id",
     stripePath: "/reports/{report_id}",
     resource: "reports",
     operation: "retrieve",
@@ -615,7 +615,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/reports/:report_id/download-url",
+    fastifyPath: "/reports/:report_id/download-url",
     stripePath: "/reports/{report_id}/download-url",
     resource: "reports",
     operation: "action",
@@ -626,7 +626,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulation-types",
+    fastifyPath: "/simulation-types",
     stripePath: "/simulation-types",
     resource: "simulation_types",
     operation: "list",
@@ -635,7 +635,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations",
+    fastifyPath: "/simulations",
     stripePath: "/simulations",
     resource: "simulations",
     operation: "list",
@@ -644,7 +644,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/simulations",
+    fastifyPath: "/simulations",
     stripePath: "/simulations",
     resource: "simulations",
     operation: "create",
@@ -653,7 +653,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations/:simulation_id",
+    fastifyPath: "/simulations/:simulation_id",
     stripePath: "/simulations/{simulation_id}",
     resource: "simulations",
     operation: "retrieve",
@@ -663,7 +663,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/simulations/:simulation_id",
+    fastifyPath: "/simulations/:simulation_id",
     stripePath: "/simulations/{simulation_id}",
     resource: "simulations",
     operation: "update",
@@ -673,7 +673,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs",
+    fastifyPath: "/simulations/:simulation_id/runs",
     stripePath: "/simulations/{simulation_id}/runs",
     resource: "simulations",
     operation: "list",
@@ -683,7 +683,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs",
+    fastifyPath: "/simulations/:simulation_id/runs",
     stripePath: "/simulations/{simulation_id}/runs",
     resource: "simulations",
     operation: "create",
@@ -693,7 +693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs/:simulation_run_id",
+    fastifyPath: "/simulations/:simulation_id/runs/:simulation_run_id",
     stripePath: "/simulations/{simulation_id}/runs/{simulation_run_id}",
     resource: "simulations",
     operation: "retrieve",
@@ -703,7 +703,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs/:simulation_run_id/events",
+    fastifyPath: "/simulations/:simulation_id/runs/:simulation_run_id/events",
     stripePath: "/simulations/{simulation_id}/runs/{simulation_run_id}/events",
     resource: "simulations",
     operation: "list",
@@ -713,7 +713,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs/:simulation_run_id/events/:simulation_event_id",
+    fastifyPath: "/simulations/:simulation_id/runs/:simulation_run_id/events/:simulation_event_id",
     stripePath: "/simulations/{simulation_id}/runs/{simulation_run_id}/events/{simulation_event_id}",
     resource: "simulations",
     operation: "retrieve",
@@ -723,7 +723,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/simulations/:simulation_id/runs/:simulation_run_id/events/:simulation_event_id/replay",
+    fastifyPath: "/simulations/:simulation_id/runs/:simulation_run_id/events/:simulation_event_id/replay",
     stripePath: "/simulations/{simulation_id}/runs/{simulation_run_id}/events/{simulation_event_id}/replay",
     resource: "simulations",
     operation: "action",
@@ -733,7 +733,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -743,7 +743,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -754,7 +754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "update",
@@ -765,7 +765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/cancel",
+    fastifyPath: "/subscriptions/:subscription_id/cancel",
     stripePath: "/subscriptions/{subscription_id}/cancel",
     resource: "subscriptions",
     operation: "action",
@@ -776,7 +776,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/pause",
+    fastifyPath: "/subscriptions/:subscription_id/pause",
     stripePath: "/subscriptions/{subscription_id}/pause",
     resource: "subscriptions",
     operation: "action",
@@ -787,7 +787,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/resume",
+    fastifyPath: "/subscriptions/:subscription_id/resume",
     stripePath: "/subscriptions/{subscription_id}/resume",
     resource: "subscriptions",
     operation: "action",
@@ -798,7 +798,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/activate",
+    fastifyPath: "/subscriptions/:subscription_id/activate",
     stripePath: "/subscriptions/{subscription_id}/activate",
     resource: "subscriptions",
     operation: "action",
@@ -809,7 +809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/update-payment-method-transaction",
+    fastifyPath: "/subscriptions/:subscription_id/update-payment-method-transaction",
     stripePath: "/subscriptions/{subscription_id}/update-payment-method-transaction",
     resource: "subscriptions",
     operation: "action",
@@ -820,7 +820,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/preview",
+    fastifyPath: "/subscriptions/:subscription_id/preview",
     stripePath: "/subscriptions/{subscription_id}/preview",
     resource: "subscriptions",
     operation: "action",
@@ -831,7 +831,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/charge",
+    fastifyPath: "/subscriptions/:subscription_id/charge",
     stripePath: "/subscriptions/{subscription_id}/charge",
     resource: "subscriptions",
     operation: "action",
@@ -842,7 +842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/subscriptions/:subscription_id/charge/preview",
+    fastifyPath: "/subscriptions/:subscription_id/charge/preview",
     stripePath: "/subscriptions/{subscription_id}/charge/preview",
     resource: "subscriptions",
     operation: "action",
@@ -853,7 +853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/transactions",
+    fastifyPath: "/transactions",
     stripePath: "/transactions",
     resource: "transactions",
     operation: "list",
@@ -863,7 +863,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/transactions",
+    fastifyPath: "/transactions",
     stripePath: "/transactions",
     resource: "transactions",
     operation: "create",
@@ -873,7 +873,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/transactions/:transaction_id",
+    fastifyPath: "/transactions/:transaction_id",
     stripePath: "/transactions/{transaction_id}",
     resource: "transactions",
     operation: "retrieve",
@@ -884,7 +884,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PATCH",
-    fastifyPath: "/paddle/transactions/:transaction_id",
+    fastifyPath: "/transactions/:transaction_id",
     stripePath: "/transactions/{transaction_id}",
     resource: "transactions",
     operation: "update",
@@ -895,7 +895,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/transactions/preview",
+    fastifyPath: "/transactions/preview",
     stripePath: "/transactions/preview",
     resource: "transactions",
     operation: "action",
@@ -905,7 +905,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/paddle/transactions/:transaction_id/revise",
+    fastifyPath: "/transactions/:transaction_id/revise",
     stripePath: "/transactions/{transaction_id}/revise",
     resource: "transactions",
     operation: "action",
@@ -916,7 +916,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/paddle/transactions/:transaction_id/invoice",
+    fastifyPath: "/transactions/:transaction_id/invoice",
     stripePath: "/transactions/{transaction_id}/invoice",
     resource: "transactions",
     operation: "action",

--- a/packages/adapters/adapter-paddle/src/mcp.ts
+++ b/packages/adapters/adapter-paddle/src/mcp.ts
@@ -45,7 +45,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('list_products', 'List Paddle products', {
     per_page: z.number().optional().describe('Results per page (1-200)'),
   }, async ({ per_page }) => {
-    const data = await call('GET', `/paddle/products${qs({ per_page: per_page ?? 50 })}`) as any;
+    const data = await call('GET', `/products${qs({ per_page: per_page ?? 50 })}`) as any;
     if (!data.data?.length) return text('No products found.');
     const lines = data.data.map((p: any) => `- ${p.id} — ${p.name} [${p.status}]`);
     return text(`Products (${data.data.length}):\n${lines.join('\n')}`);
@@ -57,7 +57,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     tax_category: z.string().optional().describe('Tax category (default: standard)'),
     custom_data: z.record(z.string()).optional().describe('Custom metadata'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/products', params) as any;
+    const data = await call('POST', '/products', params) as any;
     return text(`Created product ${data.data.id}: ${data.data.name}`);
   });
 
@@ -65,7 +65,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('list_prices', 'List Paddle prices', {
     product_id: z.string().optional().describe('Filter by product ID'),
   }, async ({ product_id }) => {
-    const data = await call('GET', `/paddle/prices${qs({ product_id })}`) as any;
+    const data = await call('GET', `/prices${qs({ product_id })}`) as any;
     if (!data.data?.length) return text('No prices found.');
     const lines = data.data.map((p: any) => `- ${p.id} — ${p.description ?? p.name ?? 'unnamed'} [${p.status}]`);
     return text(`Prices (${data.data.length}):\n${lines.join('\n')}`);
@@ -83,7 +83,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
       frequency: z.number().int().positive(),
     }).optional().describe('Billing cycle (omit for one-time prices)'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/prices', params) as any;
+    const data = await call('POST', '/prices', params) as any;
     return text(`Created price ${data.data.id}`);
   });
 
@@ -92,7 +92,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     email: z.string().optional().describe('Filter by email'),
     per_page: z.number().optional().describe('Results per page'),
   }, async ({ email, per_page }) => {
-    const data = await call('GET', `/paddle/customers${qs({ email, per_page })}`) as any;
+    const data = await call('GET', `/customers${qs({ email, per_page })}`) as any;
     if (!data.data?.length) return text('No customers found.');
     const lines = data.data.map((c: any) => `- ${c.id} — ${c.name ?? '(no name)'} (${c.email})`);
     return text(`Customers (${data.data.length}):\n${lines.join('\n')}`);
@@ -104,7 +104,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     locale: z.string().optional().describe('Locale (e.g., en)'),
     custom_data: z.record(z.string()).optional().describe('Custom metadata'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/customers', params) as any;
+    const data = await call('POST', '/customers', params) as any;
     return text(`Created customer ${data.data.id}: ${data.data.name ?? data.data.email}`);
   });
 
@@ -113,7 +113,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     customer_id: z.string().optional().describe('Filter by customer ID'),
     status: z.enum(['active', 'canceled', 'past_due', 'paused', 'trialing']).optional(),
   }, async ({ customer_id, status }) => {
-    const data = await call('GET', `/paddle/subscriptions${qs({ customer_id, status })}`) as any;
+    const data = await call('GET', `/subscriptions${qs({ customer_id, status })}`) as any;
     if (!data.data?.length) return text('No subscriptions found.');
     const lines = data.data.map((s: any) => `- ${s.id} — customer ${s.customer_id} [${s.status}]`);
     return text(`Subscriptions (${data.data.length}):\n${lines.join('\n')}`);
@@ -123,7 +123,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     subscription_id: z.string().describe('Subscription ID'),
     effective_from: z.enum(['immediately', 'next_billing_period']).optional().describe('When cancellation takes effect'),
   }, async ({ subscription_id, effective_from }) => {
-    const data = await call('POST', `/paddle/subscriptions/${subscription_id}/cancel`, { effective_from }) as any;
+    const data = await call('POST', `/subscriptions/${subscription_id}/cancel`, { effective_from }) as any;
     return text(`Cancelled subscription ${data.data.id} [${data.data.status}]`);
   });
 
@@ -131,7 +131,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     subscription_id: z.string().describe('Subscription ID'),
     effective_from: z.enum(['immediately', 'next_billing_period']).optional(),
   }, async ({ subscription_id, effective_from }) => {
-    const data = await call('POST', `/paddle/subscriptions/${subscription_id}/pause`, { effective_from }) as any;
+    const data = await call('POST', `/subscriptions/${subscription_id}/pause`, { effective_from }) as any;
     return text(`Paused subscription ${data.data.id} [${data.data.status}]`);
   });
 
@@ -139,7 +139,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     subscription_id: z.string().describe('Subscription ID'),
     effective_from: z.enum(['immediately']).optional(),
   }, async ({ subscription_id, effective_from }) => {
-    const data = await call('POST', `/paddle/subscriptions/${subscription_id}/resume`, { effective_from }) as any;
+    const data = await call('POST', `/subscriptions/${subscription_id}/resume`, { effective_from }) as any;
     return text(`Resumed subscription ${data.data.id} [${data.data.status}]`);
   });
 
@@ -149,7 +149,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     subscription_id: z.string().optional().describe('Filter by subscription ID'),
     status: z.enum(['draft', 'ready', 'billed', 'paid', 'completed', 'canceled', 'past_due']).optional(),
   }, async ({ customer_id, subscription_id, status }) => {
-    const data = await call('GET', `/paddle/transactions${qs({ customer_id, subscription_id, status })}`) as any;
+    const data = await call('GET', `/transactions${qs({ customer_id, subscription_id, status })}`) as any;
     if (!data.data?.length) return text('No transactions found.');
     const lines = data.data.map((t: any) => `- ${t.id} — ${t.currency_code} [${t.status}]`);
     return text(`Transactions (${data.data.length}):\n${lines.join('\n')}`);
@@ -162,7 +162,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     })).describe('Line items'),
     customer_id: z.string().optional().describe('Customer ID'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/transactions', params) as any;
+    const data = await call('POST', '/transactions', params) as any;
     return text(`Created transaction ${data.data.id} [${data.data.status}]`);
   });
 
@@ -175,7 +175,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
     code: z.string().optional().describe('Discount code'),
     recur: z.boolean().optional().describe('Apply to recurring payments'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/discounts', params) as any;
+    const data = await call('POST', '/discounts', params) as any;
     return text(`Created discount ${data.data.id}: ${data.data.description}`);
   });
 
@@ -190,7 +190,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
       amount: z.string().optional().describe('Amount (for partial adjustments)'),
     })).describe('Items to adjust'),
   }, async (params) => {
-    const data = await call('POST', '/paddle/adjustments', params) as any;
+    const data = await call('POST', '/adjustments', params) as any;
     return text(`Created adjustment ${data.data.id} [${data.data.status}]`);
   });
 
@@ -204,7 +204,7 @@ export function registerPaddleTools(server: McpServer, baseUrl: string = 'http:/
 
     for (const type of types) {
       try {
-        const data = await call('GET', `/paddle/${type}`) as any;
+        const data = await call('GET', `/${type}`) as any;
         if (!data.data?.length) continue;
         const matches = data.data.filter((item: any) => {
           const str = JSON.stringify(item).toLowerCase();

--- a/packages/adapters/adapter-paddle/src/paddle-adapter.ts
+++ b/packages/adapters/adapter-paddle/src/paddle-adapter.ts
@@ -160,17 +160,17 @@ export class PaddleAdapter extends OpenApiMockAdapter<PaddleConfig> {
 
   private mountOverrides(store: StateStore): void {
     // Subscription lifecycle
-    this.registerOverride('POST', '/paddle/subscriptions/:subscription_id/cancel',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/cancel',
       subscriptionOverrides.buildCancelHandler(store));
-    this.registerOverride('POST', '/paddle/subscriptions/:subscription_id/pause',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/pause',
       subscriptionOverrides.buildPauseHandler(store));
-    this.registerOverride('POST', '/paddle/subscriptions/:subscription_id/resume',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/resume',
       subscriptionOverrides.buildResumeHandler(store));
-    this.registerOverride('POST', '/paddle/subscriptions/:subscription_id/activate',
+    this.registerOverride('POST', '/subscriptions/:subscription_id/activate',
       subscriptionOverrides.buildActivateHandler(store));
 
     // Transaction lifecycle
-    this.registerOverride('POST', '/paddle/transactions/:transaction_id/revise',
+    this.registerOverride('POST', '/transactions/:transaction_id/revise',
       transactionOverrides.buildReviseHandler(store));
   }
 }

--- a/packages/adapters/adapter-plaid/adapter.json
+++ b/packages/adapters/adapter-plaid/adapter.json
@@ -3,7 +3,7 @@
   "name": "Plaid API",
   "description": "Plaid banking data — accounts, transactions, auth, identity, balance, investments",
   "type": "api-mock",
-  "basePath": "/plaid",
+  "basePath": "",
   "versions": ["2020-09-14"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://plaid.com/docs/api",

--- a/packages/adapters/adapter-plaid/scripts/plaid-codegen.ts
+++ b/packages/adapters/adapter-plaid/scripts/plaid-codegen.ts
@@ -504,8 +504,8 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const httpMethod = method.toUpperCase() as ExtractedRoute['method'];
       const description = operation.summary ?? operation.description ?? '';
 
-      // Plaid has no path params, so fastifyPath is just /plaid + specPath
-      const fastifyPath = '/plaid' + specPath;
+      // Plaid has no path params, so fastifyPath is just specPath
+      const fastifyPath = specPath;
 
       const resource = detectPlaidResource(specPath);
       const op = detectPlaidOperation(specPath, httpMethod);
@@ -673,7 +673,7 @@ function generateRoutesTs(routes: ExtractedRoute[]): string {
     `export interface GeneratedRoute {`,
     `  /** HTTP method */`,
     `  method: RouteMethod;`,
-    `  /** Fastify route path with /plaid prefix */`,
+    `  /** Fastify route path */`,
     `  fastifyPath: string;`,
     `  /** Original Plaid spec path (field name is historical) */`,
     `  stripePath: string;`,

--- a/packages/adapters/adapter-plaid/src/__tests__/plaid-adapter.test.ts
+++ b/packages/adapters/adapter-plaid/src/__tests__/plaid-adapter.test.ts
@@ -23,7 +23,7 @@ describe('PlaidAdapter', () => {
       expect(adapter.id).toBe('plaid');
       expect(adapter.name).toBe('Plaid API');
       expect(adapter.type).toBe('api-mock');
-      expect(adapter.basePath).toBe('/plaid');
+      expect(adapter.basePath).toBe('');
     });
 
     it('should have versions', () => {
@@ -54,7 +54,7 @@ describe('PlaidAdapter', () => {
     it('should create a sandbox public token', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/sandbox/public_token/create',
+        url: '/sandbox/public_token/create',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           institution_id: 'ins_109508',
@@ -71,7 +71,7 @@ describe('PlaidAdapter', () => {
     it('should exchange public token for access token', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/public_token/exchange',
+        url: '/item/public_token/exchange',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ public_token: publicToken }),
       });
@@ -87,7 +87,7 @@ describe('PlaidAdapter', () => {
     it('should get item details', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/get',
+        url: '/item/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -102,7 +102,7 @@ describe('PlaidAdapter', () => {
     it('should get accounts', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/get',
+        url: '/accounts/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -125,7 +125,7 @@ describe('PlaidAdapter', () => {
     it('should get account balances', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/balance/get',
+        url: '/accounts/balance/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -138,7 +138,7 @@ describe('PlaidAdapter', () => {
       // First get all accounts to get an ID
       const allRes = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/get',
+        url: '/accounts/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -146,7 +146,7 @@ describe('PlaidAdapter', () => {
 
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/get',
+        url: '/accounts/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           access_token: accessToken,
@@ -161,7 +161,7 @@ describe('PlaidAdapter', () => {
     it('should get auth data with routing numbers', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/auth/get',
+        url: '/auth/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -176,7 +176,7 @@ describe('PlaidAdapter', () => {
     it('should get transactions', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/transactions/get',
+        url: '/transactions/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           access_token: accessToken,
@@ -202,7 +202,7 @@ describe('PlaidAdapter', () => {
     it('should paginate transactions', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/transactions/get',
+        url: '/transactions/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           access_token: accessToken,
@@ -221,7 +221,7 @@ describe('PlaidAdapter', () => {
       // Initial sync (no cursor) — returns all transactions
       const res1 = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/transactions/sync',
+        url: '/transactions/sync',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -234,7 +234,7 @@ describe('PlaidAdapter', () => {
       // Subsequent sync (with cursor) — returns empty (caught up)
       const res2 = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/transactions/sync',
+        url: '/transactions/sync',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           access_token: accessToken,
@@ -248,7 +248,7 @@ describe('PlaidAdapter', () => {
     it('should refresh transactions', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/transactions/refresh',
+        url: '/transactions/refresh',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -259,7 +259,7 @@ describe('PlaidAdapter', () => {
     it('should get identity data', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/identity/get',
+        url: '/identity/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -274,7 +274,7 @@ describe('PlaidAdapter', () => {
     it('should remove an item', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/remove',
+        url: '/item/remove',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -284,7 +284,7 @@ describe('PlaidAdapter', () => {
       // Subsequent calls should fail
       const res2 = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/get',
+        url: '/item/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: accessToken }),
       });
@@ -299,7 +299,7 @@ describe('PlaidAdapter', () => {
     it('should list institutions', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/institutions/get',
+        url: '/institutions/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ count: 10, offset: 0, country_codes: ['US'] }),
       });
@@ -312,7 +312,7 @@ describe('PlaidAdapter', () => {
     it('should get institution by ID', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/institutions/get_by_id',
+        url: '/institutions/get_by_id',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ institution_id: 'ins_109508', country_codes: ['US'] }),
       });
@@ -325,7 +325,7 @@ describe('PlaidAdapter', () => {
     it('should search institutions', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/institutions/search',
+        url: '/institutions/search',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ query: 'platypus', products: ['transactions'], country_codes: ['US'] }),
       });
@@ -342,7 +342,7 @@ describe('PlaidAdapter', () => {
     it('should get categories', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/categories/get',
+        url: '/categories/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -360,7 +360,7 @@ describe('PlaidAdapter', () => {
     it('should return error for missing access_token', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/get',
+        url: '/accounts/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -373,7 +373,7 @@ describe('PlaidAdapter', () => {
     it('should return error for invalid access_token', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/accounts/get',
+        url: '/accounts/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: 'invalid-token-12345' }),
       });
@@ -386,7 +386,7 @@ describe('PlaidAdapter', () => {
     it('should return error for missing public_token on exchange', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/public_token/exchange',
+        url: '/item/public_token/exchange',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -397,7 +397,7 @@ describe('PlaidAdapter', () => {
     it('should return error for invalid institution_id', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/institutions/get_by_id',
+        url: '/institutions/get_by_id',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ institution_id: 'ins_nonexistent' }),
       });
@@ -413,7 +413,7 @@ describe('PlaidAdapter', () => {
       // Create a new item first
       const createRes = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/sandbox/public_token/create',
+        url: '/sandbox/public_token/create',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ institution_id: 'ins_109509', initial_products: ['transactions'] }),
       });
@@ -421,7 +421,7 @@ describe('PlaidAdapter', () => {
 
       const exchangeRes = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/public_token/exchange',
+        url: '/item/public_token/exchange',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ public_token: pt }),
       });
@@ -430,7 +430,7 @@ describe('PlaidAdapter', () => {
       // Reset login
       const resetRes = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/sandbox/item/reset_login',
+        url: '/sandbox/item/reset_login',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: at }),
       });
@@ -440,7 +440,7 @@ describe('PlaidAdapter', () => {
       // Verify item now has error
       const itemRes = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/item/get',
+        url: '/item/get',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ access_token: at }),
       });
@@ -455,7 +455,7 @@ describe('PlaidAdapter', () => {
     it('should create a link token', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/plaid/link/token/create',
+        url: '/link/token/create',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           user: { client_user_id: 'user-123' },

--- a/packages/adapters/adapter-plaid/src/generated/meta.ts
+++ b/packages/adapters/adapter-plaid/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-plaid generate
 // Plaid OpenAPI spec version: 2020-09-14_1.682.2
-// Generated at: 2026-03-12T14:01:42.019Z
+// Generated at: 2026-03-20T11:03:16.583Z
 
 export const PLAID_SPEC_VERSION = "2020-09-14_1.682.2";
-export const PLAID_SPEC_GENERATED_AT = "2026-03-12T14:01:42.019Z";
+export const PLAID_SPEC_GENERATED_AT = "2026-03-20T11:03:16.583Z";

--- a/packages/adapters/adapter-plaid/src/generated/routes.ts
+++ b/packages/adapters/adapter-plaid/src/generated/routes.ts
@@ -6,7 +6,7 @@ export type RouteOperation = 'list' | 'create' | 'retrieve' | 'update' | 'delete
 export interface GeneratedRoute {
   /** HTTP method */
   method: RouteMethod;
-  /** Fastify route path with /plaid prefix */
+  /** Fastify route path */
   fastifyPath: string;
   /** Original Plaid spec path (field name is historical) */
   stripePath: string;
@@ -27,7 +27,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/create",
+    fastifyPath: "/asset_report/create",
     stripePath: "/asset_report/create",
     resource: "asset_report",
     operation: "create",
@@ -36,7 +36,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/get",
+    fastifyPath: "/asset_report/get",
     stripePath: "/asset_report/get",
     resource: "asset_report",
     operation: "retrieve",
@@ -45,7 +45,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/pdf/get",
+    fastifyPath: "/asset_report/pdf/get",
     stripePath: "/asset_report/pdf/get",
     resource: "asset_report",
     operation: "retrieve",
@@ -54,7 +54,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/refresh",
+    fastifyPath: "/asset_report/refresh",
     stripePath: "/asset_report/refresh",
     resource: "asset_report",
     operation: "action",
@@ -63,7 +63,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/filter",
+    fastifyPath: "/asset_report/filter",
     stripePath: "/asset_report/filter",
     resource: "asset_report",
     operation: "action",
@@ -72,7 +72,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/remove",
+    fastifyPath: "/asset_report/remove",
     stripePath: "/asset_report/remove",
     resource: "asset_report",
     operation: "delete",
@@ -81,7 +81,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/audit_copy/create",
+    fastifyPath: "/asset_report/audit_copy/create",
     stripePath: "/asset_report/audit_copy/create",
     resource: "asset_report",
     operation: "create",
@@ -90,7 +90,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/audit_copy/get",
+    fastifyPath: "/asset_report/audit_copy/get",
     stripePath: "/asset_report/audit_copy/get",
     resource: "asset_report",
     operation: "retrieve",
@@ -99,7 +99,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/audit_copy/pdf/get",
+    fastifyPath: "/asset_report/audit_copy/pdf/get",
     stripePath: "/asset_report/audit_copy/pdf/get",
     resource: "asset_report",
     operation: "retrieve",
@@ -108,7 +108,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/asset_report/audit_copy/remove",
+    fastifyPath: "/asset_report/audit_copy/remove",
     stripePath: "/asset_report/audit_copy/remove",
     resource: "asset_report",
     operation: "delete",
@@ -117,7 +117,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/monitoring_insights/subscribe",
+    fastifyPath: "/cra/monitoring_insights/subscribe",
     stripePath: "/cra/monitoring_insights/subscribe",
     resource: "cra",
     operation: "action",
@@ -126,7 +126,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/monitoring_insights/unsubscribe",
+    fastifyPath: "/cra/monitoring_insights/unsubscribe",
     stripePath: "/cra/monitoring_insights/unsubscribe",
     resource: "cra",
     operation: "action",
@@ -135,7 +135,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/monitoring_insights/get",
+    fastifyPath: "/cra/monitoring_insights/get",
     stripePath: "/cra/monitoring_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -144,7 +144,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/audit_copy_token/update",
+    fastifyPath: "/credit/audit_copy_token/update",
     stripePath: "/credit/audit_copy_token/update",
     resource: "credit",
     operation: "update",
@@ -153,7 +153,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/partner_insights/get",
+    fastifyPath: "/cra/partner_insights/get",
     stripePath: "/cra/partner_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -162,7 +162,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/income_insights/get",
+    fastifyPath: "/cra/check_report/income_insights/get",
     stripePath: "/cra/check_report/income_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -171,7 +171,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/base_report/get",
+    fastifyPath: "/cra/check_report/base_report/get",
     stripePath: "/cra/check_report/base_report/get",
     resource: "cra",
     operation: "retrieve",
@@ -180,7 +180,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/pdf/get",
+    fastifyPath: "/cra/check_report/pdf/get",
     stripePath: "/cra/check_report/pdf/get",
     resource: "cra",
     operation: "retrieve",
@@ -189,7 +189,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/create",
+    fastifyPath: "/cra/check_report/create",
     stripePath: "/cra/check_report/create",
     resource: "cra",
     operation: "create",
@@ -198,7 +198,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/partner_insights/get",
+    fastifyPath: "/cra/check_report/partner_insights/get",
     stripePath: "/cra/check_report/partner_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -207,7 +207,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/cashflow_insights/get",
+    fastifyPath: "/cra/check_report/cashflow_insights/get",
     stripePath: "/cra/check_report/cashflow_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -216,7 +216,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/lend_score/get",
+    fastifyPath: "/cra/check_report/lend_score/get",
     stripePath: "/cra/check_report/lend_score/get",
     resource: "cra",
     operation: "retrieve",
@@ -225,7 +225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/network_insights/get",
+    fastifyPath: "/cra/check_report/network_insights/get",
     stripePath: "/cra/check_report/network_insights/get",
     resource: "cra",
     operation: "retrieve",
@@ -234,7 +234,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/verification/get",
+    fastifyPath: "/cra/check_report/verification/get",
     stripePath: "/cra/check_report/verification/get",
     resource: "cra",
     operation: "retrieve",
@@ -243,7 +243,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/check_report/verification/pdf/get",
+    fastifyPath: "/cra/check_report/verification/pdf/get",
     stripePath: "/cra/check_report/verification/pdf/get",
     resource: "cra",
     operation: "retrieve",
@@ -252,7 +252,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/loans/applications/register",
+    fastifyPath: "/cra/loans/applications/register",
     stripePath: "/cra/loans/applications/register",
     resource: "cra",
     operation: "action",
@@ -261,7 +261,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/loans/register",
+    fastifyPath: "/cra/loans/register",
     stripePath: "/cra/loans/register",
     resource: "cra",
     operation: "action",
@@ -270,7 +270,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/loans/update",
+    fastifyPath: "/cra/loans/update",
     stripePath: "/cra/loans/update",
     resource: "cra",
     operation: "update",
@@ -279,7 +279,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cra/loans/unregister",
+    fastifyPath: "/cra/loans/unregister",
     stripePath: "/cra/loans/unregister",
     resource: "cra",
     operation: "action",
@@ -288,7 +288,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/consumer_report/pdf/get",
+    fastifyPath: "/consumer_report/pdf/get",
     stripePath: "/consumer_report/pdf/get",
     resource: "consumer_report",
     operation: "retrieve",
@@ -297,7 +297,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/oauth/token",
+    fastifyPath: "/oauth/token",
     stripePath: "/oauth/token",
     resource: "oauth",
     operation: "action",
@@ -306,7 +306,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/oauth/introspect",
+    fastifyPath: "/oauth/introspect",
     stripePath: "/oauth/introspect",
     resource: "oauth",
     operation: "action",
@@ -315,7 +315,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/oauth/revoke",
+    fastifyPath: "/oauth/revoke",
     stripePath: "/oauth/revoke",
     resource: "oauth",
     operation: "action",
@@ -324,7 +324,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/statements/list",
+    fastifyPath: "/statements/list",
     stripePath: "/statements/list",
     resource: "statements",
     operation: "list",
@@ -333,7 +333,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/statements/download",
+    fastifyPath: "/statements/download",
     stripePath: "/statements/download",
     resource: "statements",
     operation: "action",
@@ -342,7 +342,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/statements/refresh",
+    fastifyPath: "/statements/refresh",
     stripePath: "/statements/refresh",
     resource: "statements",
     operation: "action",
@@ -351,7 +351,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/consent/events/get",
+    fastifyPath: "/consent/events/get",
     stripePath: "/consent/events/get",
     resource: "consent",
     operation: "retrieve",
@@ -360,7 +360,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/activity/list",
+    fastifyPath: "/item/activity/list",
     stripePath: "/item/activity/list",
     resource: "item",
     operation: "list",
@@ -369,7 +369,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/application/list",
+    fastifyPath: "/item/application/list",
     stripePath: "/item/application/list",
     resource: "item",
     operation: "list",
@@ -378,7 +378,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/application/unlink",
+    fastifyPath: "/item/application/unlink",
     stripePath: "/item/application/unlink",
     resource: "item",
     operation: "action",
@@ -387,7 +387,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/application/scopes/update",
+    fastifyPath: "/item/application/scopes/update",
     stripePath: "/item/application/scopes/update",
     resource: "item",
     operation: "update",
@@ -396,7 +396,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/application/get",
+    fastifyPath: "/application/get",
     stripePath: "/application/get",
     resource: "application",
     operation: "retrieve",
@@ -405,7 +405,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/get",
+    fastifyPath: "/item/get",
     stripePath: "/item/get",
     resource: "item",
     operation: "retrieve",
@@ -414,7 +414,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user_account/session/get",
+    fastifyPath: "/user_account/session/get",
     stripePath: "/user_account/session/get",
     resource: "user_account",
     operation: "retrieve",
@@ -423,7 +423,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user_account/session/event/send",
+    fastifyPath: "/user_account/session/event/send",
     stripePath: "/user_account/session/event/send",
     resource: "user_account",
     operation: "action",
@@ -432,7 +432,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/profile/network_status/get",
+    fastifyPath: "/profile/network_status/get",
     stripePath: "/profile/network_status/get",
     resource: "profile",
     operation: "retrieve",
@@ -441,7 +441,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/network/status/get",
+    fastifyPath: "/network/status/get",
     stripePath: "/network/status/get",
     resource: "network",
     operation: "retrieve",
@@ -450,7 +450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/auth/get",
+    fastifyPath: "/auth/get",
     stripePath: "/auth/get",
     resource: "auth",
     operation: "retrieve",
@@ -459,7 +459,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/auth/verify",
+    fastifyPath: "/auth/verify",
     stripePath: "/auth/verify",
     resource: "auth",
     operation: "action",
@@ -468,7 +468,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transactions/get",
+    fastifyPath: "/transactions/get",
     stripePath: "/transactions/get",
     resource: "transactions",
     operation: "retrieve",
@@ -477,7 +477,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transactions/refresh",
+    fastifyPath: "/transactions/refresh",
     stripePath: "/transactions/refresh",
     resource: "transactions",
     operation: "action",
@@ -486,7 +486,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transactions/create",
+    fastifyPath: "/sandbox/transactions/create",
     stripePath: "/sandbox/transactions/create",
     resource: "sandbox",
     operation: "create",
@@ -495,7 +495,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cashflow_report/refresh",
+    fastifyPath: "/cashflow_report/refresh",
     stripePath: "/cashflow_report/refresh",
     resource: "cashflow_report",
     operation: "action",
@@ -504,7 +504,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cashflow_report/get",
+    fastifyPath: "/cashflow_report/get",
     stripePath: "/cashflow_report/get",
     resource: "cashflow_report",
     operation: "retrieve",
@@ -513,7 +513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cashflow_report/transactions/get",
+    fastifyPath: "/cashflow_report/transactions/get",
     stripePath: "/cashflow_report/transactions/get",
     resource: "cashflow_report",
     operation: "retrieve",
@@ -522,7 +522,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/cashflow_report/insights/get",
+    fastifyPath: "/cashflow_report/insights/get",
     stripePath: "/cashflow_report/insights/get",
     resource: "cashflow_report",
     operation: "retrieve",
@@ -531,7 +531,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transactions/recurring/get",
+    fastifyPath: "/transactions/recurring/get",
     stripePath: "/transactions/recurring/get",
     resource: "transactions",
     operation: "retrieve",
@@ -540,7 +540,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transactions/sync",
+    fastifyPath: "/transactions/sync",
     stripePath: "/transactions/sync",
     resource: "transactions",
     operation: "action",
@@ -549,7 +549,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transactions/enrich",
+    fastifyPath: "/transactions/enrich",
     stripePath: "/transactions/enrich",
     resource: "transactions",
     operation: "action",
@@ -558,7 +558,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/transactions/refresh",
+    fastifyPath: "/user/transactions/refresh",
     stripePath: "/user/transactions/refresh",
     resource: "user",
     operation: "action",
@@ -567,7 +567,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/financial_data/refresh",
+    fastifyPath: "/user/financial_data/refresh",
     stripePath: "/user/financial_data/refresh",
     resource: "user",
     operation: "action",
@@ -576,7 +576,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/institutions/get",
+    fastifyPath: "/institutions/get",
     stripePath: "/institutions/get",
     resource: "institutions",
     operation: "retrieve",
@@ -585,7 +585,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/institutions/search",
+    fastifyPath: "/institutions/search",
     stripePath: "/institutions/search",
     resource: "institutions",
     operation: "action",
@@ -594,7 +594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/institutions/get_by_id",
+    fastifyPath: "/institutions/get_by_id",
     stripePath: "/institutions/get_by_id",
     resource: "institutions",
     operation: "action",
@@ -603,7 +603,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/remove",
+    fastifyPath: "/item/remove",
     stripePath: "/item/remove",
     resource: "item",
     operation: "delete",
@@ -612,7 +612,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/accounts/get",
+    fastifyPath: "/accounts/get",
     stripePath: "/accounts/get",
     resource: "accounts",
     operation: "retrieve",
@@ -621,7 +621,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/categories/get",
+    fastifyPath: "/categories/get",
     stripePath: "/categories/get",
     resource: "categories",
     operation: "retrieve",
@@ -630,7 +630,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/processor_token/create",
+    fastifyPath: "/sandbox/processor_token/create",
     stripePath: "/sandbox/processor_token/create",
     resource: "sandbox",
     operation: "create",
@@ -639,7 +639,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/public_token/create",
+    fastifyPath: "/sandbox/public_token/create",
     stripePath: "/sandbox/public_token/create",
     resource: "sandbox",
     operation: "create",
@@ -648,7 +648,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/item/fire_webhook",
+    fastifyPath: "/sandbox/item/fire_webhook",
     stripePath: "/sandbox/item/fire_webhook",
     resource: "sandbox",
     operation: "action",
@@ -657,7 +657,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/accounts/balance/get",
+    fastifyPath: "/accounts/balance/get",
     stripePath: "/accounts/balance/get",
     resource: "accounts",
     operation: "retrieve",
@@ -666,7 +666,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity/get",
+    fastifyPath: "/identity/get",
     stripePath: "/identity/get",
     resource: "identity",
     operation: "retrieve",
@@ -675,7 +675,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity/documents/uploads/get",
+    fastifyPath: "/identity/documents/uploads/get",
     stripePath: "/identity/documents/uploads/get",
     resource: "identity",
     operation: "retrieve",
@@ -684,7 +684,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity/match",
+    fastifyPath: "/identity/match",
     stripePath: "/identity/match",
     resource: "identity",
     operation: "action",
@@ -693,7 +693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity/refresh",
+    fastifyPath: "/identity/refresh",
     stripePath: "/identity/refresh",
     resource: "identity",
     operation: "action",
@@ -702,7 +702,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/dashboard_user/get",
+    fastifyPath: "/dashboard_user/get",
     stripePath: "/dashboard_user/get",
     resource: "dashboard_user",
     operation: "retrieve",
@@ -711,7 +711,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/dashboard_user/list",
+    fastifyPath: "/dashboard_user/list",
     stripePath: "/dashboard_user/list",
     resource: "dashboard_user",
     operation: "list",
@@ -720,7 +720,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity_verification/create",
+    fastifyPath: "/identity_verification/create",
     stripePath: "/identity_verification/create",
     resource: "identity_verification",
     operation: "create",
@@ -729,7 +729,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity_verification/get",
+    fastifyPath: "/identity_verification/get",
     stripePath: "/identity_verification/get",
     resource: "identity_verification",
     operation: "retrieve",
@@ -738,7 +738,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity_verification/list",
+    fastifyPath: "/identity_verification/list",
     stripePath: "/identity_verification/list",
     resource: "identity_verification",
     operation: "list",
@@ -747,7 +747,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity_verification/retry",
+    fastifyPath: "/identity_verification/retry",
     stripePath: "/identity_verification/retry",
     resource: "identity_verification",
     operation: "action",
@@ -756,7 +756,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/create",
+    fastifyPath: "/watchlist_screening/entity/create",
     stripePath: "/watchlist_screening/entity/create",
     resource: "watchlist_screening",
     operation: "create",
@@ -765,7 +765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/get",
+    fastifyPath: "/watchlist_screening/entity/get",
     stripePath: "/watchlist_screening/entity/get",
     resource: "watchlist_screening",
     operation: "retrieve",
@@ -774,7 +774,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/history/list",
+    fastifyPath: "/watchlist_screening/entity/history/list",
     stripePath: "/watchlist_screening/entity/history/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -783,7 +783,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/hit/list",
+    fastifyPath: "/watchlist_screening/entity/hit/list",
     stripePath: "/watchlist_screening/entity/hit/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -792,7 +792,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/list",
+    fastifyPath: "/watchlist_screening/entity/list",
     stripePath: "/watchlist_screening/entity/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -801,7 +801,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/program/get",
+    fastifyPath: "/watchlist_screening/entity/program/get",
     stripePath: "/watchlist_screening/entity/program/get",
     resource: "watchlist_screening",
     operation: "retrieve",
@@ -810,7 +810,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/program/list",
+    fastifyPath: "/watchlist_screening/entity/program/list",
     stripePath: "/watchlist_screening/entity/program/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -819,7 +819,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/review/create",
+    fastifyPath: "/watchlist_screening/entity/review/create",
     stripePath: "/watchlist_screening/entity/review/create",
     resource: "watchlist_screening",
     operation: "create",
@@ -828,7 +828,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/review/list",
+    fastifyPath: "/watchlist_screening/entity/review/list",
     stripePath: "/watchlist_screening/entity/review/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -837,7 +837,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/entity/update",
+    fastifyPath: "/watchlist_screening/entity/update",
     stripePath: "/watchlist_screening/entity/update",
     resource: "watchlist_screening",
     operation: "update",
@@ -846,7 +846,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/create",
+    fastifyPath: "/watchlist_screening/individual/create",
     stripePath: "/watchlist_screening/individual/create",
     resource: "watchlist_screening",
     operation: "create",
@@ -855,7 +855,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/get",
+    fastifyPath: "/watchlist_screening/individual/get",
     stripePath: "/watchlist_screening/individual/get",
     resource: "watchlist_screening",
     operation: "retrieve",
@@ -864,7 +864,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/history/list",
+    fastifyPath: "/watchlist_screening/individual/history/list",
     stripePath: "/watchlist_screening/individual/history/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -873,7 +873,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/hit/list",
+    fastifyPath: "/watchlist_screening/individual/hit/list",
     stripePath: "/watchlist_screening/individual/hit/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -882,7 +882,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/list",
+    fastifyPath: "/watchlist_screening/individual/list",
     stripePath: "/watchlist_screening/individual/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -891,7 +891,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/program/get",
+    fastifyPath: "/watchlist_screening/individual/program/get",
     stripePath: "/watchlist_screening/individual/program/get",
     resource: "watchlist_screening",
     operation: "retrieve",
@@ -900,7 +900,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/program/list",
+    fastifyPath: "/watchlist_screening/individual/program/list",
     stripePath: "/watchlist_screening/individual/program/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -909,7 +909,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/review/create",
+    fastifyPath: "/watchlist_screening/individual/review/create",
     stripePath: "/watchlist_screening/individual/review/create",
     resource: "watchlist_screening",
     operation: "create",
@@ -918,7 +918,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/review/list",
+    fastifyPath: "/watchlist_screening/individual/review/list",
     stripePath: "/watchlist_screening/individual/review/list",
     resource: "watchlist_screening",
     operation: "list",
@@ -927,7 +927,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/watchlist_screening/individual/update",
+    fastifyPath: "/watchlist_screening/individual/update",
     stripePath: "/watchlist_screening/individual/update",
     resource: "watchlist_screening",
     operation: "update",
@@ -936,7 +936,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/account_risk/v1/evaluate",
+    fastifyPath: "/beacon/account_risk/v1/evaluate",
     stripePath: "/beacon/account_risk/v1/evaluate",
     resource: "beacon",
     operation: "action",
@@ -945,7 +945,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/create",
+    fastifyPath: "/beacon/user/create",
     stripePath: "/beacon/user/create",
     resource: "beacon",
     operation: "create",
@@ -954,7 +954,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/get",
+    fastifyPath: "/beacon/user/get",
     stripePath: "/beacon/user/get",
     resource: "beacon",
     operation: "retrieve",
@@ -963,7 +963,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/review",
+    fastifyPath: "/beacon/user/review",
     stripePath: "/beacon/user/review",
     resource: "beacon",
     operation: "action",
@@ -972,7 +972,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/report/create",
+    fastifyPath: "/beacon/report/create",
     stripePath: "/beacon/report/create",
     resource: "beacon",
     operation: "create",
@@ -981,7 +981,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/report/list",
+    fastifyPath: "/beacon/report/list",
     stripePath: "/beacon/report/list",
     resource: "beacon",
     operation: "list",
@@ -990,7 +990,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/report_syndication/list",
+    fastifyPath: "/beacon/report_syndication/list",
     stripePath: "/beacon/report_syndication/list",
     resource: "beacon",
     operation: "list",
@@ -999,7 +999,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/report/get",
+    fastifyPath: "/beacon/report/get",
     stripePath: "/beacon/report/get",
     resource: "beacon",
     operation: "retrieve",
@@ -1008,7 +1008,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/report_syndication/get",
+    fastifyPath: "/beacon/report_syndication/get",
     stripePath: "/beacon/report_syndication/get",
     resource: "beacon",
     operation: "retrieve",
@@ -1017,7 +1017,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/update",
+    fastifyPath: "/beacon/user/update",
     stripePath: "/beacon/user/update",
     resource: "beacon",
     operation: "update",
@@ -1026,7 +1026,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/duplicate/get",
+    fastifyPath: "/beacon/duplicate/get",
     stripePath: "/beacon/duplicate/get",
     resource: "beacon",
     operation: "retrieve",
@@ -1035,7 +1035,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/identity_verification/autofill/create",
+    fastifyPath: "/identity_verification/autofill/create",
     stripePath: "/identity_verification/autofill/create",
     resource: "identity_verification",
     operation: "create",
@@ -1044,7 +1044,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/history/list",
+    fastifyPath: "/beacon/user/history/list",
     stripePath: "/beacon/user/history/list",
     resource: "beacon",
     operation: "list",
@@ -1053,7 +1053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beacon/user/account_insights/get",
+    fastifyPath: "/beacon/user/account_insights/get",
     stripePath: "/beacon/user/account_insights/get",
     resource: "beacon",
     operation: "retrieve",
@@ -1062,7 +1062,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/protect/user/insights/get",
+    fastifyPath: "/protect/user/insights/get",
     stripePath: "/protect/user/insights/get",
     resource: "protect",
     operation: "retrieve",
@@ -1071,7 +1071,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/protect/report/create",
+    fastifyPath: "/protect/report/create",
     stripePath: "/protect/report/create",
     resource: "protect",
     operation: "create",
@@ -1080,7 +1080,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/protect/compute",
+    fastifyPath: "/protect/compute",
     stripePath: "/protect/compute",
     resource: "protect",
     operation: "action",
@@ -1089,7 +1089,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/protect/event/send",
+    fastifyPath: "/protect/event/send",
     stripePath: "/protect/event/send",
     resource: "protect",
     operation: "action",
@@ -1098,7 +1098,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/protect/event/get",
+    fastifyPath: "/protect/event/get",
     stripePath: "/protect/event/get",
     resource: "protect",
     operation: "retrieve",
@@ -1107,7 +1107,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/business_verification/get",
+    fastifyPath: "/business_verification/get",
     stripePath: "/business_verification/get",
     resource: "business_verification",
     operation: "retrieve",
@@ -1116,7 +1116,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/business_verification/create",
+    fastifyPath: "/business_verification/create",
     stripePath: "/business_verification/create",
     resource: "business_verification",
     operation: "create",
@@ -1125,7 +1125,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/auth/get",
+    fastifyPath: "/processor/auth/get",
     stripePath: "/processor/auth/get",
     resource: "processor",
     operation: "retrieve",
@@ -1134,7 +1134,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/account/get",
+    fastifyPath: "/processor/account/get",
     stripePath: "/processor/account/get",
     resource: "processor",
     operation: "retrieve",
@@ -1143,7 +1143,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/investments/holdings/get",
+    fastifyPath: "/processor/investments/holdings/get",
     stripePath: "/processor/investments/holdings/get",
     resource: "processor",
     operation: "retrieve",
@@ -1152,7 +1152,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/investments/transactions/get",
+    fastifyPath: "/processor/investments/transactions/get",
     stripePath: "/processor/investments/transactions/get",
     resource: "processor",
     operation: "retrieve",
@@ -1161,7 +1161,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/transactions/get",
+    fastifyPath: "/processor/transactions/get",
     stripePath: "/processor/transactions/get",
     resource: "processor",
     operation: "retrieve",
@@ -1170,7 +1170,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/transactions/sync",
+    fastifyPath: "/processor/transactions/sync",
     stripePath: "/processor/transactions/sync",
     resource: "processor",
     operation: "action",
@@ -1179,7 +1179,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/transactions/refresh",
+    fastifyPath: "/processor/transactions/refresh",
     stripePath: "/processor/transactions/refresh",
     resource: "processor",
     operation: "action",
@@ -1188,7 +1188,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/transactions/recurring/get",
+    fastifyPath: "/processor/transactions/recurring/get",
     stripePath: "/processor/transactions/recurring/get",
     resource: "processor",
     operation: "retrieve",
@@ -1197,7 +1197,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/signal/evaluate",
+    fastifyPath: "/processor/signal/evaluate",
     stripePath: "/processor/signal/evaluate",
     resource: "processor",
     operation: "action",
@@ -1206,7 +1206,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/signal/decision/report",
+    fastifyPath: "/processor/signal/decision/report",
     stripePath: "/processor/signal/decision/report",
     resource: "processor",
     operation: "action",
@@ -1215,7 +1215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/signal/return/report",
+    fastifyPath: "/processor/signal/return/report",
     stripePath: "/processor/signal/return/report",
     resource: "processor",
     operation: "action",
@@ -1224,7 +1224,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/signal/prepare",
+    fastifyPath: "/processor/signal/prepare",
     stripePath: "/processor/signal/prepare",
     resource: "processor",
     operation: "action",
@@ -1233,7 +1233,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/bank_transfer/create",
+    fastifyPath: "/processor/bank_transfer/create",
     stripePath: "/processor/bank_transfer/create",
     resource: "processor",
     operation: "create",
@@ -1242,7 +1242,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/liabilities/get",
+    fastifyPath: "/processor/liabilities/get",
     stripePath: "/processor/liabilities/get",
     resource: "processor",
     operation: "retrieve",
@@ -1251,7 +1251,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/identity/get",
+    fastifyPath: "/processor/identity/get",
     stripePath: "/processor/identity/get",
     resource: "processor",
     operation: "retrieve",
@@ -1260,7 +1260,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/identity/match",
+    fastifyPath: "/processor/identity/match",
     stripePath: "/processor/identity/match",
     resource: "processor",
     operation: "action",
@@ -1269,7 +1269,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/balance/get",
+    fastifyPath: "/processor/balance/get",
     stripePath: "/processor/balance/get",
     resource: "processor",
     operation: "retrieve",
@@ -1278,7 +1278,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/webhook/update",
+    fastifyPath: "/item/webhook/update",
     stripePath: "/item/webhook/update",
     resource: "item",
     operation: "update",
@@ -1287,7 +1287,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/access_token/invalidate",
+    fastifyPath: "/item/access_token/invalidate",
     stripePath: "/item/access_token/invalidate",
     resource: "item",
     operation: "action",
@@ -1296,7 +1296,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/webhook_verification_key/get",
+    fastifyPath: "/webhook_verification_key/get",
     stripePath: "/webhook_verification_key/get",
     resource: "webhook_verification_key",
     operation: "retrieve",
@@ -1305,7 +1305,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/liabilities/get",
+    fastifyPath: "/liabilities/get",
     stripePath: "/liabilities/get",
     resource: "liabilities",
     operation: "retrieve",
@@ -1314,7 +1314,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/recipient/create",
+    fastifyPath: "/payment_initiation/recipient/create",
     stripePath: "/payment_initiation/recipient/create",
     resource: "payment_initiation",
     operation: "create",
@@ -1323,7 +1323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/payment/reverse",
+    fastifyPath: "/payment_initiation/payment/reverse",
     stripePath: "/payment_initiation/payment/reverse",
     resource: "payment_initiation",
     operation: "action",
@@ -1332,7 +1332,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/recipient/get",
+    fastifyPath: "/payment_initiation/recipient/get",
     stripePath: "/payment_initiation/recipient/get",
     resource: "payment_initiation",
     operation: "retrieve",
@@ -1341,7 +1341,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/recipient/list",
+    fastifyPath: "/payment_initiation/recipient/list",
     stripePath: "/payment_initiation/recipient/list",
     resource: "payment_initiation",
     operation: "list",
@@ -1350,7 +1350,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/payment/create",
+    fastifyPath: "/payment_initiation/payment/create",
     stripePath: "/payment_initiation/payment/create",
     resource: "payment_initiation",
     operation: "create",
@@ -1359,7 +1359,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/payment/token/create",
+    fastifyPath: "/payment_initiation/payment/token/create",
     stripePath: "/payment_initiation/payment/token/create",
     resource: "payment_initiation",
     operation: "create",
@@ -1368,7 +1368,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/consent/create",
+    fastifyPath: "/payment_initiation/consent/create",
     stripePath: "/payment_initiation/consent/create",
     resource: "payment_initiation",
     operation: "create",
@@ -1377,7 +1377,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/consent/get",
+    fastifyPath: "/payment_initiation/consent/get",
     stripePath: "/payment_initiation/consent/get",
     resource: "payment_initiation",
     operation: "retrieve",
@@ -1386,7 +1386,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/consent/revoke",
+    fastifyPath: "/payment_initiation/consent/revoke",
     stripePath: "/payment_initiation/consent/revoke",
     resource: "payment_initiation",
     operation: "action",
@@ -1395,7 +1395,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/consent/payment/execute",
+    fastifyPath: "/payment_initiation/consent/payment/execute",
     stripePath: "/payment_initiation/consent/payment/execute",
     resource: "payment_initiation",
     operation: "action",
@@ -1404,7 +1404,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/item/reset_login",
+    fastifyPath: "/sandbox/item/reset_login",
     stripePath: "/sandbox/item/reset_login",
     resource: "sandbox",
     operation: "action",
@@ -1413,7 +1413,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/item/set_verification_status",
+    fastifyPath: "/sandbox/item/set_verification_status",
     stripePath: "/sandbox/item/set_verification_status",
     resource: "sandbox",
     operation: "action",
@@ -1422,7 +1422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/user/reset_login",
+    fastifyPath: "/sandbox/user/reset_login",
     stripePath: "/sandbox/user/reset_login",
     resource: "sandbox",
     operation: "action",
@@ -1431,7 +1431,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/public_token/exchange",
+    fastifyPath: "/item/public_token/exchange",
     stripePath: "/item/public_token/exchange",
     resource: "item",
     operation: "action",
@@ -1440,7 +1440,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/public_token/create",
+    fastifyPath: "/item/public_token/create",
     stripePath: "/item/public_token/create",
     resource: "item",
     operation: "create",
@@ -1449,7 +1449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/create",
+    fastifyPath: "/user/create",
     stripePath: "/user/create",
     resource: "user",
     operation: "create",
@@ -1458,7 +1458,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/get",
+    fastifyPath: "/user/get",
     stripePath: "/user/get",
     resource: "user",
     operation: "retrieve",
@@ -1467,7 +1467,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/identity/remove",
+    fastifyPath: "/user/identity/remove",
     stripePath: "/user/identity/remove",
     resource: "user",
     operation: "delete",
@@ -1476,7 +1476,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/update",
+    fastifyPath: "/user/update",
     stripePath: "/user/update",
     resource: "user",
     operation: "update",
@@ -1485,7 +1485,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/remove",
+    fastifyPath: "/user/remove",
     stripePath: "/user/remove",
     resource: "user",
     operation: "delete",
@@ -1494,7 +1494,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/products/terminate",
+    fastifyPath: "/user/products/terminate",
     stripePath: "/user/products/terminate",
     resource: "user",
     operation: "action",
@@ -1503,7 +1503,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/items/get",
+    fastifyPath: "/user/items/get",
     stripePath: "/user/items/get",
     resource: "user",
     operation: "retrieve",
@@ -1512,7 +1512,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/items/associate",
+    fastifyPath: "/user/items/associate",
     stripePath: "/user/items/associate",
     resource: "user",
     operation: "action",
@@ -1521,7 +1521,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/items/remove",
+    fastifyPath: "/user/items/remove",
     stripePath: "/user/items/remove",
     resource: "user",
     operation: "delete",
@@ -1530,7 +1530,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/third_party_token/create",
+    fastifyPath: "/user/third_party_token/create",
     stripePath: "/user/third_party_token/create",
     resource: "user",
     operation: "create",
@@ -1539,7 +1539,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/user/third_party_token/remove",
+    fastifyPath: "/user/third_party_token/remove",
     stripePath: "/user/third_party_token/remove",
     resource: "user",
     operation: "delete",
@@ -1548,7 +1548,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/sessions/get",
+    fastifyPath: "/credit/sessions/get",
     stripePath: "/credit/sessions/get",
     resource: "credit",
     operation: "retrieve",
@@ -1557,7 +1557,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/payment/get",
+    fastifyPath: "/payment_initiation/payment/get",
     stripePath: "/payment_initiation/payment/get",
     resource: "payment_initiation",
     operation: "retrieve",
@@ -1566,7 +1566,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_initiation/payment/list",
+    fastifyPath: "/payment_initiation/payment/list",
     stripePath: "/payment_initiation/payment/list",
     resource: "payment_initiation",
     operation: "list",
@@ -1575,7 +1575,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/investments/holdings/get",
+    fastifyPath: "/investments/holdings/get",
     stripePath: "/investments/holdings/get",
     resource: "investments",
     operation: "retrieve",
@@ -1584,7 +1584,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/investments/transactions/get",
+    fastifyPath: "/investments/transactions/get",
     stripePath: "/investments/transactions/get",
     resource: "investments",
     operation: "retrieve",
@@ -1593,7 +1593,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/investments/refresh",
+    fastifyPath: "/investments/refresh",
     stripePath: "/investments/refresh",
     resource: "investments",
     operation: "action",
@@ -1602,7 +1602,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/investments/auth/get",
+    fastifyPath: "/investments/auth/get",
     stripePath: "/investments/auth/get",
     resource: "investments",
     operation: "retrieve",
@@ -1611,7 +1611,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/token/create",
+    fastifyPath: "/processor/token/create",
     stripePath: "/processor/token/create",
     resource: "processor",
     operation: "create",
@@ -1620,7 +1620,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/token/permissions/set",
+    fastifyPath: "/processor/token/permissions/set",
     stripePath: "/processor/token/permissions/set",
     resource: "processor",
     operation: "action",
@@ -1629,7 +1629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/token/permissions/get",
+    fastifyPath: "/processor/token/permissions/get",
     stripePath: "/processor/token/permissions/get",
     resource: "processor",
     operation: "retrieve",
@@ -1638,7 +1638,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/token/webhook/update",
+    fastifyPath: "/processor/token/webhook/update",
     stripePath: "/processor/token/webhook/update",
     resource: "processor",
     operation: "update",
@@ -1647,7 +1647,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/stripe/bank_account_token/create",
+    fastifyPath: "/processor/stripe/bank_account_token/create",
     stripePath: "/processor/stripe/bank_account_token/create",
     resource: "processor",
     operation: "create",
@@ -1656,7 +1656,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/processor/apex/processor_token/create",
+    fastifyPath: "/processor/apex/processor_token/create",
     stripePath: "/processor/apex/processor_token/create",
     resource: "processor",
     operation: "create",
@@ -1665,7 +1665,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/item/import",
+    fastifyPath: "/item/import",
     stripePath: "/item/import",
     resource: "item",
     operation: "action",
@@ -1674,7 +1674,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/link/token/create",
+    fastifyPath: "/link/token/create",
     stripePath: "/link/token/create",
     resource: "link_token",
     operation: "create",
@@ -1683,7 +1683,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/link/token/get",
+    fastifyPath: "/link/token/get",
     stripePath: "/link/token/get",
     resource: "link_token",
     operation: "retrieve",
@@ -1692,7 +1692,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/link/oauth/correlation_id/exchange",
+    fastifyPath: "/link/oauth/correlation_id/exchange",
     stripePath: "/link/oauth/correlation_id/exchange",
     resource: "link",
     operation: "action",
@@ -1701,7 +1701,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/session/token/create",
+    fastifyPath: "/session/token/create",
     stripePath: "/session/token/create",
     resource: "session",
     operation: "create",
@@ -1710,7 +1710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/get",
+    fastifyPath: "/transfer/get",
     stripePath: "/transfer/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1719,7 +1719,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/recurring/get",
+    fastifyPath: "/transfer/recurring/get",
     stripePath: "/transfer/recurring/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1728,7 +1728,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/get",
+    fastifyPath: "/bank_transfer/get",
     stripePath: "/bank_transfer/get",
     resource: "bank_transfer",
     operation: "retrieve",
@@ -1737,7 +1737,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/authorization/create",
+    fastifyPath: "/transfer/authorization/create",
     stripePath: "/transfer/authorization/create",
     resource: "transfer",
     operation: "create",
@@ -1746,7 +1746,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/authorization/cancel",
+    fastifyPath: "/transfer/authorization/cancel",
     stripePath: "/transfer/authorization/cancel",
     resource: "transfer",
     operation: "action",
@@ -1755,7 +1755,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/balance/get",
+    fastifyPath: "/transfer/balance/get",
     stripePath: "/transfer/balance/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1764,7 +1764,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/capabilities/get",
+    fastifyPath: "/transfer/capabilities/get",
     stripePath: "/transfer/capabilities/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1773,7 +1773,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/configuration/get",
+    fastifyPath: "/transfer/configuration/get",
     stripePath: "/transfer/configuration/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1782,7 +1782,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/ledger/get",
+    fastifyPath: "/transfer/ledger/get",
     stripePath: "/transfer/ledger/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1791,7 +1791,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/ledger/distribute",
+    fastifyPath: "/transfer/ledger/distribute",
     stripePath: "/transfer/ledger/distribute",
     resource: "transfer",
     operation: "action",
@@ -1800,7 +1800,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/ledger/deposit",
+    fastifyPath: "/transfer/ledger/deposit",
     stripePath: "/transfer/ledger/deposit",
     resource: "transfer",
     operation: "action",
@@ -1809,7 +1809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/ledger/withdraw",
+    fastifyPath: "/transfer/ledger/withdraw",
     stripePath: "/transfer/ledger/withdraw",
     resource: "transfer",
     operation: "action",
@@ -1818,7 +1818,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/originator/funding_account/update",
+    fastifyPath: "/transfer/originator/funding_account/update",
     stripePath: "/transfer/originator/funding_account/update",
     resource: "transfer",
     operation: "update",
@@ -1827,7 +1827,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/originator/funding_account/create",
+    fastifyPath: "/transfer/originator/funding_account/create",
     stripePath: "/transfer/originator/funding_account/create",
     resource: "transfer",
     operation: "create",
@@ -1836,7 +1836,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/metrics/get",
+    fastifyPath: "/transfer/metrics/get",
     stripePath: "/transfer/metrics/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1845,7 +1845,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/create",
+    fastifyPath: "/transfer/create",
     stripePath: "/transfer/create",
     resource: "transfer",
     operation: "create",
@@ -1854,7 +1854,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/recurring/create",
+    fastifyPath: "/transfer/recurring/create",
     stripePath: "/transfer/recurring/create",
     resource: "transfer",
     operation: "create",
@@ -1863,7 +1863,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/create",
+    fastifyPath: "/bank_transfer/create",
     stripePath: "/bank_transfer/create",
     resource: "bank_transfer",
     operation: "create",
@@ -1872,7 +1872,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/list",
+    fastifyPath: "/transfer/list",
     stripePath: "/transfer/list",
     resource: "transfer",
     operation: "list",
@@ -1881,7 +1881,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/recurring/list",
+    fastifyPath: "/transfer/recurring/list",
     stripePath: "/transfer/recurring/list",
     resource: "transfer",
     operation: "list",
@@ -1890,7 +1890,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/list",
+    fastifyPath: "/bank_transfer/list",
     stripePath: "/bank_transfer/list",
     resource: "bank_transfer",
     operation: "list",
@@ -1899,7 +1899,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/cancel",
+    fastifyPath: "/transfer/cancel",
     stripePath: "/transfer/cancel",
     resource: "transfer",
     operation: "action",
@@ -1908,7 +1908,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/recurring/cancel",
+    fastifyPath: "/transfer/recurring/cancel",
     stripePath: "/transfer/recurring/cancel",
     resource: "transfer",
     operation: "action",
@@ -1917,7 +1917,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/cancel",
+    fastifyPath: "/bank_transfer/cancel",
     stripePath: "/bank_transfer/cancel",
     resource: "bank_transfer",
     operation: "action",
@@ -1926,7 +1926,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/event/list",
+    fastifyPath: "/transfer/event/list",
     stripePath: "/transfer/event/list",
     resource: "transfer",
     operation: "list",
@@ -1935,7 +1935,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/ledger/event/list",
+    fastifyPath: "/transfer/ledger/event/list",
     stripePath: "/transfer/ledger/event/list",
     resource: "transfer",
     operation: "list",
@@ -1944,7 +1944,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/event/list",
+    fastifyPath: "/bank_transfer/event/list",
     stripePath: "/bank_transfer/event/list",
     resource: "bank_transfer",
     operation: "list",
@@ -1953,7 +1953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/event/sync",
+    fastifyPath: "/transfer/event/sync",
     stripePath: "/transfer/event/sync",
     resource: "transfer",
     operation: "action",
@@ -1962,7 +1962,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/event/sync",
+    fastifyPath: "/bank_transfer/event/sync",
     stripePath: "/bank_transfer/event/sync",
     resource: "bank_transfer",
     operation: "action",
@@ -1971,7 +1971,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/sweep/get",
+    fastifyPath: "/transfer/sweep/get",
     stripePath: "/transfer/sweep/get",
     resource: "transfer",
     operation: "retrieve",
@@ -1980,7 +1980,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/sweep/get",
+    fastifyPath: "/bank_transfer/sweep/get",
     stripePath: "/bank_transfer/sweep/get",
     resource: "bank_transfer",
     operation: "retrieve",
@@ -1989,7 +1989,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/sweep/list",
+    fastifyPath: "/transfer/sweep/list",
     stripePath: "/transfer/sweep/list",
     resource: "transfer",
     operation: "list",
@@ -1998,7 +1998,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/sweep/list",
+    fastifyPath: "/bank_transfer/sweep/list",
     stripePath: "/bank_transfer/sweep/list",
     resource: "bank_transfer",
     operation: "list",
@@ -2007,7 +2007,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/balance/get",
+    fastifyPath: "/bank_transfer/balance/get",
     stripePath: "/bank_transfer/balance/get",
     resource: "bank_transfer",
     operation: "retrieve",
@@ -2016,7 +2016,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/bank_transfer/migrate_account",
+    fastifyPath: "/bank_transfer/migrate_account",
     stripePath: "/bank_transfer/migrate_account",
     resource: "bank_transfer",
     operation: "action",
@@ -2025,7 +2025,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/migrate_account",
+    fastifyPath: "/transfer/migrate_account",
     stripePath: "/transfer/migrate_account",
     resource: "transfer",
     operation: "action",
@@ -2034,7 +2034,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/intent/create",
+    fastifyPath: "/transfer/intent/create",
     stripePath: "/transfer/intent/create",
     resource: "transfer",
     operation: "create",
@@ -2043,7 +2043,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/intent/get",
+    fastifyPath: "/transfer/intent/get",
     stripePath: "/transfer/intent/get",
     resource: "transfer",
     operation: "retrieve",
@@ -2052,7 +2052,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/repayment/list",
+    fastifyPath: "/transfer/repayment/list",
     stripePath: "/transfer/repayment/list",
     resource: "transfer",
     operation: "list",
@@ -2061,7 +2061,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/repayment/return/list",
+    fastifyPath: "/transfer/repayment/return/list",
     stripePath: "/transfer/repayment/return/list",
     resource: "transfer",
     operation: "list",
@@ -2070,7 +2070,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/platform/requirement/submit",
+    fastifyPath: "/transfer/platform/requirement/submit",
     stripePath: "/transfer/platform/requirement/submit",
     resource: "transfer",
     operation: "action",
@@ -2079,7 +2079,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/originator/create",
+    fastifyPath: "/transfer/originator/create",
     stripePath: "/transfer/originator/create",
     resource: "transfer",
     operation: "create",
@@ -2088,7 +2088,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/questionnaire/create",
+    fastifyPath: "/transfer/questionnaire/create",
     stripePath: "/transfer/questionnaire/create",
     resource: "transfer",
     operation: "create",
@@ -2097,7 +2097,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/diligence/submit",
+    fastifyPath: "/transfer/diligence/submit",
     stripePath: "/transfer/diligence/submit",
     resource: "transfer",
     operation: "action",
@@ -2106,7 +2106,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/diligence/document/upload",
+    fastifyPath: "/transfer/diligence/document/upload",
     stripePath: "/transfer/diligence/document/upload",
     resource: "transfer",
     operation: "action",
@@ -2115,7 +2115,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/originator/get",
+    fastifyPath: "/transfer/originator/get",
     stripePath: "/transfer/originator/get",
     resource: "transfer",
     operation: "retrieve",
@@ -2124,7 +2124,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/originator/list",
+    fastifyPath: "/transfer/originator/list",
     stripePath: "/transfer/originator/list",
     resource: "transfer",
     operation: "list",
@@ -2133,7 +2133,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/refund/create",
+    fastifyPath: "/transfer/refund/create",
     stripePath: "/transfer/refund/create",
     resource: "transfer",
     operation: "create",
@@ -2142,7 +2142,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/refund/get",
+    fastifyPath: "/transfer/refund/get",
     stripePath: "/transfer/refund/get",
     resource: "transfer",
     operation: "retrieve",
@@ -2151,7 +2151,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/refund/cancel",
+    fastifyPath: "/transfer/refund/cancel",
     stripePath: "/transfer/refund/cancel",
     resource: "transfer",
     operation: "action",
@@ -2160,7 +2160,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/platform/originator/create",
+    fastifyPath: "/transfer/platform/originator/create",
     stripePath: "/transfer/platform/originator/create",
     resource: "transfer",
     operation: "create",
@@ -2169,7 +2169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/transfer/platform/person/create",
+    fastifyPath: "/transfer/platform/person/create",
     stripePath: "/transfer/platform/person/create",
     resource: "transfer",
     operation: "create",
@@ -2178,7 +2178,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/bank_transfer/simulate",
+    fastifyPath: "/sandbox/bank_transfer/simulate",
     stripePath: "/sandbox/bank_transfer/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2187,7 +2187,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/sweep/simulate",
+    fastifyPath: "/sandbox/transfer/sweep/simulate",
     stripePath: "/sandbox/transfer/sweep/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2196,7 +2196,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/simulate",
+    fastifyPath: "/sandbox/transfer/simulate",
     stripePath: "/sandbox/transfer/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2205,7 +2205,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/refund/simulate",
+    fastifyPath: "/sandbox/transfer/refund/simulate",
     stripePath: "/sandbox/transfer/refund/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2214,7 +2214,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/ledger/simulate_available",
+    fastifyPath: "/sandbox/transfer/ledger/simulate_available",
     stripePath: "/sandbox/transfer/ledger/simulate_available",
     resource: "sandbox",
     operation: "action",
@@ -2223,7 +2223,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/ledger/deposit/simulate",
+    fastifyPath: "/sandbox/transfer/ledger/deposit/simulate",
     stripePath: "/sandbox/transfer/ledger/deposit/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2232,7 +2232,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/ledger/withdraw/simulate",
+    fastifyPath: "/sandbox/transfer/ledger/withdraw/simulate",
     stripePath: "/sandbox/transfer/ledger/withdraw/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2241,7 +2241,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/repayment/simulate",
+    fastifyPath: "/sandbox/transfer/repayment/simulate",
     stripePath: "/sandbox/transfer/repayment/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2250,7 +2250,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/fire_webhook",
+    fastifyPath: "/sandbox/transfer/fire_webhook",
     stripePath: "/sandbox/transfer/fire_webhook",
     resource: "sandbox",
     operation: "action",
@@ -2259,7 +2259,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/test_clock/create",
+    fastifyPath: "/sandbox/transfer/test_clock/create",
     stripePath: "/sandbox/transfer/test_clock/create",
     resource: "sandbox",
     operation: "create",
@@ -2268,7 +2268,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/test_clock/advance",
+    fastifyPath: "/sandbox/transfer/test_clock/advance",
     stripePath: "/sandbox/transfer/test_clock/advance",
     resource: "sandbox",
     operation: "action",
@@ -2277,7 +2277,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/test_clock/get",
+    fastifyPath: "/sandbox/transfer/test_clock/get",
     stripePath: "/sandbox/transfer/test_clock/get",
     resource: "sandbox",
     operation: "retrieve",
@@ -2286,7 +2286,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/transfer/test_clock/list",
+    fastifyPath: "/sandbox/transfer/test_clock/list",
     stripePath: "/sandbox/transfer/test_clock/list",
     resource: "sandbox",
     operation: "list",
@@ -2295,7 +2295,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/payment_profile/reset_login",
+    fastifyPath: "/sandbox/payment_profile/reset_login",
     stripePath: "/sandbox/payment_profile/reset_login",
     resource: "sandbox",
     operation: "action",
@@ -2304,7 +2304,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/payment/simulate",
+    fastifyPath: "/sandbox/payment/simulate",
     stripePath: "/sandbox/payment/simulate",
     resource: "sandbox",
     operation: "action",
@@ -2313,7 +2313,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/employers/search",
+    fastifyPath: "/employers/search",
     stripePath: "/employers/search",
     resource: "employers",
     operation: "action",
@@ -2322,7 +2322,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/income/verification/create",
+    fastifyPath: "/income/verification/create",
     stripePath: "/income/verification/create",
     resource: "income",
     operation: "create",
@@ -2331,7 +2331,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/income/verification/paystubs/get",
+    fastifyPath: "/income/verification/paystubs/get",
     stripePath: "/income/verification/paystubs/get",
     resource: "income",
     operation: "retrieve",
@@ -2340,7 +2340,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/income/verification/documents/download",
+    fastifyPath: "/income/verification/documents/download",
     stripePath: "/income/verification/documents/download",
     resource: "income",
     operation: "action",
@@ -2349,7 +2349,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/income/verification/taxforms/get",
+    fastifyPath: "/income/verification/taxforms/get",
     stripePath: "/income/verification/taxforms/get",
     resource: "income",
     operation: "retrieve",
@@ -2358,7 +2358,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/income/verification/precheck",
+    fastifyPath: "/income/verification/precheck",
     stripePath: "/income/verification/precheck",
     resource: "income",
     operation: "action",
@@ -2367,7 +2367,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/employment/verification/get",
+    fastifyPath: "/employment/verification/get",
     stripePath: "/employment/verification/get",
     resource: "employment",
     operation: "retrieve",
@@ -2376,7 +2376,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/audit_copy_token/create",
+    fastifyPath: "/credit/audit_copy_token/create",
     stripePath: "/credit/audit_copy_token/create",
     resource: "credit",
     operation: "create",
@@ -2385,7 +2385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/audit_copy_token/remove",
+    fastifyPath: "/credit/audit_copy_token/remove",
     stripePath: "/credit/audit_copy_token/remove",
     resource: "credit",
     operation: "delete",
@@ -2394,7 +2394,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/asset_report/freddie_mac/get",
+    fastifyPath: "/credit/asset_report/freddie_mac/get",
     stripePath: "/credit/asset_report/freddie_mac/get",
     resource: "credit",
     operation: "retrieve",
@@ -2403,7 +2403,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/freddie_mac/reports/get",
+    fastifyPath: "/credit/freddie_mac/reports/get",
     stripePath: "/credit/freddie_mac/reports/get",
     resource: "credit",
     operation: "retrieve",
@@ -2412,7 +2412,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/credit/v1/bank_employment/get",
+    fastifyPath: "/beta/credit/v1/bank_employment/get",
     stripePath: "/beta/credit/v1/bank_employment/get",
     resource: "beta",
     operation: "retrieve",
@@ -2421,7 +2421,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/bank_income/get",
+    fastifyPath: "/credit/bank_income/get",
     stripePath: "/credit/bank_income/get",
     resource: "credit",
     operation: "retrieve",
@@ -2430,7 +2430,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/bank_income/pdf/get",
+    fastifyPath: "/credit/bank_income/pdf/get",
     stripePath: "/credit/bank_income/pdf/get",
     resource: "credit",
     operation: "retrieve",
@@ -2439,7 +2439,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/bank_income/refresh",
+    fastifyPath: "/credit/bank_income/refresh",
     stripePath: "/credit/bank_income/refresh",
     resource: "credit",
     operation: "action",
@@ -2448,7 +2448,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/bank_income/webhook/update",
+    fastifyPath: "/credit/bank_income/webhook/update",
     stripePath: "/credit/bank_income/webhook/update",
     resource: "credit",
     operation: "update",
@@ -2457,7 +2457,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/payroll_income/parsing_config/update",
+    fastifyPath: "/credit/payroll_income/parsing_config/update",
     stripePath: "/credit/payroll_income/parsing_config/update",
     resource: "credit",
     operation: "update",
@@ -2466,7 +2466,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/bank_statements/uploads/get",
+    fastifyPath: "/credit/bank_statements/uploads/get",
     stripePath: "/credit/bank_statements/uploads/get",
     resource: "credit",
     operation: "retrieve",
@@ -2475,7 +2475,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/payroll_income/get",
+    fastifyPath: "/credit/payroll_income/get",
     stripePath: "/credit/payroll_income/get",
     resource: "credit",
     operation: "retrieve",
@@ -2484,7 +2484,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/payroll_income/risk_signals/get",
+    fastifyPath: "/credit/payroll_income/risk_signals/get",
     stripePath: "/credit/payroll_income/risk_signals/get",
     resource: "credit",
     operation: "retrieve",
@@ -2493,7 +2493,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/payroll_income/precheck",
+    fastifyPath: "/credit/payroll_income/precheck",
     stripePath: "/credit/payroll_income/precheck",
     resource: "credit",
     operation: "action",
@@ -2502,7 +2502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/employment/get",
+    fastifyPath: "/credit/employment/get",
     stripePath: "/credit/employment/get",
     resource: "credit",
     operation: "retrieve",
@@ -2511,7 +2511,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/payroll_income/refresh",
+    fastifyPath: "/credit/payroll_income/refresh",
     stripePath: "/credit/payroll_income/refresh",
     resource: "credit",
     operation: "action",
@@ -2520,7 +2520,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/relay/create",
+    fastifyPath: "/credit/relay/create",
     stripePath: "/credit/relay/create",
     resource: "credit",
     operation: "create",
@@ -2529,7 +2529,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/relay/get",
+    fastifyPath: "/credit/relay/get",
     stripePath: "/credit/relay/get",
     resource: "credit",
     operation: "retrieve",
@@ -2538,7 +2538,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/relay/pdf/get",
+    fastifyPath: "/credit/relay/pdf/get",
     stripePath: "/credit/relay/pdf/get",
     resource: "credit",
     operation: "retrieve",
@@ -2547,7 +2547,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/relay/refresh",
+    fastifyPath: "/credit/relay/refresh",
     stripePath: "/credit/relay/refresh",
     resource: "credit",
     operation: "action",
@@ -2556,7 +2556,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/credit/relay/remove",
+    fastifyPath: "/credit/relay/remove",
     stripePath: "/credit/relay/remove",
     resource: "credit",
     operation: "delete",
@@ -2565,7 +2565,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/bank_transfer/fire_webhook",
+    fastifyPath: "/sandbox/bank_transfer/fire_webhook",
     stripePath: "/sandbox/bank_transfer/fire_webhook",
     resource: "sandbox",
     operation: "action",
@@ -2574,7 +2574,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/income/fire_webhook",
+    fastifyPath: "/sandbox/income/fire_webhook",
     stripePath: "/sandbox/income/fire_webhook",
     resource: "sandbox",
     operation: "action",
@@ -2583,7 +2583,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/bank_income/fire_webhook",
+    fastifyPath: "/sandbox/bank_income/fire_webhook",
     stripePath: "/sandbox/bank_income/fire_webhook",
     resource: "sandbox",
     operation: "action",
@@ -2592,7 +2592,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/cra/cashflow_updates/update",
+    fastifyPath: "/sandbox/cra/cashflow_updates/update",
     stripePath: "/sandbox/cra/cashflow_updates/update",
     resource: "sandbox",
     operation: "update",
@@ -2601,7 +2601,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/sandbox/oauth/select_accounts",
+    fastifyPath: "/sandbox/oauth/select_accounts",
     stripePath: "/sandbox/oauth/select_accounts",
     resource: "sandbox",
     operation: "action",
@@ -2610,7 +2610,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/signal/evaluate",
+    fastifyPath: "/signal/evaluate",
     stripePath: "/signal/evaluate",
     resource: "signal",
     operation: "action",
@@ -2619,7 +2619,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/signal/schedule",
+    fastifyPath: "/signal/schedule",
     stripePath: "/signal/schedule",
     resource: "signal",
     operation: "action",
@@ -2628,7 +2628,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/signal/decision/report",
+    fastifyPath: "/signal/decision/report",
     stripePath: "/signal/decision/report",
     resource: "signal",
     operation: "action",
@@ -2637,7 +2637,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/signal/return/report",
+    fastifyPath: "/signal/return/report",
     stripePath: "/signal/return/report",
     resource: "signal",
     operation: "action",
@@ -2646,7 +2646,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/signal/prepare",
+    fastifyPath: "/signal/prepare",
     stripePath: "/signal/prepare",
     resource: "signal",
     operation: "action",
@@ -2655,7 +2655,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/create",
+    fastifyPath: "/wallet/create",
     stripePath: "/wallet/create",
     resource: "wallet",
     operation: "create",
@@ -2664,7 +2664,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/get",
+    fastifyPath: "/wallet/get",
     stripePath: "/wallet/get",
     resource: "wallet",
     operation: "retrieve",
@@ -2673,7 +2673,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/list",
+    fastifyPath: "/wallet/list",
     stripePath: "/wallet/list",
     resource: "wallet",
     operation: "list",
@@ -2682,7 +2682,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/transaction/execute",
+    fastifyPath: "/wallet/transaction/execute",
     stripePath: "/wallet/transaction/execute",
     resource: "wallet",
     operation: "action",
@@ -2691,7 +2691,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/transaction/get",
+    fastifyPath: "/wallet/transaction/get",
     stripePath: "/wallet/transaction/get",
     resource: "wallet",
     operation: "retrieve",
@@ -2700,7 +2700,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/wallet/transaction/list",
+    fastifyPath: "/wallet/transaction/list",
     stripePath: "/wallet/transaction/list",
     resource: "wallet",
     operation: "list",
@@ -2709,7 +2709,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/transactions/v1/enhance",
+    fastifyPath: "/beta/transactions/v1/enhance",
     stripePath: "/beta/transactions/v1/enhance",
     resource: "beta",
     operation: "action",
@@ -2718,7 +2718,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/transactions/rules/v1/create",
+    fastifyPath: "/beta/transactions/rules/v1/create",
     stripePath: "/beta/transactions/rules/v1/create",
     resource: "beta",
     operation: "create",
@@ -2727,7 +2727,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/transactions/rules/v1/list",
+    fastifyPath: "/beta/transactions/rules/v1/list",
     stripePath: "/beta/transactions/rules/v1/list",
     resource: "beta",
     operation: "list",
@@ -2736,7 +2736,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/transactions/rules/v1/remove",
+    fastifyPath: "/beta/transactions/rules/v1/remove",
     stripePath: "/beta/transactions/rules/v1/remove",
     resource: "beta",
     operation: "delete",
@@ -2745,7 +2745,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/transactions/user_insights/v1/get",
+    fastifyPath: "/beta/transactions/user_insights/v1/get",
     stripePath: "/beta/transactions/user_insights/v1/get",
     resource: "beta",
     operation: "retrieve",
@@ -2754,7 +2754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/ewa_report/v1/get",
+    fastifyPath: "/beta/ewa_report/v1/get",
     stripePath: "/beta/ewa_report/v1/get",
     resource: "beta",
     operation: "retrieve",
@@ -2763,7 +2763,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/issues/search",
+    fastifyPath: "/issues/search",
     stripePath: "/issues/search",
     resource: "issues",
     operation: "action",
@@ -2772,7 +2772,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/issues/get",
+    fastifyPath: "/issues/get",
     stripePath: "/issues/get",
     resource: "issues",
     operation: "retrieve",
@@ -2781,7 +2781,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/issues/subscribe",
+    fastifyPath: "/issues/subscribe",
     stripePath: "/issues/subscribe",
     resource: "issues",
     operation: "action",
@@ -2790,7 +2790,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_profile/create",
+    fastifyPath: "/payment_profile/create",
     stripePath: "/payment_profile/create",
     resource: "payment_profile",
     operation: "create",
@@ -2799,7 +2799,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_profile/get",
+    fastifyPath: "/payment_profile/get",
     stripePath: "/payment_profile/get",
     resource: "payment_profile",
     operation: "retrieve",
@@ -2808,7 +2808,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/payment_profile/remove",
+    fastifyPath: "/payment_profile/remove",
     stripePath: "/payment_profile/remove",
     resource: "payment_profile",
     operation: "delete",
@@ -2817,7 +2817,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/partner/customer/create",
+    fastifyPath: "/partner/customer/create",
     stripePath: "/partner/customer/create",
     resource: "partner",
     operation: "create",
@@ -2826,7 +2826,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/partner/customer/get",
+    fastifyPath: "/partner/customer/get",
     stripePath: "/partner/customer/get",
     resource: "partner",
     operation: "retrieve",
@@ -2835,7 +2835,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/partner/customer/enable",
+    fastifyPath: "/partner/customer/enable",
     stripePath: "/partner/customer/enable",
     resource: "partner",
     operation: "action",
@@ -2844,7 +2844,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/partner/customer/remove",
+    fastifyPath: "/partner/customer/remove",
     stripePath: "/partner/customer/remove",
     resource: "partner",
     operation: "delete",
@@ -2853,7 +2853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/partner/customer/oauth_institutions/get",
+    fastifyPath: "/partner/customer/oauth_institutions/get",
     stripePath: "/partner/customer/oauth_institutions/get",
     resource: "partner",
     operation: "retrieve",
@@ -2862,7 +2862,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/partner/customer/v1/create",
+    fastifyPath: "/beta/partner/customer/v1/create",
     stripePath: "/beta/partner/customer/v1/create",
     resource: "beta",
     operation: "create",
@@ -2871,7 +2871,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/partner/customer/v1/get",
+    fastifyPath: "/beta/partner/customer/v1/get",
     stripePath: "/beta/partner/customer/v1/get",
     resource: "beta",
     operation: "retrieve",
@@ -2880,7 +2880,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/partner/customer/v1/update",
+    fastifyPath: "/beta/partner/customer/v1/update",
     stripePath: "/beta/partner/customer/v1/update",
     resource: "beta",
     operation: "update",
@@ -2889,7 +2889,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/beta/partner/customer/v1/enable",
+    fastifyPath: "/beta/partner/customer/v1/enable",
     stripePath: "/beta/partner/customer/v1/enable",
     resource: "beta",
     operation: "action",
@@ -2898,7 +2898,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/link_delivery/create",
+    fastifyPath: "/link_delivery/create",
     stripePath: "/link_delivery/create",
     resource: "link_delivery",
     operation: "create",
@@ -2907,7 +2907,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/link_delivery/get",
+    fastifyPath: "/link_delivery/get",
     stripePath: "/link_delivery/get",
     resource: "link_delivery",
     operation: "retrieve",
@@ -2916,7 +2916,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/fdx/notifications",
+    fastifyPath: "/fdx/notifications",
     stripePath: "/fdx/notifications",
     resource: "fdx",
     operation: "action",
@@ -2925,7 +2925,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/plaid/fdx/recipients",
+    fastifyPath: "/fdx/recipients",
     stripePath: "/fdx/recipients",
     resource: "fdx",
     operation: "action",
@@ -2934,7 +2934,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/plaid/fdx/recipient/{recipientId}",
+    fastifyPath: "/fdx/recipient/{recipientId}",
     stripePath: "/fdx/recipient/{recipientId}",
     resource: "fdx",
     operation: "action",
@@ -2943,7 +2943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/plaid/network_insights/report/get",
+    fastifyPath: "/network_insights/report/get",
     stripePath: "/network_insights/report/get",
     resource: "network_insights",
     operation: "retrieve",

--- a/packages/adapters/adapter-plaid/src/mcp.ts
+++ b/packages/adapters/adapter-plaid/src/mcp.ts
@@ -27,14 +27,14 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
     institution_id: z.string().optional().describe('Institution ID (default: ins_109508)'),
     initial_products: z.array(z.string()).optional().describe('Products to enable (default: [transactions])'),
   }, async (params) => {
-    const data = await call('/plaid/sandbox/public_token/create', params);
+    const data = await call('/sandbox/public_token/create', params);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('exchange_public_token', 'Exchange a public token for an access token', {
     public_token: z.string().describe('The public token to exchange'),
   }, async (params) => {
-    const data = await call('/plaid/item/public_token/exchange', params);
+    const data = await call('/item/public_token/exchange', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -42,14 +42,14 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
   server.tool('get_item', 'Retrieve an Item', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/item/get', params);
+    const data = await call('/item/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('remove_item', 'Remove an Item', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/item/remove', params);
+    const data = await call('/item/remove', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -57,14 +57,14 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
   server.tool('get_accounts', 'Retrieve accounts for an Item', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/accounts/get', params);
+    const data = await call('/accounts/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('get_balance', 'Get real-time account balances', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/accounts/balance/get', params);
+    const data = await call('/accounts/balance/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -72,7 +72,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
   server.tool('get_auth', 'Retrieve auth data (account + routing numbers)', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/auth/get', params);
+    const data = await call('/auth/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -85,7 +85,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
     offset: z.number().optional().describe('Pagination offset (default 0)'),
   }, async ({ count, offset, ...params }) => {
     const body = { ...params, options: { count, offset } };
-    const data = await call('/plaid/transactions/get', body);
+    const data = await call('/transactions/get', body);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -93,7 +93,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
     access_token: z.string().describe('The access token for the Item'),
     cursor: z.string().optional().describe('Sync cursor from previous call'),
   }, async (params) => {
-    const data = await call('/plaid/transactions/sync', params);
+    const data = await call('/transactions/sync', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -101,7 +101,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
   server.tool('get_identity', 'Get identity data for accounts', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/identity/get', params);
+    const data = await call('/identity/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -111,7 +111,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
     products: z.array(z.string()).optional().describe('Filter by supported products'),
     country_codes: z.array(z.string()).optional().describe('Filter by country codes'),
   }, async (params) => {
-    const data = await call('/plaid/institutions/search', params);
+    const data = await call('/institutions/search', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -119,7 +119,7 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
     institution_id: z.string().describe('The institution ID'),
     country_codes: z.array(z.string()).optional().describe('Country codes'),
   }, async (params) => {
-    const data = await call('/plaid/institutions/get_by_id', params);
+    const data = await call('/institutions/get_by_id', params);
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -127,13 +127,13 @@ export function registerPlaidTools(server: McpServer, baseUrl: string): void {
   server.tool('get_holdings', 'Get investment holdings', {
     access_token: z.string().describe('The access token for the Item'),
   }, async (params) => {
-    const data = await call('/plaid/investments/holdings/get', params);
+    const data = await call('/investments/holdings/get', params);
     return text(JSON.stringify(data, null, 2));
   });
 
   // ── Mimic admin tools ──────────────────────────────────────────────────
   server.tool('plaid_list_endpoints', 'List all available Plaid mock API endpoints', {}, async () => {
-    const endpoints = await call('/plaid/endpoints', {}).catch(() => ({ endpoints: 'Use GET /plaid/endpoints' }));
+    const endpoints = await call('/endpoints', {}).catch(() => ({ endpoints: 'Use GET /endpoints' }));
     return text(JSON.stringify(endpoints, null, 2));
   });
 }

--- a/packages/adapters/adapter-plaid/src/plaid-adapter.ts
+++ b/packages/adapters/adapter-plaid/src/plaid-adapter.ts
@@ -109,61 +109,61 @@ export class PlaidAdapter extends OpenApiMockAdapter<PlaidConfig> {
 
   private mountOverrides(store: StateStore): void {
     // ── Link Token ──────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/link/token/create',
+    this.registerOverride('POST', '/link/token/create',
       coreOverrides.buildLinkTokenCreateHandler(store));
 
     // ── Sandbox ─────────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/sandbox/public_token/create',
+    this.registerOverride('POST', '/sandbox/public_token/create',
       coreOverrides.buildSandboxPublicTokenCreateHandler(store));
-    this.registerOverride('POST', '/plaid/sandbox/item/reset_login',
+    this.registerOverride('POST', '/sandbox/item/reset_login',
       coreOverrides.buildSandboxItemResetLoginHandler(store));
 
     // ── Item / Token Exchange ───────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/item/public_token/exchange',
+    this.registerOverride('POST', '/item/public_token/exchange',
       coreOverrides.buildItemPublicTokenExchangeHandler(store));
-    this.registerOverride('POST', '/plaid/item/get',
+    this.registerOverride('POST', '/item/get',
       coreOverrides.buildItemGetHandler(store));
-    this.registerOverride('POST', '/plaid/item/remove',
+    this.registerOverride('POST', '/item/remove',
       coreOverrides.buildItemRemoveHandler(store));
 
     // ── Accounts ────────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/accounts/get',
+    this.registerOverride('POST', '/accounts/get',
       coreOverrides.buildAccountsGetHandler(store));
-    this.registerOverride('POST', '/plaid/accounts/balance/get',
+    this.registerOverride('POST', '/accounts/balance/get',
       coreOverrides.buildAccountsBalanceGetHandler(store));
 
     // ── Auth ────────────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/auth/get',
+    this.registerOverride('POST', '/auth/get',
       coreOverrides.buildAuthGetHandler(store));
 
     // ── Transactions ────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/transactions/get',
+    this.registerOverride('POST', '/transactions/get',
       coreOverrides.buildTransactionsGetHandler(store));
-    this.registerOverride('POST', '/plaid/transactions/sync',
+    this.registerOverride('POST', '/transactions/sync',
       coreOverrides.buildTransactionsSyncHandler(store));
-    this.registerOverride('POST', '/plaid/transactions/refresh',
+    this.registerOverride('POST', '/transactions/refresh',
       coreOverrides.buildTransactionsRefreshHandler(store));
 
     // ── Identity ────────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/identity/get',
+    this.registerOverride('POST', '/identity/get',
       coreOverrides.buildIdentityGetHandler(store));
 
     // ── Institutions ────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/institutions/get',
+    this.registerOverride('POST', '/institutions/get',
       coreOverrides.buildInstitutionsGetHandler(store));
-    this.registerOverride('POST', '/plaid/institutions/get_by_id',
+    this.registerOverride('POST', '/institutions/get_by_id',
       coreOverrides.buildInstitutionsGetByIdHandler(store));
-    this.registerOverride('POST', '/plaid/institutions/search',
+    this.registerOverride('POST', '/institutions/search',
       coreOverrides.buildInstitutionsSearchHandler(store));
 
     // ── Investments ─────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/investments/holdings/get',
+    this.registerOverride('POST', '/investments/holdings/get',
       coreOverrides.buildInvestmentsHoldingsGetHandler(store));
-    this.registerOverride('POST', '/plaid/investments/transactions/get',
+    this.registerOverride('POST', '/investments/transactions/get',
       coreOverrides.buildInvestmentsTransactionsGetHandler(store));
 
     // ── Categories ──────────────────────────────────────────────────────
-    this.registerOverride('POST', '/plaid/categories/get',
+    this.registerOverride('POST', '/categories/get',
       coreOverrides.buildCategoriesGetHandler());
   }
 }

--- a/packages/adapters/adapter-recurly/adapter.json
+++ b/packages/adapters/adapter-recurly/adapter.json
@@ -3,7 +3,7 @@
   "name": "Recurly API",
   "description": "Recurly subscription management, recurring billing, and revenue recognition mock adapter",
   "type": "api-mock",
-  "basePath": "/recurly",
+  "basePath": "",
   "versions": ["v2021-02-25"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://developers.recurly.com/api/v2021-02-25",

--- a/packages/adapters/adapter-recurly/scripts/recurly-codegen.ts
+++ b/packages/adapters/adapter-recurly/scripts/recurly-codegen.ts
@@ -598,8 +598,8 @@ function extractRoutes(spec: OaSpec, resources: Map<string, ResourceInfo>): Extr
       const httpMethod = method.toUpperCase() as ExtractedRoute['method'];
       const description = operation.summary ?? operation.description ?? '';
 
-      // Convert {param} → :param, add /recurly prefix
-      const fastifyPath = '/recurly' + specPath.replace(/\{([^}]+)\}/g, ':$1');
+      // Convert {param} → :param, 
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, ':$1');
 
       // Determine resource
       const resource = detectRouteResource(specPath, knownKeys);

--- a/packages/adapters/adapter-recurly/src/__tests__/recurly-adapter.test.ts
+++ b/packages/adapters/adapter-recurly/src/__tests__/recurly-adapter.test.ts
@@ -19,7 +19,7 @@ describe('RecurlyAdapter', () => {
 
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('recurly');
-    expect(adapter.basePath).toBe('/recurly');
+    expect(adapter.basePath).toBe('');
     expect(adapter.name).toBe('Recurly API');
   });
 
@@ -37,7 +37,7 @@ describe('RecurlyAdapter', () => {
   it('should create an account', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'acct-001', email: 'test@example.com', first_name: 'Test', last_name: 'User' }),
     });
@@ -52,7 +52,7 @@ describe('RecurlyAdapter', () => {
   it('should list accounts', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/accounts',
+      url: '/accounts',
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -64,7 +64,7 @@ describe('RecurlyAdapter', () => {
     // Create first
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'acct-retrieve', email: 'retrieve@test.com' }),
     });
@@ -72,7 +72,7 @@ describe('RecurlyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/recurly/accounts/${accountId}`,
+      url: `/accounts/${accountId}`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().id).toBe(accountId);
@@ -81,7 +81,7 @@ describe('RecurlyAdapter', () => {
   it('should update an account', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'acct-update' }),
     });
@@ -89,7 +89,7 @@ describe('RecurlyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/accounts/${accountId}`,
+      url: `/accounts/${accountId}`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ company: 'Updated Corp' }),
     });
@@ -100,7 +100,7 @@ describe('RecurlyAdapter', () => {
   it('should return 404 for non-existent account', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/accounts/acct_nonexistent',
+      url: '/accounts/acct_nonexistent',
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -112,7 +112,7 @@ describe('RecurlyAdapter', () => {
   it('should deactivate an account', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'acct-deactivate' }),
     });
@@ -120,7 +120,7 @@ describe('RecurlyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'DELETE',
-      url: `/recurly/accounts/${accountId}`,
+      url: `/accounts/${accountId}`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().state).toBe('closed');
@@ -129,7 +129,7 @@ describe('RecurlyAdapter', () => {
   it('should reactivate a closed account', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'acct-reactivate' }),
     });
@@ -138,13 +138,13 @@ describe('RecurlyAdapter', () => {
     // Deactivate
     await ts.server.inject({
       method: 'DELETE',
-      url: `/recurly/accounts/${accountId}`,
+      url: `/accounts/${accountId}`,
     });
 
     // Reactivate
     const res = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/accounts/${accountId}/reactivate`,
+      url: `/accounts/${accountId}/reactivate`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().state).toBe('active');
@@ -155,7 +155,7 @@ describe('RecurlyAdapter', () => {
   it('should create a plan', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/plans',
+      url: '/plans',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'basic-monthly', name: 'Basic Monthly', interval_unit: 'months', interval_length: 1 }),
     });
@@ -168,7 +168,7 @@ describe('RecurlyAdapter', () => {
   it('should list plans', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/plans',
+      url: '/plans',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().data.length).toBeGreaterThan(0);
@@ -179,7 +179,7 @@ describe('RecurlyAdapter', () => {
   it('should create a subscription', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ plan_code: 'basic-monthly', currency: 'USD' }),
     });
@@ -192,7 +192,7 @@ describe('RecurlyAdapter', () => {
   it('should list subscriptions', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().data.length).toBeGreaterThan(0);
@@ -201,7 +201,7 @@ describe('RecurlyAdapter', () => {
   it('should cancel a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ plan_code: 'cancel-test' }),
     });
@@ -209,7 +209,7 @@ describe('RecurlyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/subscriptions/${subId}/cancel`,
+      url: `/subscriptions/${subId}/cancel`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().state).toBe('canceled');
@@ -218,7 +218,7 @@ describe('RecurlyAdapter', () => {
   it('should reactivate a canceled subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ plan_code: 'reactivate-test' }),
     });
@@ -227,13 +227,13 @@ describe('RecurlyAdapter', () => {
     // Cancel
     await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/subscriptions/${subId}/cancel`,
+      url: `/subscriptions/${subId}/cancel`,
     });
 
     // Reactivate
     const res = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/subscriptions/${subId}/reactivate`,
+      url: `/subscriptions/${subId}/reactivate`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().state).toBe('active');
@@ -242,7 +242,7 @@ describe('RecurlyAdapter', () => {
   it('should pause and resume a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ plan_code: 'pause-test' }),
     });
@@ -251,7 +251,7 @@ describe('RecurlyAdapter', () => {
     // Pause
     const pauseRes = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/subscriptions/${subId}/pause`,
+      url: `/subscriptions/${subId}/pause`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ remaining_pause_cycles: 2 }),
     });
@@ -261,7 +261,7 @@ describe('RecurlyAdapter', () => {
     // Resume
     const resumeRes = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/subscriptions/${subId}/resume`,
+      url: `/subscriptions/${subId}/resume`,
     });
     expect(resumeRes.statusCode).toBe(200);
     expect(resumeRes.json().state).toBe('active');
@@ -270,7 +270,7 @@ describe('RecurlyAdapter', () => {
   it('should terminate a subscription', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/subscriptions',
+      url: '/subscriptions',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ plan_code: 'terminate-test' }),
     });
@@ -278,7 +278,7 @@ describe('RecurlyAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'DELETE',
-      url: `/recurly/subscriptions/${subId}`,
+      url: `/subscriptions/${subId}`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().state).toBe('expired');
@@ -289,7 +289,7 @@ describe('RecurlyAdapter', () => {
   it('should list invoices', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/invoices',
+      url: '/invoices',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().object).toBe('list');
@@ -299,7 +299,7 @@ describe('RecurlyAdapter', () => {
     // Create an invoice via the account sub-resource
     const acctRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'inv-test-acct' }),
     });
@@ -307,7 +307,7 @@ describe('RecurlyAdapter', () => {
 
     const invRes = await ts.server.inject({
       method: 'POST',
-      url: `/recurly/accounts/${accountId}/invoices`,
+      url: `/accounts/${accountId}/invoices`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ currency: 'USD' }),
     });
@@ -317,7 +317,7 @@ describe('RecurlyAdapter', () => {
     // Collect it
     const collectRes = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/invoices/${invoiceId}/collect`,
+      url: `/invoices/${invoiceId}/collect`,
     });
     expect(collectRes.statusCode).toBe(200);
     expect(collectRes.json().state).toBe('paid');
@@ -326,7 +326,7 @@ describe('RecurlyAdapter', () => {
   it('should void an invoice', async () => {
     const acctRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/accounts',
+      url: '/accounts',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'void-inv-acct' }),
     });
@@ -334,7 +334,7 @@ describe('RecurlyAdapter', () => {
 
     const invRes = await ts.server.inject({
       method: 'POST',
-      url: `/recurly/accounts/${accountId}/invoices`,
+      url: `/accounts/${accountId}/invoices`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ currency: 'USD' }),
     });
@@ -342,7 +342,7 @@ describe('RecurlyAdapter', () => {
 
     const voidRes = await ts.server.inject({
       method: 'PUT',
-      url: `/recurly/invoices/${invoiceId}/void`,
+      url: `/invoices/${invoiceId}/void`,
     });
     expect(voidRes.statusCode).toBe(200);
     expect(voidRes.json().state).toBe('voided');
@@ -353,7 +353,7 @@ describe('RecurlyAdapter', () => {
   it('should create and list coupons', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/coupons',
+      url: '/coupons',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'SUMMER20', name: 'Summer 20% Off', discount_type: 'percent', discount_percent: 20 }),
     });
@@ -362,7 +362,7 @@ describe('RecurlyAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/coupons',
+      url: '/coupons',
     });
     expect(listRes.statusCode).toBe(200);
     expect(listRes.json().data.length).toBeGreaterThan(0);
@@ -373,7 +373,7 @@ describe('RecurlyAdapter', () => {
   it('should create and list items', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: '/recurly/items',
+      url: '/items',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ code: 'widget-001', name: 'Widget' }),
     });
@@ -382,7 +382,7 @@ describe('RecurlyAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/items',
+      url: '/items',
     });
     expect(listRes.statusCode).toBe(200);
     expect(listRes.json().data.length).toBeGreaterThan(0);
@@ -393,7 +393,7 @@ describe('RecurlyAdapter', () => {
   it('should list add-ons', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/add_ons',
+      url: '/add_ons',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().object).toBe('list');
@@ -404,7 +404,7 @@ describe('RecurlyAdapter', () => {
   it('should list transactions', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: '/recurly/transactions',
+      url: '/transactions',
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().object).toBe('list');
@@ -441,7 +441,7 @@ describe('RecurlyAdapter', () => {
 
     const seededAdapter = new RecurlyAdapter();
     const seededTs = await buildTestServer(seededAdapter, seedData);
-    const res = await seededTs.server.inject({ method: 'GET', url: '/recurly/accounts' });
+    const res = await seededTs.server.inject({ method: 'GET', url: '/accounts' });
     expect(res.json().data).toContainEqual(expect.objectContaining({ id: 'acct_seed1' }));
     await seededTs.close();
   });

--- a/packages/adapters/adapter-recurly/src/generated/meta.ts
+++ b/packages/adapters/adapter-recurly/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-recurly generate
 // Recurly OpenAPI spec version: v2021-02-25
-// Generated at: 2026-03-12T22:02:55.910Z
+// Generated at: 2026-03-20T11:03:15.418Z
 
 export const RECURLY_SPEC_VERSION = "v2021-02-25";
-export const RECURLY_SPEC_GENERATED_AT = "2026-03-12T22:02:55.910Z";
+export const RECURLY_SPEC_GENERATED_AT = "2026-03-20T11:03:15.418Z";

--- a/packages/adapters/adapter-recurly/src/generated/routes.ts
+++ b/packages/adapters/adapter-recurly/src/generated/routes.ts
@@ -18,7 +18,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/recurly/sites",
+    fastifyPath: "/sites",
     stripePath: "/sites",
     resource: "sites",
     operation: "list",
@@ -28,7 +28,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/sites/:site_id",
+    fastifyPath: "/sites/:site_id",
     stripePath: "/sites/{site_id}",
     resource: "sites",
     operation: "retrieve",
@@ -39,7 +39,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts",
+    fastifyPath: "/accounts",
     stripePath: "/accounts",
     resource: "accounts",
     operation: "list",
@@ -49,7 +49,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts",
+    fastifyPath: "/accounts",
     stripePath: "/accounts",
     resource: "accounts",
     operation: "create",
@@ -59,7 +59,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id",
+    fastifyPath: "/accounts/:account_id",
     stripePath: "/accounts/{account_id}",
     resource: "accounts",
     operation: "retrieve",
@@ -70,7 +70,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id",
+    fastifyPath: "/accounts/:account_id",
     stripePath: "/accounts/{account_id}",
     resource: "accounts",
     operation: "update",
@@ -81,7 +81,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id",
+    fastifyPath: "/accounts/:account_id",
     stripePath: "/accounts/{account_id}",
     resource: "accounts",
     operation: "action",
@@ -92,7 +92,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/acquisition",
+    fastifyPath: "/accounts/:account_id/acquisition",
     stripePath: "/accounts/{account_id}/acquisition",
     resource: "accounts",
     operation: "list",
@@ -103,7 +103,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/acquisition",
+    fastifyPath: "/accounts/:account_id/acquisition",
     stripePath: "/accounts/{account_id}/acquisition",
     resource: "accounts",
     operation: "action",
@@ -114,7 +114,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/acquisition",
+    fastifyPath: "/accounts/:account_id/acquisition",
     stripePath: "/accounts/{account_id}/acquisition",
     resource: "accounts",
     operation: "delete",
@@ -125,7 +125,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/reactivate",
+    fastifyPath: "/accounts/:account_id/reactivate",
     stripePath: "/accounts/{account_id}/reactivate",
     resource: "accounts",
     operation: "action",
@@ -136,7 +136,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/balance",
+    fastifyPath: "/accounts/:account_id/balance",
     stripePath: "/accounts/{account_id}/balance",
     resource: "accounts",
     operation: "list",
@@ -147,7 +147,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/billing_info",
+    fastifyPath: "/accounts/:account_id/billing_info",
     stripePath: "/accounts/{account_id}/billing_info",
     resource: "accounts",
     operation: "list",
@@ -158,7 +158,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/billing_info",
+    fastifyPath: "/accounts/:account_id/billing_info",
     stripePath: "/accounts/{account_id}/billing_info",
     resource: "accounts",
     operation: "action",
@@ -169,7 +169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/billing_info",
+    fastifyPath: "/accounts/:account_id/billing_info",
     stripePath: "/accounts/{account_id}/billing_info",
     resource: "accounts",
     operation: "delete",
@@ -180,7 +180,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/billing_info/verify",
+    fastifyPath: "/accounts/:account_id/billing_info/verify",
     stripePath: "/accounts/{account_id}/billing_info/verify",
     resource: "accounts",
     operation: "action",
@@ -191,7 +191,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/billing_info/verify_cvv",
+    fastifyPath: "/accounts/:account_id/billing_info/verify_cvv",
     stripePath: "/accounts/{account_id}/billing_info/verify_cvv",
     resource: "accounts",
     operation: "action",
@@ -202,7 +202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos",
+    fastifyPath: "/accounts/:account_id/billing_infos",
     stripePath: "/accounts/{account_id}/billing_infos",
     resource: "billing_infos",
     operation: "list",
@@ -213,7 +213,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos",
+    fastifyPath: "/accounts/:account_id/billing_infos",
     stripePath: "/accounts/{account_id}/billing_infos",
     resource: "billing_infos",
     operation: "create",
@@ -224,7 +224,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos/:billing_info_id",
+    fastifyPath: "/accounts/:account_id/billing_infos/:billing_info_id",
     stripePath: "/accounts/{account_id}/billing_infos/{billing_info_id}",
     resource: "billing_infos",
     operation: "retrieve",
@@ -235,7 +235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos/:billing_info_id",
+    fastifyPath: "/accounts/:account_id/billing_infos/:billing_info_id",
     stripePath: "/accounts/{account_id}/billing_infos/{billing_info_id}",
     resource: "billing_infos",
     operation: "update",
@@ -246,7 +246,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos/:billing_info_id",
+    fastifyPath: "/accounts/:account_id/billing_infos/:billing_info_id",
     stripePath: "/accounts/{account_id}/billing_infos/{billing_info_id}",
     resource: "billing_infos",
     operation: "delete",
@@ -257,7 +257,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos/:billing_info_id/verify",
+    fastifyPath: "/accounts/:account_id/billing_infos/:billing_info_id/verify",
     stripePath: "/accounts/{account_id}/billing_infos/{billing_info_id}/verify",
     resource: "billing_infos",
     operation: "action",
@@ -268,7 +268,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/billing_infos/:billing_info_id/verify_cvv",
+    fastifyPath: "/accounts/:account_id/billing_infos/:billing_info_id/verify_cvv",
     stripePath: "/accounts/{account_id}/billing_infos/{billing_info_id}/verify_cvv",
     resource: "billing_infos",
     operation: "action",
@@ -279,7 +279,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions",
     stripePath: "/accounts/{account_id}/coupon_redemptions",
     resource: "coupon_redemptions",
     operation: "list",
@@ -290,7 +290,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions/active",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions/active",
     stripePath: "/accounts/{account_id}/coupon_redemptions/active",
     resource: "coupon_redemptions",
     operation: "action",
@@ -301,7 +301,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions/active",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions/active",
     stripePath: "/accounts/{account_id}/coupon_redemptions/active",
     resource: "coupon_redemptions",
     operation: "action",
@@ -312,7 +312,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions/active",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions/active",
     stripePath: "/accounts/{account_id}/coupon_redemptions/active",
     resource: "coupon_redemptions",
     operation: "action",
@@ -323,7 +323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions/:coupon_redemption_id",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions/:coupon_redemption_id",
     stripePath: "/accounts/{account_id}/coupon_redemptions/{coupon_redemption_id}",
     resource: "coupon_redemptions",
     operation: "retrieve",
@@ -334,7 +334,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/coupon_redemptions/:coupon_redemption_id",
+    fastifyPath: "/accounts/:account_id/coupon_redemptions/:coupon_redemption_id",
     stripePath: "/accounts/{account_id}/coupon_redemptions/{coupon_redemption_id}",
     resource: "coupon_redemptions",
     operation: "delete",
@@ -345,7 +345,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/credit_payments",
+    fastifyPath: "/accounts/:account_id/credit_payments",
     stripePath: "/accounts/{account_id}/credit_payments",
     resource: "credit_payments",
     operation: "list",
@@ -356,7 +356,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/external_accounts",
+    fastifyPath: "/accounts/:account_id/external_accounts",
     stripePath: "/accounts/{account_id}/external_accounts",
     resource: "external_accounts",
     operation: "list",
@@ -367,7 +367,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/external_accounts",
+    fastifyPath: "/accounts/:account_id/external_accounts",
     stripePath: "/accounts/{account_id}/external_accounts",
     resource: "external_accounts",
     operation: "create",
@@ -378,7 +378,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/external_accounts/:external_account_id",
+    fastifyPath: "/accounts/:account_id/external_accounts/:external_account_id",
     stripePath: "/accounts/{account_id}/external_accounts/{external_account_id}",
     resource: "external_accounts",
     operation: "retrieve",
@@ -389,7 +389,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/external_accounts/:external_account_id",
+    fastifyPath: "/accounts/:account_id/external_accounts/:external_account_id",
     stripePath: "/accounts/{account_id}/external_accounts/{external_account_id}",
     resource: "external_accounts",
     operation: "update",
@@ -400,7 +400,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/external_accounts/:external_account_id",
+    fastifyPath: "/accounts/:account_id/external_accounts/:external_account_id",
     stripePath: "/accounts/{account_id}/external_accounts/{external_account_id}",
     resource: "external_accounts",
     operation: "delete",
@@ -411,7 +411,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/external_invoices",
+    fastifyPath: "/accounts/:account_id/external_invoices",
     stripePath: "/accounts/{account_id}/external_invoices",
     resource: "external_invoices",
     operation: "list",
@@ -422,7 +422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/invoices",
+    fastifyPath: "/accounts/:account_id/invoices",
     stripePath: "/accounts/{account_id}/invoices",
     resource: "invoices",
     operation: "list",
@@ -433,7 +433,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/invoices",
+    fastifyPath: "/accounts/:account_id/invoices",
     stripePath: "/accounts/{account_id}/invoices",
     resource: "invoices",
     operation: "create",
@@ -444,7 +444,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/invoices/preview",
+    fastifyPath: "/accounts/:account_id/invoices/preview",
     stripePath: "/accounts/{account_id}/invoices/preview",
     resource: "invoices",
     operation: "action",
@@ -455,7 +455,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/line_items",
+    fastifyPath: "/accounts/:account_id/line_items",
     stripePath: "/accounts/{account_id}/line_items",
     resource: "line_items",
     operation: "list",
@@ -466,7 +466,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/line_items",
+    fastifyPath: "/accounts/:account_id/line_items",
     stripePath: "/accounts/{account_id}/line_items",
     resource: "line_items",
     operation: "create",
@@ -477,7 +477,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/notes",
+    fastifyPath: "/accounts/:account_id/notes",
     stripePath: "/accounts/{account_id}/notes",
     resource: "notes",
     operation: "list",
@@ -488,7 +488,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/notes",
+    fastifyPath: "/accounts/:account_id/notes",
     stripePath: "/accounts/{account_id}/notes",
     resource: "notes",
     operation: "create",
@@ -499,7 +499,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/notes/:account_note_id",
+    fastifyPath: "/accounts/:account_id/notes/:account_note_id",
     stripePath: "/accounts/{account_id}/notes/{account_note_id}",
     resource: "notes",
     operation: "retrieve",
@@ -510,7 +510,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/notes/:account_note_id",
+    fastifyPath: "/accounts/:account_id/notes/:account_note_id",
     stripePath: "/accounts/{account_id}/notes/{account_note_id}",
     resource: "notes",
     operation: "delete",
@@ -521,7 +521,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/shipping_addresses",
+    fastifyPath: "/accounts/:account_id/shipping_addresses",
     stripePath: "/accounts/{account_id}/shipping_addresses",
     resource: "shipping_addresses",
     operation: "list",
@@ -532,7 +532,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/accounts/:account_id/shipping_addresses",
+    fastifyPath: "/accounts/:account_id/shipping_addresses",
     stripePath: "/accounts/{account_id}/shipping_addresses",
     resource: "shipping_addresses",
     operation: "create",
@@ -543,7 +543,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/shipping_addresses/:shipping_address_id",
+    fastifyPath: "/accounts/:account_id/shipping_addresses/:shipping_address_id",
     stripePath: "/accounts/{account_id}/shipping_addresses/{shipping_address_id}",
     resource: "shipping_addresses",
     operation: "retrieve",
@@ -554,7 +554,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/accounts/:account_id/shipping_addresses/:shipping_address_id",
+    fastifyPath: "/accounts/:account_id/shipping_addresses/:shipping_address_id",
     stripePath: "/accounts/{account_id}/shipping_addresses/{shipping_address_id}",
     resource: "shipping_addresses",
     operation: "update",
@@ -565,7 +565,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/accounts/:account_id/shipping_addresses/:shipping_address_id",
+    fastifyPath: "/accounts/:account_id/shipping_addresses/:shipping_address_id",
     stripePath: "/accounts/{account_id}/shipping_addresses/{shipping_address_id}",
     resource: "shipping_addresses",
     operation: "delete",
@@ -576,7 +576,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/subscriptions",
+    fastifyPath: "/accounts/:account_id/subscriptions",
     stripePath: "/accounts/{account_id}/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -587,7 +587,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/transactions",
+    fastifyPath: "/accounts/:account_id/transactions",
     stripePath: "/accounts/{account_id}/transactions",
     resource: "transactions",
     operation: "list",
@@ -598,7 +598,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/accounts",
+    fastifyPath: "/accounts/:account_id/accounts",
     stripePath: "/accounts/{account_id}/accounts",
     resource: "accounts",
     operation: "list",
@@ -609,7 +609,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/acquisitions",
+    fastifyPath: "/acquisitions",
     stripePath: "/acquisitions",
     resource: "acquisitions",
     operation: "list",
@@ -618,7 +618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/coupons",
+    fastifyPath: "/coupons",
     stripePath: "/coupons",
     resource: "coupons",
     operation: "list",
@@ -628,7 +628,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/coupons",
+    fastifyPath: "/coupons",
     stripePath: "/coupons",
     resource: "coupons",
     operation: "create",
@@ -638,7 +638,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/coupons/:coupon_id",
+    fastifyPath: "/coupons/:coupon_id",
     stripePath: "/coupons/{coupon_id}",
     resource: "coupons",
     operation: "retrieve",
@@ -649,7 +649,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/coupons/:coupon_id",
+    fastifyPath: "/coupons/:coupon_id",
     stripePath: "/coupons/{coupon_id}",
     resource: "coupons",
     operation: "update",
@@ -660,7 +660,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/coupons/:coupon_id",
+    fastifyPath: "/coupons/:coupon_id",
     stripePath: "/coupons/{coupon_id}",
     resource: "coupons",
     operation: "action",
@@ -671,7 +671,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/coupons/:coupon_id/generate",
+    fastifyPath: "/coupons/:coupon_id/generate",
     stripePath: "/coupons/{coupon_id}/generate",
     resource: "coupons",
     operation: "action",
@@ -682,7 +682,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/coupons/:coupon_id/restore",
+    fastifyPath: "/coupons/:coupon_id/restore",
     stripePath: "/coupons/{coupon_id}/restore",
     resource: "coupons",
     operation: "action",
@@ -693,7 +693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/coupons/:coupon_id/unique_coupon_codes",
+    fastifyPath: "/coupons/:coupon_id/unique_coupon_codes",
     stripePath: "/coupons/{coupon_id}/unique_coupon_codes",
     resource: "unique_coupon_codes",
     operation: "list",
@@ -704,7 +704,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/credit_payments",
+    fastifyPath: "/credit_payments",
     stripePath: "/credit_payments",
     resource: "credit_payments",
     operation: "list",
@@ -714,7 +714,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/credit_payments/:credit_payment_id",
+    fastifyPath: "/credit_payments/:credit_payment_id",
     stripePath: "/credit_payments/{credit_payment_id}",
     resource: "credit_payments",
     operation: "retrieve",
@@ -725,7 +725,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/custom_field_definitions",
+    fastifyPath: "/custom_field_definitions",
     stripePath: "/custom_field_definitions",
     resource: "custom_field_definitions",
     operation: "list",
@@ -735,7 +735,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/custom_field_definitions/:custom_field_definition_id",
+    fastifyPath: "/custom_field_definitions/:custom_field_definition_id",
     stripePath: "/custom_field_definitions/{custom_field_definition_id}",
     resource: "custom_field_definitions",
     operation: "retrieve",
@@ -746,7 +746,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/general_ledger_accounts",
+    fastifyPath: "/general_ledger_accounts",
     stripePath: "/general_ledger_accounts",
     resource: "general_ledger_accounts",
     operation: "list",
@@ -756,7 +756,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/general_ledger_accounts",
+    fastifyPath: "/general_ledger_accounts",
     stripePath: "/general_ledger_accounts",
     resource: "general_ledger_accounts",
     operation: "create",
@@ -766,7 +766,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/general_ledger_accounts/:general_ledger_account_id",
+    fastifyPath: "/general_ledger_accounts/:general_ledger_account_id",
     stripePath: "/general_ledger_accounts/{general_ledger_account_id}",
     resource: "general_ledger_accounts",
     operation: "retrieve",
@@ -777,7 +777,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/general_ledger_accounts/:general_ledger_account_id",
+    fastifyPath: "/general_ledger_accounts/:general_ledger_account_id",
     stripePath: "/general_ledger_accounts/{general_ledger_account_id}",
     resource: "general_ledger_accounts",
     operation: "update",
@@ -788,7 +788,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/performance_obligations/:performance_obligation_id",
+    fastifyPath: "/performance_obligations/:performance_obligation_id",
     stripePath: "/performance_obligations/{performance_obligation_id}",
     resource: "performance_obligations",
     operation: "retrieve",
@@ -799,7 +799,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/performance_obligations",
+    fastifyPath: "/performance_obligations",
     stripePath: "/performance_obligations",
     resource: "performance_obligations",
     operation: "list",
@@ -809,7 +809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoice_templates/:invoice_template_id/accounts",
+    fastifyPath: "/invoice_templates/:invoice_template_id/accounts",
     stripePath: "/invoice_templates/{invoice_template_id}/accounts",
     resource: "accounts",
     operation: "list",
@@ -820,7 +820,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/items",
+    fastifyPath: "/items",
     stripePath: "/items",
     resource: "items",
     operation: "list",
@@ -830,7 +830,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/items",
+    fastifyPath: "/items",
     stripePath: "/items",
     resource: "items",
     operation: "create",
@@ -840,7 +840,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/items/:item_id",
+    fastifyPath: "/items/:item_id",
     stripePath: "/items/{item_id}",
     resource: "items",
     operation: "retrieve",
@@ -851,7 +851,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/items/:item_id",
+    fastifyPath: "/items/:item_id",
     stripePath: "/items/{item_id}",
     resource: "items",
     operation: "update",
@@ -862,7 +862,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/items/:item_id",
+    fastifyPath: "/items/:item_id",
     stripePath: "/items/{item_id}",
     resource: "items",
     operation: "action",
@@ -873,7 +873,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/items/:item_id/reactivate",
+    fastifyPath: "/items/:item_id/reactivate",
     stripePath: "/items/{item_id}/reactivate",
     resource: "items",
     operation: "action",
@@ -884,7 +884,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/measured_units",
+    fastifyPath: "/measured_units",
     stripePath: "/measured_units",
     resource: "measured_units",
     operation: "list",
@@ -894,7 +894,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/measured_units",
+    fastifyPath: "/measured_units",
     stripePath: "/measured_units",
     resource: "measured_units",
     operation: "create",
@@ -904,7 +904,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/measured_units/:measured_unit_id",
+    fastifyPath: "/measured_units/:measured_unit_id",
     stripePath: "/measured_units/{measured_unit_id}",
     resource: "measured_units",
     operation: "retrieve",
@@ -915,7 +915,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/measured_units/:measured_unit_id",
+    fastifyPath: "/measured_units/:measured_unit_id",
     stripePath: "/measured_units/{measured_unit_id}",
     resource: "measured_units",
     operation: "update",
@@ -926,7 +926,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/measured_units/:measured_unit_id",
+    fastifyPath: "/measured_units/:measured_unit_id",
     stripePath: "/measured_units/{measured_unit_id}",
     resource: "measured_units",
     operation: "delete",
@@ -937,7 +937,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_products",
+    fastifyPath: "/external_products",
     stripePath: "/external_products",
     resource: "external_products",
     operation: "list",
@@ -947,7 +947,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/external_products",
+    fastifyPath: "/external_products",
     stripePath: "/external_products",
     resource: "external_products",
     operation: "create",
@@ -957,7 +957,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_products/:external_product_id",
+    fastifyPath: "/external_products/:external_product_id",
     stripePath: "/external_products/{external_product_id}",
     resource: "external_products",
     operation: "retrieve",
@@ -968,7 +968,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/external_products/:external_product_id",
+    fastifyPath: "/external_products/:external_product_id",
     stripePath: "/external_products/{external_product_id}",
     resource: "external_products",
     operation: "update",
@@ -979,7 +979,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/external_products/:external_product_id",
+    fastifyPath: "/external_products/:external_product_id",
     stripePath: "/external_products/{external_product_id}",
     resource: "external_products",
     operation: "action",
@@ -990,7 +990,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_products/:external_product_id/external_product_references",
+    fastifyPath: "/external_products/:external_product_id/external_product_references",
     stripePath: "/external_products/{external_product_id}/external_product_references",
     resource: "external_products",
     operation: "list",
@@ -1001,7 +1001,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/external_products/:external_product_id/external_product_references",
+    fastifyPath: "/external_products/:external_product_id/external_product_references",
     stripePath: "/external_products/{external_product_id}/external_product_references",
     resource: "external_products",
     operation: "create",
@@ -1012,7 +1012,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_products/:external_product_id/external_product_references/:external_product_reference_id",
+    fastifyPath: "/external_products/:external_product_id/external_product_references/:external_product_reference_id",
     stripePath: "/external_products/{external_product_id}/external_product_references/{external_product_reference_id}",
     resource: "external_products",
     operation: "retrieve",
@@ -1023,7 +1023,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/external_products/:external_product_id/external_product_references/:external_product_reference_id",
+    fastifyPath: "/external_products/:external_product_id/external_product_references/:external_product_reference_id",
     stripePath: "/external_products/{external_product_id}/external_product_references/{external_product_reference_id}",
     resource: "external_products",
     operation: "action",
@@ -1034,7 +1034,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_subscriptions",
+    fastifyPath: "/external_subscriptions",
     stripePath: "/external_subscriptions",
     resource: "external_subscriptions",
     operation: "list",
@@ -1044,7 +1044,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/external_subscriptions",
+    fastifyPath: "/external_subscriptions",
     stripePath: "/external_subscriptions",
     resource: "external_subscriptions",
     operation: "create",
@@ -1054,7 +1054,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id",
+    fastifyPath: "/external_subscriptions/:external_subscription_id",
     stripePath: "/external_subscriptions/{external_subscription_id}",
     resource: "external_subscriptions",
     operation: "retrieve",
@@ -1065,7 +1065,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id",
+    fastifyPath: "/external_subscriptions/:external_subscription_id",
     stripePath: "/external_subscriptions/{external_subscription_id}",
     resource: "external_subscriptions",
     operation: "update",
@@ -1076,7 +1076,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id/external_invoices",
+    fastifyPath: "/external_subscriptions/:external_subscription_id/external_invoices",
     stripePath: "/external_subscriptions/{external_subscription_id}/external_invoices",
     resource: "external_invoices",
     operation: "list",
@@ -1087,7 +1087,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id/external_invoices",
+    fastifyPath: "/external_subscriptions/:external_subscription_id/external_invoices",
     stripePath: "/external_subscriptions/{external_subscription_id}/external_invoices",
     resource: "external_invoices",
     operation: "create",
@@ -1098,7 +1098,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoices",
+    fastifyPath: "/invoices",
     stripePath: "/invoices",
     resource: "invoices",
     operation: "list",
@@ -1108,7 +1108,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoices/:invoice_id",
+    fastifyPath: "/invoices/:invoice_id",
     stripePath: "/invoices/{invoice_id}",
     resource: "invoices",
     operation: "retrieve",
@@ -1119,7 +1119,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id",
+    fastifyPath: "/invoices/:invoice_id",
     stripePath: "/invoices/{invoice_id}",
     resource: "invoices",
     operation: "update",
@@ -1130,7 +1130,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/apply_credit_balance",
+    fastifyPath: "/invoices/:invoice_id/apply_credit_balance",
     stripePath: "/invoices/{invoice_id}/apply_credit_balance",
     resource: "invoices",
     operation: "action",
@@ -1141,7 +1141,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/collect",
+    fastifyPath: "/invoices/:invoice_id/collect",
     stripePath: "/invoices/{invoice_id}/collect",
     resource: "invoices",
     operation: "action",
@@ -1152,7 +1152,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/mark_failed",
+    fastifyPath: "/invoices/:invoice_id/mark_failed",
     stripePath: "/invoices/{invoice_id}/mark_failed",
     resource: "invoices",
     operation: "action",
@@ -1163,7 +1163,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/mark_successful",
+    fastifyPath: "/invoices/:invoice_id/mark_successful",
     stripePath: "/invoices/{invoice_id}/mark_successful",
     resource: "invoices",
     operation: "action",
@@ -1174,7 +1174,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/reopen",
+    fastifyPath: "/invoices/:invoice_id/reopen",
     stripePath: "/invoices/{invoice_id}/reopen",
     resource: "invoices",
     operation: "action",
@@ -1185,7 +1185,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/invoices/:invoice_id/void",
+    fastifyPath: "/invoices/:invoice_id/void",
     stripePath: "/invoices/{invoice_id}/void",
     resource: "invoices",
     operation: "action",
@@ -1196,7 +1196,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/invoices/:invoice_id/transactions",
+    fastifyPath: "/invoices/:invoice_id/transactions",
     stripePath: "/invoices/{invoice_id}/transactions",
     resource: "transactions",
     operation: "action",
@@ -1207,7 +1207,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoices/:invoice_id/line_items",
+    fastifyPath: "/invoices/:invoice_id/line_items",
     stripePath: "/invoices/{invoice_id}/line_items",
     resource: "line_items",
     operation: "list",
@@ -1218,7 +1218,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoices/:invoice_id/coupon_redemptions",
+    fastifyPath: "/invoices/:invoice_id/coupon_redemptions",
     stripePath: "/invoices/{invoice_id}/coupon_redemptions",
     resource: "coupon_redemptions",
     operation: "list",
@@ -1229,7 +1229,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoices/:invoice_id/related_invoices",
+    fastifyPath: "/invoices/:invoice_id/related_invoices",
     stripePath: "/invoices/{invoice_id}/related_invoices",
     resource: "invoices",
     operation: "list",
@@ -1240,7 +1240,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/invoices/:invoice_id/refund",
+    fastifyPath: "/invoices/:invoice_id/refund",
     stripePath: "/invoices/{invoice_id}/refund",
     resource: "invoices",
     operation: "action",
@@ -1251,7 +1251,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/line_items",
+    fastifyPath: "/line_items",
     stripePath: "/line_items",
     resource: "line_items",
     operation: "list",
@@ -1261,7 +1261,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/line_items/:line_item_id",
+    fastifyPath: "/line_items/:line_item_id",
     stripePath: "/line_items/{line_item_id}",
     resource: "line_items",
     operation: "retrieve",
@@ -1272,7 +1272,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/line_items/:line_item_id",
+    fastifyPath: "/line_items/:line_item_id",
     stripePath: "/line_items/{line_item_id}",
     resource: "line_items",
     operation: "delete",
@@ -1283,7 +1283,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/plans",
+    fastifyPath: "/plans",
     stripePath: "/plans",
     resource: "plans",
     operation: "list",
@@ -1293,7 +1293,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/plans",
+    fastifyPath: "/plans",
     stripePath: "/plans",
     resource: "plans",
     operation: "create",
@@ -1303,7 +1303,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/plans/:plan_id",
+    fastifyPath: "/plans/:plan_id",
     stripePath: "/plans/{plan_id}",
     resource: "plans",
     operation: "retrieve",
@@ -1314,7 +1314,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/plans/:plan_id",
+    fastifyPath: "/plans/:plan_id",
     stripePath: "/plans/{plan_id}",
     resource: "plans",
     operation: "update",
@@ -1325,7 +1325,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/plans/:plan_id",
+    fastifyPath: "/plans/:plan_id",
     stripePath: "/plans/{plan_id}",
     resource: "plans",
     operation: "delete",
@@ -1336,7 +1336,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/plans/:plan_id/add_ons",
+    fastifyPath: "/plans/:plan_id/add_ons",
     stripePath: "/plans/{plan_id}/add_ons",
     resource: "add_ons",
     operation: "list",
@@ -1347,7 +1347,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/plans/:plan_id/add_ons",
+    fastifyPath: "/plans/:plan_id/add_ons",
     stripePath: "/plans/{plan_id}/add_ons",
     resource: "add_ons",
     operation: "create",
@@ -1358,7 +1358,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/plans/:plan_id/add_ons/:add_on_id",
+    fastifyPath: "/plans/:plan_id/add_ons/:add_on_id",
     stripePath: "/plans/{plan_id}/add_ons/{add_on_id}",
     resource: "add_ons",
     operation: "retrieve",
@@ -1369,7 +1369,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/plans/:plan_id/add_ons/:add_on_id",
+    fastifyPath: "/plans/:plan_id/add_ons/:add_on_id",
     stripePath: "/plans/{plan_id}/add_ons/{add_on_id}",
     resource: "add_ons",
     operation: "update",
@@ -1380,7 +1380,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/plans/:plan_id/add_ons/:add_on_id",
+    fastifyPath: "/plans/:plan_id/add_ons/:add_on_id",
     stripePath: "/plans/{plan_id}/add_ons/{add_on_id}",
     resource: "add_ons",
     operation: "delete",
@@ -1391,7 +1391,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/price_segments",
+    fastifyPath: "/price_segments",
     stripePath: "/price_segments",
     resource: "price_segments",
     operation: "list",
@@ -1401,7 +1401,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/price_segments/:price_segment_id",
+    fastifyPath: "/price_segments/:price_segment_id",
     stripePath: "/price_segments/{price_segment_id}",
     resource: "price_segments",
     operation: "retrieve",
@@ -1412,7 +1412,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/add_ons",
+    fastifyPath: "/add_ons",
     stripePath: "/add_ons",
     resource: "add_ons",
     operation: "list",
@@ -1422,7 +1422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/add_ons/:add_on_id",
+    fastifyPath: "/add_ons/:add_on_id",
     stripePath: "/add_ons/{add_on_id}",
     resource: "add_ons",
     operation: "retrieve",
@@ -1433,7 +1433,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/shipping_methods",
+    fastifyPath: "/shipping_methods",
     stripePath: "/shipping_methods",
     resource: "shipping_methods",
     operation: "list",
@@ -1443,7 +1443,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/shipping_methods",
+    fastifyPath: "/shipping_methods",
     stripePath: "/shipping_methods",
     resource: "shipping_methods",
     operation: "create",
@@ -1453,7 +1453,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/shipping_methods/:shipping_method_id",
+    fastifyPath: "/shipping_methods/:shipping_method_id",
     stripePath: "/shipping_methods/{shipping_method_id}",
     resource: "shipping_methods",
     operation: "retrieve",
@@ -1464,7 +1464,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/shipping_methods/:shipping_method_id",
+    fastifyPath: "/shipping_methods/:shipping_method_id",
     stripePath: "/shipping_methods/{shipping_method_id}",
     resource: "shipping_methods",
     operation: "update",
@@ -1475,7 +1475,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/shipping_methods/:shipping_method_id",
+    fastifyPath: "/shipping_methods/:shipping_method_id",
     stripePath: "/shipping_methods/{shipping_method_id}",
     resource: "shipping_methods",
     operation: "action",
@@ -1486,7 +1486,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -1496,7 +1496,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/subscriptions",
+    fastifyPath: "/subscriptions",
     stripePath: "/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -1506,7 +1506,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1517,7 +1517,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "update",
@@ -1528,7 +1528,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/subscriptions/:subscription_id",
+    fastifyPath: "/subscriptions/:subscription_id",
     stripePath: "/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "delete",
@@ -1539,7 +1539,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/cancel",
+    fastifyPath: "/subscriptions/:subscription_id/cancel",
     stripePath: "/subscriptions/{subscription_id}/cancel",
     resource: "subscriptions",
     operation: "action",
@@ -1550,7 +1550,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/reactivate",
+    fastifyPath: "/subscriptions/:subscription_id/reactivate",
     stripePath: "/subscriptions/{subscription_id}/reactivate",
     resource: "subscriptions",
     operation: "action",
@@ -1561,7 +1561,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/pause",
+    fastifyPath: "/subscriptions/:subscription_id/pause",
     stripePath: "/subscriptions/{subscription_id}/pause",
     resource: "subscriptions",
     operation: "action",
@@ -1572,7 +1572,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/resume",
+    fastifyPath: "/subscriptions/:subscription_id/resume",
     stripePath: "/subscriptions/{subscription_id}/resume",
     resource: "subscriptions",
     operation: "action",
@@ -1583,7 +1583,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/convert_trial",
+    fastifyPath: "/subscriptions/:subscription_id/convert_trial",
     stripePath: "/subscriptions/{subscription_id}/convert_trial",
     resource: "subscriptions",
     operation: "action",
@@ -1594,7 +1594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/preview_renewal",
+    fastifyPath: "/subscriptions/:subscription_id/preview_renewal",
     stripePath: "/subscriptions/{subscription_id}/preview_renewal",
     resource: "subscriptions",
     operation: "list",
@@ -1605,7 +1605,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/change",
+    fastifyPath: "/subscriptions/:subscription_id/change",
     stripePath: "/subscriptions/{subscription_id}/change",
     resource: "subscriptions",
     operation: "list",
@@ -1616,7 +1616,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/change",
+    fastifyPath: "/subscriptions/:subscription_id/change",
     stripePath: "/subscriptions/{subscription_id}/change",
     resource: "subscriptions",
     operation: "create",
@@ -1627,7 +1627,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/change",
+    fastifyPath: "/subscriptions/:subscription_id/change",
     stripePath: "/subscriptions/{subscription_id}/change",
     resource: "subscriptions",
     operation: "delete",
@@ -1638,7 +1638,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/change/preview",
+    fastifyPath: "/subscriptions/:subscription_id/change/preview",
     stripePath: "/subscriptions/{subscription_id}/change/preview",
     resource: "subscriptions",
     operation: "action",
@@ -1649,7 +1649,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/invoices",
+    fastifyPath: "/subscriptions/:subscription_id/invoices",
     stripePath: "/subscriptions/{subscription_id}/invoices",
     resource: "invoices",
     operation: "list",
@@ -1660,7 +1660,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/line_items",
+    fastifyPath: "/subscriptions/:subscription_id/line_items",
     stripePath: "/subscriptions/{subscription_id}/line_items",
     resource: "line_items",
     operation: "list",
@@ -1671,7 +1671,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/coupon_redemptions",
+    fastifyPath: "/subscriptions/:subscription_id/coupon_redemptions",
     stripePath: "/subscriptions/{subscription_id}/coupon_redemptions",
     resource: "coupon_redemptions",
     operation: "list",
@@ -1682,7 +1682,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/coupon_redemptions/:coupon_redemption_id",
+    fastifyPath: "/subscriptions/:subscription_id/coupon_redemptions/:coupon_redemption_id",
     stripePath: "/subscriptions/{subscription_id}/coupon_redemptions/{coupon_redemption_id}",
     resource: "coupon_redemptions",
     operation: "retrieve",
@@ -1693,7 +1693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/coupon_redemptions/:coupon_redemption_id",
+    fastifyPath: "/subscriptions/:subscription_id/coupon_redemptions/:coupon_redemption_id",
     stripePath: "/subscriptions/{subscription_id}/coupon_redemptions/{coupon_redemption_id}",
     resource: "coupon_redemptions",
     operation: "delete",
@@ -1704,7 +1704,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/add_ons/:add_on_id/usage",
+    fastifyPath: "/subscriptions/:subscription_id/add_ons/:add_on_id/usage",
     stripePath: "/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage",
     resource: "usage",
     operation: "list",
@@ -1715,7 +1715,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/subscriptions/:subscription_id/add_ons/:add_on_id/usage",
+    fastifyPath: "/subscriptions/:subscription_id/add_ons/:add_on_id/usage",
     stripePath: "/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage",
     resource: "usage",
     operation: "create",
@@ -1726,7 +1726,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/usage/:usage_id",
+    fastifyPath: "/usage/:usage_id",
     stripePath: "/usage/{usage_id}",
     resource: "usage",
     operation: "retrieve",
@@ -1737,7 +1737,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/usage/:usage_id",
+    fastifyPath: "/usage/:usage_id",
     stripePath: "/usage/{usage_id}",
     resource: "usage",
     operation: "update",
@@ -1748,7 +1748,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/usage/:usage_id",
+    fastifyPath: "/usage/:usage_id",
     stripePath: "/usage/{usage_id}",
     resource: "usage",
     operation: "delete",
@@ -1759,7 +1759,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/transactions",
+    fastifyPath: "/transactions",
     stripePath: "/transactions",
     resource: "transactions",
     operation: "list",
@@ -1769,7 +1769,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/transactions/:transaction_id",
+    fastifyPath: "/transactions/:transaction_id",
     stripePath: "/transactions/{transaction_id}",
     resource: "transactions",
     operation: "retrieve",
@@ -1780,7 +1780,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/unique_coupon_codes/:unique_coupon_code_id",
+    fastifyPath: "/unique_coupon_codes/:unique_coupon_code_id",
     stripePath: "/unique_coupon_codes/{unique_coupon_code_id}",
     resource: "unique_coupon_codes",
     operation: "retrieve",
@@ -1791,7 +1791,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/recurly/unique_coupon_codes/:unique_coupon_code_id",
+    fastifyPath: "/unique_coupon_codes/:unique_coupon_code_id",
     stripePath: "/unique_coupon_codes/{unique_coupon_code_id}",
     resource: "unique_coupon_codes",
     operation: "action",
@@ -1802,7 +1802,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/unique_coupon_codes/:unique_coupon_code_id/restore",
+    fastifyPath: "/unique_coupon_codes/:unique_coupon_code_id/restore",
     stripePath: "/unique_coupon_codes/{unique_coupon_code_id}/restore",
     resource: "unique_coupon_codes",
     operation: "action",
@@ -1813,7 +1813,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases",
+    fastifyPath: "/purchases",
     stripePath: "/purchases",
     resource: "purchases",
     operation: "create",
@@ -1822,7 +1822,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases/preview",
+    fastifyPath: "/purchases/preview",
     stripePath: "/purchases/preview",
     resource: "purchases",
     operation: "action",
@@ -1831,7 +1831,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases/pending",
+    fastifyPath: "/purchases/pending",
     stripePath: "/purchases/pending",
     resource: "purchases",
     operation: "action",
@@ -1840,7 +1840,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases/authorize",
+    fastifyPath: "/purchases/authorize",
     stripePath: "/purchases/authorize",
     resource: "purchases",
     operation: "action",
@@ -1849,7 +1849,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases/:transaction_id/capture",
+    fastifyPath: "/purchases/:transaction_id/capture",
     stripePath: "/purchases/{transaction_id}/capture",
     resource: "purchases",
     operation: "action",
@@ -1859,7 +1859,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/purchases/:transaction_id/cancel/",
+    fastifyPath: "/purchases/:transaction_id/cancel/",
     stripePath: "/purchases/{transaction_id}/cancel/",
     resource: "purchases",
     operation: "action",
@@ -1869,7 +1869,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/export_dates",
+    fastifyPath: "/export_dates",
     stripePath: "/export_dates",
     resource: "export_dates",
     operation: "list",
@@ -1878,7 +1878,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/export_dates/:export_date/export_files",
+    fastifyPath: "/export_dates/:export_date/export_files",
     stripePath: "/export_dates/{export_date}/export_files",
     resource: "export_dates",
     operation: "list",
@@ -1888,7 +1888,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/dunning_campaigns",
+    fastifyPath: "/dunning_campaigns",
     stripePath: "/dunning_campaigns",
     resource: "dunning_campaigns",
     operation: "list",
@@ -1898,7 +1898,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/dunning_campaigns/:dunning_campaign_id",
+    fastifyPath: "/dunning_campaigns/:dunning_campaign_id",
     stripePath: "/dunning_campaigns/{dunning_campaign_id}",
     resource: "dunning_campaigns",
     operation: "retrieve",
@@ -1909,7 +1909,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/recurly/dunning_campaigns/:dunning_campaign_id/bulk_update",
+    fastifyPath: "/dunning_campaigns/:dunning_campaign_id/bulk_update",
     stripePath: "/dunning_campaigns/{dunning_campaign_id}/bulk_update",
     resource: "dunning_campaigns",
     operation: "action",
@@ -1920,7 +1920,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoice_templates",
+    fastifyPath: "/invoice_templates",
     stripePath: "/invoice_templates",
     resource: "invoice_templates",
     operation: "list",
@@ -1930,7 +1930,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/invoice_templates/:invoice_template_id",
+    fastifyPath: "/invoice_templates/:invoice_template_id",
     stripePath: "/invoice_templates/{invoice_template_id}",
     resource: "invoice_templates",
     operation: "retrieve",
@@ -1941,7 +1941,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_invoices",
+    fastifyPath: "/external_invoices",
     stripePath: "/external_invoices",
     resource: "external_invoices",
     operation: "list",
@@ -1951,7 +1951,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_invoices/:external_invoice_id",
+    fastifyPath: "/external_invoices/:external_invoice_id",
     stripePath: "/external_invoices/{external_invoice_id}",
     resource: "external_invoices",
     operation: "retrieve",
@@ -1962,7 +1962,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id/external_payment_phases",
+    fastifyPath: "/external_subscriptions/:external_subscription_id/external_payment_phases",
     stripePath: "/external_subscriptions/{external_subscription_id}/external_payment_phases",
     resource: "external_subscriptions",
     operation: "list",
@@ -1973,7 +1973,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/external_subscriptions/:external_subscription_id/external_payment_phases/:external_payment_phase_id",
+    fastifyPath: "/external_subscriptions/:external_subscription_id/external_payment_phases/:external_payment_phase_id",
     stripePath: "/external_subscriptions/{external_subscription_id}/external_payment_phases/{external_payment_phase_id}",
     resource: "external_subscriptions",
     operation: "retrieve",
@@ -1984,7 +1984,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/entitlements",
+    fastifyPath: "/accounts/:account_id/entitlements",
     stripePath: "/accounts/{account_id}/entitlements",
     resource: "accounts",
     operation: "list",
@@ -1995,7 +1995,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/accounts/:account_id/external_subscriptions",
+    fastifyPath: "/accounts/:account_id/external_subscriptions",
     stripePath: "/accounts/{account_id}/external_subscriptions",
     resource: "external_subscriptions",
     operation: "list",
@@ -2006,7 +2006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/business_entities/:business_entity_id",
+    fastifyPath: "/business_entities/:business_entity_id",
     stripePath: "/business_entities/{business_entity_id}",
     resource: "business_entities",
     operation: "retrieve",
@@ -2017,7 +2017,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/business_entities",
+    fastifyPath: "/business_entities",
     stripePath: "/business_entities",
     resource: "business_entities",
     operation: "list",
@@ -2027,7 +2027,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/gift_cards",
+    fastifyPath: "/gift_cards",
     stripePath: "/gift_cards",
     resource: "gift_cards",
     operation: "list",
@@ -2037,7 +2037,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/gift_cards",
+    fastifyPath: "/gift_cards",
     stripePath: "/gift_cards",
     resource: "gift_cards",
     operation: "create",
@@ -2047,7 +2047,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/gift_cards/:gift_card_id",
+    fastifyPath: "/gift_cards/:gift_card_id",
     stripePath: "/gift_cards/{gift_card_id}",
     resource: "gift_cards",
     operation: "retrieve",
@@ -2058,7 +2058,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/gift_cards/preview",
+    fastifyPath: "/gift_cards/preview",
     stripePath: "/gift_cards/preview",
     resource: "gift_cards",
     operation: "action",
@@ -2068,7 +2068,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/recurly/gift_cards/:redemption_code/redeem",
+    fastifyPath: "/gift_cards/:redemption_code/redeem",
     stripePath: "/gift_cards/{redemption_code}/redeem",
     resource: "gift_cards",
     operation: "action",
@@ -2079,7 +2079,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/recurly/business_entities/:business_entity_id/invoices",
+    fastifyPath: "/business_entities/:business_entity_id/invoices",
     stripePath: "/business_entities/{business_entity_id}/invoices",
     resource: "invoices",
     operation: "list",

--- a/packages/adapters/adapter-recurly/src/mcp.ts
+++ b/packages/adapters/adapter-recurly/src/mcp.ts
@@ -42,14 +42,14 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     last_name: z.string().optional().describe('Last name'),
     company: z.string().optional().describe('Company name'),
   }, async (params) => {
-    const data = await call('POST', '/recurly/accounts', params) as any;
+    const data = await call('POST', '/accounts', params) as any;
     return text(`Created account ${data.id}: ${data.first_name ?? ''} ${data.last_name ?? ''} (${data.email ?? 'no email'})`);
   });
 
   server.tool('list_accounts', 'List Recurly accounts', {
     limit: z.number().int().min(1).max(200).optional().describe('Max results'),
   }, async ({ limit }) => {
-    const data = await call('GET', `/recurly/accounts${qs({ limit: limit ?? 20 })}`) as any;
+    const data = await call('GET', `/accounts${qs({ limit: limit ?? 20 })}`) as any;
     if (!data.data?.length) return text('No accounts found.');
     const lines = data.data.map((a: any) => `• ${a.id} — ${a.first_name ?? ''} ${a.last_name ?? ''} [${a.state}]`);
     return text(`Accounts (${data.data.length}):\n${lines.join('\n')}`);
@@ -58,7 +58,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
   server.tool('get_account', 'Get a specific account', {
     account_id: z.string().describe('Account ID'),
   }, async ({ account_id }) => {
-    const data = await call('GET', `/recurly/accounts/${account_id}`) as any;
+    const data = await call('GET', `/accounts/${account_id}`) as any;
     return text(JSON.stringify(data, null, 2));
   });
 
@@ -70,12 +70,12 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     interval_unit: z.enum(['days', 'months']).optional().describe('Billing interval unit'),
     interval_length: z.number().int().positive().optional().describe('Billing interval length'),
   }, async (params) => {
-    const data = await call('POST', '/recurly/plans', params) as any;
+    const data = await call('POST', '/plans', params) as any;
     return text(`Created plan ${data.id}: ${data.name} (${data.code})`);
   });
 
   server.tool('list_plans', 'List subscription plans', {}, async () => {
-    const data = await call('GET', '/recurly/plans') as any;
+    const data = await call('GET', '/plans') as any;
     if (!data.data?.length) return text('No plans found.');
     const lines = data.data.map((p: any) => `• ${p.id} — ${p.name} (${p.code}) [${p.state}]`);
     return text(`Plans (${data.data.length}):\n${lines.join('\n')}`);
@@ -88,7 +88,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     account_code: z.string().describe('Account code'),
     currency: z.string().length(3).optional().describe('Currency (default USD)'),
   }, async ({ plan_code, account_code, currency }) => {
-    const data = await call('POST', '/recurly/subscriptions', {
+    const data = await call('POST', '/subscriptions', {
       plan_code,
       account: { code: account_code },
       currency: currency ?? 'USD',
@@ -100,7 +100,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     state: z.enum(['active', 'canceled', 'expired', 'future', 'paused']).optional().describe('Filter by state'),
     limit: z.number().int().min(1).max(200).optional().describe('Max results'),
   }, async ({ state, limit }) => {
-    const data = await call('GET', `/recurly/subscriptions${qs({ state, limit: limit ?? 20 })}`) as any;
+    const data = await call('GET', `/subscriptions${qs({ state, limit: limit ?? 20 })}`) as any;
     if (!data.data?.length) return text('No subscriptions found.');
     const lines = data.data.map((s: any) => `• ${s.id} — [${s.state}]`);
     return text(`Subscriptions (${data.data.length}):\n${lines.join('\n')}`);
@@ -109,14 +109,14 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
   server.tool('cancel_subscription', 'Cancel a subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('PUT', `/recurly/subscriptions/${subscription_id}/cancel`) as any;
+    const data = await call('PUT', `/subscriptions/${subscription_id}/cancel`) as any;
     return text(`Cancelled subscription ${data.id} [${data.state}]`);
   });
 
   server.tool('reactivate_subscription', 'Reactivate a canceled subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('PUT', `/recurly/subscriptions/${subscription_id}/reactivate`) as any;
+    const data = await call('PUT', `/subscriptions/${subscription_id}/reactivate`) as any;
     return text(`Reactivated subscription ${data.id} [${data.state}]`);
   });
 
@@ -124,7 +124,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     subscription_id: z.string().describe('Subscription ID'),
     remaining_pause_cycles: z.number().int().positive().optional().describe('Number of pause cycles'),
   }, async ({ subscription_id, remaining_pause_cycles }) => {
-    const data = await call('PUT', `/recurly/subscriptions/${subscription_id}/pause`, {
+    const data = await call('PUT', `/subscriptions/${subscription_id}/pause`, {
       remaining_pause_cycles: remaining_pause_cycles ?? 1,
     }) as any;
     return text(`Paused subscription ${data.id} [${data.state}]`);
@@ -133,7 +133,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
   server.tool('resume_subscription', 'Resume a paused subscription', {
     subscription_id: z.string().describe('Subscription ID'),
   }, async ({ subscription_id }) => {
-    const data = await call('PUT', `/recurly/subscriptions/${subscription_id}/resume`) as any;
+    const data = await call('PUT', `/subscriptions/${subscription_id}/resume`) as any;
     return text(`Resumed subscription ${data.id} [${data.state}]`);
   });
 
@@ -143,7 +143,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     state: z.enum(['pending', 'processing', 'past_due', 'paid', 'failed', 'voided']).optional().describe('Filter by state'),
     limit: z.number().int().min(1).max(200).optional().describe('Max results'),
   }, async ({ state, limit }) => {
-    const data = await call('GET', `/recurly/invoices${qs({ state, limit: limit ?? 20 })}`) as any;
+    const data = await call('GET', `/invoices${qs({ state, limit: limit ?? 20 })}`) as any;
     if (!data.data?.length) return text('No invoices found.');
     const lines = data.data.map((inv: any) => `• ${inv.id} — ${inv.total ?? 0} ${inv.currency ?? 'USD'} [${inv.state}]`);
     return text(`Invoices (${data.data.length}):\n${lines.join('\n')}`);
@@ -152,21 +152,21 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
   server.tool('get_invoice', 'Get a specific invoice', {
     invoice_id: z.string().describe('Invoice ID'),
   }, async ({ invoice_id }) => {
-    const data = await call('GET', `/recurly/invoices/${invoice_id}`) as any;
+    const data = await call('GET', `/invoices/${invoice_id}`) as any;
     return text(JSON.stringify(data, null, 2));
   });
 
   server.tool('collect_invoice', 'Collect payment on an invoice', {
     invoice_id: z.string().describe('Invoice ID'),
   }, async ({ invoice_id }) => {
-    const data = await call('PUT', `/recurly/invoices/${invoice_id}/collect`) as any;
+    const data = await call('PUT', `/invoices/${invoice_id}/collect`) as any;
     return text(`Collected invoice ${data.id} [${data.state}]`);
   });
 
   server.tool('void_invoice', 'Void an invoice', {
     invoice_id: z.string().describe('Invoice ID'),
   }, async ({ invoice_id }) => {
-    const data = await call('PUT', `/recurly/invoices/${invoice_id}/void`) as any;
+    const data = await call('PUT', `/invoices/${invoice_id}/void`) as any;
     return text(`Voided invoice ${data.id} [${data.state}]`);
   });
 
@@ -178,12 +178,12 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     discount_type: z.enum(['percent', 'fixed', 'free_trial']).optional().describe('Discount type'),
     discount_percent: z.number().min(0).max(100).optional().describe('Percent discount (for percent type)'),
   }, async (params) => {
-    const data = await call('POST', '/recurly/coupons', params) as any;
+    const data = await call('POST', '/coupons', params) as any;
     return text(`Created coupon ${data.id}: ${data.name} (${data.code})`);
   });
 
   server.tool('list_coupons', 'List coupons', {}, async () => {
-    const data = await call('GET', '/recurly/coupons') as any;
+    const data = await call('GET', '/coupons') as any;
     if (!data.data?.length) return text('No coupons found.');
     const lines = data.data.map((c: any) => `• ${c.id} — ${c.name} (${c.code}) [${c.state}]`);
     return text(`Coupons (${data.data.length}):\n${lines.join('\n')}`);
@@ -196,12 +196,12 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     name: z.string().describe('Display name'),
     description: z.string().optional().describe('Item description'),
   }, async (params) => {
-    const data = await call('POST', '/recurly/items', params) as any;
+    const data = await call('POST', '/items', params) as any;
     return text(`Created item ${data.id}: ${data.name} (${data.code})`);
   });
 
   server.tool('list_items', 'List catalog items', {}, async () => {
-    const data = await call('GET', '/recurly/items') as any;
+    const data = await call('GET', '/items') as any;
     if (!data.data?.length) return text('No items found.');
     const lines = data.data.map((i: any) => `• ${i.id} — ${i.name} (${i.code}) [${i.state}]`);
     return text(`Items (${data.data.length}):\n${lines.join('\n')}`);
@@ -212,7 +212,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
   server.tool('list_transactions', 'List transactions', {
     limit: z.number().int().min(1).max(200).optional().describe('Max results'),
   }, async ({ limit }) => {
-    const data = await call('GET', `/recurly/transactions${qs({ limit: limit ?? 20 })}`) as any;
+    const data = await call('GET', `/transactions${qs({ limit: limit ?? 20 })}`) as any;
     if (!data.data?.length) return text('No transactions found.');
     const lines = data.data.map((t: any) => `• ${t.id} — ${t.amount ?? 0} ${t.currency ?? 'USD'} [${t.status ?? t.type}]`);
     return text(`Transactions (${data.data.length}):\n${lines.join('\n')}`);
@@ -229,7 +229,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
 
     for (const type of types) {
       try {
-        const data = await call('GET', `/recurly/${type}`) as any;
+        const data = await call('GET', `/${type}`) as any;
         if (!data.data?.length) continue;
         const matches = data.data.filter((item: any) => {
           const str = JSON.stringify(item).toLowerCase();
@@ -252,7 +252,7 @@ export function registerRecurlyTools(server: McpServer, baseUrl: string = 'http:
     ]).describe('Resource type'),
     resource_id: z.string().describe('Resource ID'),
   }, async ({ resource_type, resource_id }) => {
-    const data = await call('GET', `/recurly/${resource_type}/${resource_id}`) as any;
+    const data = await call('GET', `/${resource_type}/${resource_id}`) as any;
     return text(JSON.stringify(data, null, 2));
   });
 

--- a/packages/adapters/adapter-recurly/src/recurly-adapter.ts
+++ b/packages/adapters/adapter-recurly/src/recurly-adapter.ts
@@ -108,60 +108,60 @@ export class RecurlyAdapter extends OpenApiMockAdapter<RecurlyConfig> {
   private mountOverrides(store: StateStore): void {
     // ── Accounts ──────────────────────────────────────────────────────────
     this.registerOverride(
-      'DELETE', '/recurly/accounts/:account_id',
+      'DELETE', '/accounts/:account_id',
       acctOverrides.buildDeactivateHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/accounts/:account_id/reactivate',
+      'PUT', '/accounts/:account_id/reactivate',
       acctOverrides.buildReactivateHandler(store),
     );
 
     // ── Subscriptions ─────────────────────────────────────────────────────
     this.registerOverride(
-      'PUT', '/recurly/subscriptions/:subscription_id/cancel',
+      'PUT', '/subscriptions/:subscription_id/cancel',
       subOverrides.buildCancelHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/subscriptions/:subscription_id/pause',
+      'PUT', '/subscriptions/:subscription_id/pause',
       subOverrides.buildPauseHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/subscriptions/:subscription_id/resume',
+      'PUT', '/subscriptions/:subscription_id/resume',
       subOverrides.buildResumeHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/subscriptions/:subscription_id/reactivate',
+      'PUT', '/subscriptions/:subscription_id/reactivate',
       subOverrides.buildReactivateHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/subscriptions/:subscription_id/convert_trial',
+      'PUT', '/subscriptions/:subscription_id/convert_trial',
       subOverrides.buildConvertTrialHandler(store),
     );
     // DELETE /subscriptions/:id is "terminate" in Recurly
     this.registerOverride(
-      'DELETE', '/recurly/subscriptions/:subscription_id',
+      'DELETE', '/subscriptions/:subscription_id',
       subOverrides.buildTerminateHandler(store),
     );
 
     // ── Invoices ──────────────────────────────────────────────────────────
     this.registerOverride(
-      'PUT', '/recurly/invoices/:invoice_id/collect',
+      'PUT', '/invoices/:invoice_id/collect',
       invOverrides.buildCollectHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/invoices/:invoice_id/void',
+      'PUT', '/invoices/:invoice_id/void',
       invOverrides.buildVoidHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/invoices/:invoice_id/mark_failed',
+      'PUT', '/invoices/:invoice_id/mark_failed',
       invOverrides.buildMarkFailedHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/invoices/:invoice_id/mark_successful',
+      'PUT', '/invoices/:invoice_id/mark_successful',
       invOverrides.buildMarkSuccessfulHandler(store),
     );
     this.registerOverride(
-      'PUT', '/recurly/invoices/:invoice_id/reopen',
+      'PUT', '/invoices/:invoice_id/reopen',
       invOverrides.buildReopenHandler(store),
     );
   }

--- a/packages/adapters/adapter-revenuecat/adapter.json
+++ b/packages/adapters/adapter-revenuecat/adapter.json
@@ -3,7 +3,7 @@
   "name": "RevenueCat API",
   "description": "RevenueCat subscription management, entitlements, and in-app purchase mock adapter",
   "type": "api-mock",
-  "basePath": "/revenuecat",
+  "basePath": "",
   "versions": ["2.0.0"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://www.revenuecat.com/docs/api-v2",

--- a/packages/adapters/adapter-revenuecat/scripts/revenuecat-codegen.ts
+++ b/packages/adapters/adapter-revenuecat/scripts/revenuecat-codegen.ts
@@ -656,16 +656,8 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const httpMethod = method.toUpperCase() as ExtractedRoute['method'];
       const description = operation.summary ?? operation.description ?? '';
 
-      // Convert {param} to :param and prepend /revenuecat
-      // For paths starting with /projects/{project_id}, keep that prefix for routing
-      let fastifyPath: string;
-      if (specPath.startsWith('/projects/{project_id}')) {
-        const withoutProjectPrefix = specPath.replace(/^\/projects\/\{project_id\}/, '');
-        fastifyPath = '/revenuecat/projects/:project_id' + withoutProjectPrefix.replace(/\{([^}]+)\}/g, ':$1');
-      } else {
-        // Top-level paths like /projects
-        fastifyPath = '/revenuecat' + specPath.replace(/\{([^}]+)\}/g, ':$1');
-      }
+      // Convert {param} to :param
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, ':$1');
 
       const resource = detectRCResource(specPath);
       const op = detectRCOperation(specPath, method);

--- a/packages/adapters/adapter-revenuecat/src/__tests__/revenuecat-adapter.test.ts
+++ b/packages/adapters/adapter-revenuecat/src/__tests__/revenuecat-adapter.test.ts
@@ -20,7 +20,7 @@ describe('RevenueCatAdapter', () => {
   // ── Metadata ────────────────────────────────────────────────────────────────
   it('should have correct metadata', () => {
     expect(adapter.id).toBe('revenuecat');
-    expect(adapter.basePath).toBe('/revenuecat');
+    expect(adapter.basePath).toBe('');
   });
 
   it('should return endpoint definitions', () => {
@@ -36,7 +36,7 @@ describe('RevenueCatAdapter', () => {
   it('should create a customer', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ last_seen_platform: 'android', last_seen_country: 'GB' }),
     });
@@ -50,7 +50,7 @@ describe('RevenueCatAdapter', () => {
   it('should list customers', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -63,7 +63,7 @@ describe('RevenueCatAdapter', () => {
   it('should retrieve a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ last_seen_platform: 'ios' }),
     });
@@ -71,7 +71,7 @@ describe('RevenueCatAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/revenuecat/projects/${PROJECT}/customers/${customerId}`,
+      url: `/projects/${PROJECT}/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().id).toBe(customerId);
@@ -80,7 +80,7 @@ describe('RevenueCatAdapter', () => {
   it('should return 404 for non-existent customer', async () => {
     const res = await ts.server.inject({
       method: 'GET',
-      url: `/revenuecat/projects/${PROJECT}/customers/nonexistent_id`,
+      url: `/projects/${PROJECT}/customers/nonexistent_id`,
     });
     expect(res.statusCode).toBe(404);
     const body = res.json();
@@ -90,7 +90,7 @@ describe('RevenueCatAdapter', () => {
   it('should delete a customer', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({}),
     });
@@ -98,7 +98,7 @@ describe('RevenueCatAdapter', () => {
 
     const res = await ts.server.inject({
       method: 'DELETE',
-      url: `/revenuecat/projects/${PROJECT}/customers/${customerId}`,
+      url: `/projects/${PROJECT}/customers/${customerId}`,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -109,7 +109,7 @@ describe('RevenueCatAdapter', () => {
   it('should create and list entitlements', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/entitlements`,
+      url: `/projects/${PROJECT}/entitlements`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ lookup_key: 'premium', display_name: 'Premium Access' }),
     });
@@ -120,7 +120,7 @@ describe('RevenueCatAdapter', () => {
 
     const listRes = await ts.server.inject({
       method: 'GET',
-      url: `/revenuecat/projects/${PROJECT}/entitlements`,
+      url: `/projects/${PROJECT}/entitlements`,
     });
     expect(listRes.json().items.length).toBeGreaterThan(0);
   });
@@ -129,7 +129,7 @@ describe('RevenueCatAdapter', () => {
   it('should create an offering', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/offerings`,
+      url: `/projects/${PROJECT}/offerings`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ lookup_key: 'default', display_name: 'Default Offering' }),
     });
@@ -143,7 +143,7 @@ describe('RevenueCatAdapter', () => {
   it('should create a product', async () => {
     const res = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/products`,
+      url: `/projects/${PROJECT}/products`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         store_identifier: 'com.example.premium_monthly',
@@ -163,7 +163,7 @@ describe('RevenueCatAdapter', () => {
     // Create a subscription manually via the create endpoint
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({}),
     });
@@ -173,7 +173,7 @@ describe('RevenueCatAdapter', () => {
     // First seed a subscription
     const subCreateRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/customers/${customerId}/subscriptions`,
+      url: `/projects/${PROJECT}/customers/${customerId}/subscriptions`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ customer_id: customerId, status: 'active' }),
     });
@@ -188,7 +188,7 @@ describe('RevenueCatAdapter', () => {
   it('should archive and unarchive an entitlement', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/entitlements`,
+      url: `/projects/${PROJECT}/entitlements`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ lookup_key: 'pro', display_name: 'Pro Access' }),
     });
@@ -197,7 +197,7 @@ describe('RevenueCatAdapter', () => {
     // Archive
     const archiveRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/entitlements/${entitlementId}/actions/archive`,
+      url: `/projects/${PROJECT}/entitlements/${entitlementId}/actions/archive`,
     });
     expect(archiveRes.statusCode).toBe(200);
     expect(archiveRes.json().state).toBe('inactive');
@@ -205,7 +205,7 @@ describe('RevenueCatAdapter', () => {
     // Unarchive
     const unarchiveRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/entitlements/${entitlementId}/actions/unarchive`,
+      url: `/projects/${PROJECT}/entitlements/${entitlementId}/actions/unarchive`,
     });
     expect(unarchiveRes.statusCode).toBe(200);
     expect(unarchiveRes.json().state).toBe('active');
@@ -215,7 +215,7 @@ describe('RevenueCatAdapter', () => {
   it('should archive and unarchive a product', async () => {
     const createRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/products`,
+      url: `/projects/${PROJECT}/products`,
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({
         store_identifier: 'com.example.archive_test',
@@ -228,7 +228,7 @@ describe('RevenueCatAdapter', () => {
     // Archive
     const archiveRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/products/${productId}/actions/archive`,
+      url: `/projects/${PROJECT}/products/${productId}/actions/archive`,
     });
     expect(archiveRes.statusCode).toBe(200);
     expect(archiveRes.json().state).toBe('inactive');
@@ -236,7 +236,7 @@ describe('RevenueCatAdapter', () => {
     // Unarchive
     const unarchiveRes = await ts.server.inject({
       method: 'POST',
-      url: `/revenuecat/projects/${PROJECT}/products/${productId}/actions/unarchive`,
+      url: `/projects/${PROJECT}/products/${productId}/actions/unarchive`,
     });
     expect(unarchiveRes.statusCode).toBe(200);
     expect(unarchiveRes.json().state).toBe('active');
@@ -260,7 +260,7 @@ describe('RevenueCatAdapter', () => {
     const seededTs = await buildTestServer(adapter, seedData);
     const res = await seededTs.server.inject({
       method: 'GET',
-      url: `/revenuecat/projects/${PROJECT}/customers`,
+      url: `/projects/${PROJECT}/customers`,
     });
     const items = res.json().items;
     expect(items).toContainEqual(expect.objectContaining({ id: 'seed_cust_1' }));

--- a/packages/adapters/adapter-revenuecat/src/generated/meta.ts
+++ b/packages/adapters/adapter-revenuecat/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-revenuecat generate
 // RevenueCat OpenAPI spec version: 2.0.0
-// Generated at: 2026-03-13T10:59:52.632Z
+// Generated at: 2026-03-20T11:03:14.574Z
 
 export const RC_SPEC_VERSION = "2.0.0";
-export const RC_SPEC_GENERATED_AT = "2026-03-13T10:59:52.632Z";
+export const RC_SPEC_GENERATED_AT = "2026-03-20T11:03:14.574Z";

--- a/packages/adapters/adapter-revenuecat/src/generated/routes.ts
+++ b/packages/adapters/adapter-revenuecat/src/generated/routes.ts
@@ -19,7 +19,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/paywalls",
+    fastifyPath: "/projects/:project_id/paywalls",
     stripePath: "/projects/{project_id}/paywalls",
     resource: "paywalls",
     operation: "list",
@@ -29,7 +29,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/paywalls",
+    fastifyPath: "/projects/:project_id/paywalls",
     stripePath: "/projects/{project_id}/paywalls",
     resource: "paywalls",
     operation: "create",
@@ -39,7 +39,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/paywalls/:paywall_id",
+    fastifyPath: "/projects/:project_id/paywalls/:paywall_id",
     stripePath: "/projects/{project_id}/paywalls/{paywall_id}",
     resource: "paywalls",
     operation: "retrieve",
@@ -50,7 +50,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/paywalls/:paywall_id",
+    fastifyPath: "/projects/:project_id/paywalls/:paywall_id",
     stripePath: "/projects/{project_id}/paywalls/{paywall_id}",
     resource: "paywalls",
     operation: "delete",
@@ -61,7 +61,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/apps/:app_id/public_api_keys",
+    fastifyPath: "/projects/:project_id/apps/:app_id/public_api_keys",
     stripePath: "/projects/{project_id}/apps/{app_id}/public_api_keys",
     resource: "public_api_keys",
     operation: "list",
@@ -71,7 +71,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects",
+    fastifyPath: "/projects",
     stripePath: "/projects",
     resource: "projects",
     operation: "list",
@@ -81,7 +81,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects",
+    fastifyPath: "/projects",
     stripePath: "/projects",
     resource: "projects",
     operation: "create",
@@ -91,7 +91,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/apps",
+    fastifyPath: "/projects/:project_id/apps",
     stripePath: "/projects/{project_id}/apps",
     resource: "apps",
     operation: "list",
@@ -101,7 +101,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/apps",
+    fastifyPath: "/projects/:project_id/apps",
     stripePath: "/projects/{project_id}/apps",
     resource: "apps",
     operation: "create",
@@ -111,7 +111,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/apps/:app_id",
+    fastifyPath: "/projects/:project_id/apps/:app_id",
     stripePath: "/projects/{project_id}/apps/{app_id}",
     resource: "apps",
     operation: "retrieve",
@@ -122,7 +122,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/apps/:app_id",
+    fastifyPath: "/projects/:project_id/apps/:app_id",
     stripePath: "/projects/{project_id}/apps/{app_id}",
     resource: "apps",
     operation: "update",
@@ -133,7 +133,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/apps/:app_id",
+    fastifyPath: "/projects/:project_id/apps/:app_id",
     stripePath: "/projects/{project_id}/apps/{app_id}",
     resource: "apps",
     operation: "delete",
@@ -144,7 +144,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/apps/:app_id/store_kit_config",
+    fastifyPath: "/projects/:project_id/apps/:app_id/store_kit_config",
     stripePath: "/projects/{project_id}/apps/{app_id}/store_kit_config",
     resource: "apps",
     operation: "action",
@@ -155,7 +155,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/audit_logs",
+    fastifyPath: "/projects/:project_id/audit_logs",
     stripePath: "/projects/{project_id}/audit_logs",
     resource: "audit_logs",
     operation: "list",
@@ -164,7 +164,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/collaborators",
+    fastifyPath: "/projects/:project_id/collaborators",
     stripePath: "/projects/{project_id}/collaborators",
     resource: "collaborators",
     operation: "list",
@@ -174,7 +174,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers",
+    fastifyPath: "/projects/:project_id/customers",
     stripePath: "/projects/{project_id}/customers",
     resource: "customers",
     operation: "list",
@@ -184,7 +184,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers",
+    fastifyPath: "/projects/:project_id/customers",
     stripePath: "/projects/{project_id}/customers",
     resource: "customers",
     operation: "create",
@@ -194,7 +194,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id",
+    fastifyPath: "/projects/:project_id/customers/:customer_id",
     stripePath: "/projects/{project_id}/customers/{customer_id}",
     resource: "customers",
     operation: "retrieve",
@@ -205,7 +205,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id",
+    fastifyPath: "/projects/:project_id/customers/:customer_id",
     stripePath: "/projects/{project_id}/customers/{customer_id}",
     resource: "customers",
     operation: "delete",
@@ -216,7 +216,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/actions/transfer",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/actions/transfer",
     stripePath: "/projects/{project_id}/customers/{customer_id}/actions/transfer",
     resource: "customers",
     operation: "action",
@@ -227,7 +227,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/actions/grant_entitlement",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/actions/grant_entitlement",
     stripePath: "/projects/{project_id}/customers/{customer_id}/actions/grant_entitlement",
     resource: "customers",
     operation: "action",
@@ -238,7 +238,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/actions/revoke_granted_entitlement",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/actions/revoke_granted_entitlement",
     stripePath: "/projects/{project_id}/customers/{customer_id}/actions/revoke_granted_entitlement",
     resource: "customers",
     operation: "action",
@@ -249,7 +249,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/actions/assign_offering",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/actions/assign_offering",
     stripePath: "/projects/{project_id}/customers/{customer_id}/actions/assign_offering",
     resource: "customers",
     operation: "action",
@@ -260,7 +260,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/integrations/webhooks",
+    fastifyPath: "/projects/:project_id/integrations/webhooks",
     stripePath: "/projects/{project_id}/integrations/webhooks",
     resource: "webhooks",
     operation: "list",
@@ -270,7 +270,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/integrations/webhooks",
+    fastifyPath: "/projects/:project_id/integrations/webhooks",
     stripePath: "/projects/{project_id}/integrations/webhooks",
     resource: "webhooks",
     operation: "create",
@@ -280,7 +280,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/integrations/webhooks/:webhook_integration_id",
+    fastifyPath: "/projects/:project_id/integrations/webhooks/:webhook_integration_id",
     stripePath: "/projects/{project_id}/integrations/webhooks/{webhook_integration_id}",
     resource: "webhooks",
     operation: "retrieve",
@@ -291,7 +291,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/integrations/webhooks/:webhook_integration_id",
+    fastifyPath: "/projects/:project_id/integrations/webhooks/:webhook_integration_id",
     stripePath: "/projects/{project_id}/integrations/webhooks/{webhook_integration_id}",
     resource: "webhooks",
     operation: "update",
@@ -302,7 +302,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/integrations/webhooks/:webhook_integration_id",
+    fastifyPath: "/projects/:project_id/integrations/webhooks/:webhook_integration_id",
     stripePath: "/projects/{project_id}/integrations/webhooks/{webhook_integration_id}",
     resource: "webhooks",
     operation: "delete",
@@ -313,7 +313,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id",
+    fastifyPath: "/projects/:project_id/products/:product_id",
     stripePath: "/projects/{project_id}/products/{product_id}",
     resource: "products",
     operation: "retrieve",
@@ -324,7 +324,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id",
+    fastifyPath: "/projects/:project_id/products/:product_id",
     stripePath: "/projects/{project_id}/products/{product_id}",
     resource: "products",
     operation: "update",
@@ -335,7 +335,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id",
+    fastifyPath: "/projects/:project_id/products/:product_id",
     stripePath: "/projects/{project_id}/products/{product_id}",
     resource: "products",
     operation: "delete",
@@ -346,7 +346,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id/actions/archive",
+    fastifyPath: "/projects/:project_id/products/:product_id/actions/archive",
     stripePath: "/projects/{project_id}/products/{product_id}/actions/archive",
     resource: "products",
     operation: "action",
@@ -357,7 +357,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id/actions/unarchive",
+    fastifyPath: "/projects/:project_id/products/:product_id/actions/unarchive",
     stripePath: "/projects/{project_id}/products/{product_id}/actions/unarchive",
     resource: "products",
     operation: "action",
@@ -368,7 +368,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/products/:product_id/create_in_store",
+    fastifyPath: "/projects/:project_id/products/:product_id/create_in_store",
     stripePath: "/projects/{project_id}/products/{product_id}/create_in_store",
     resource: "products",
     operation: "action",
@@ -379,7 +379,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/products",
+    fastifyPath: "/projects/:project_id/products",
     stripePath: "/projects/{project_id}/products",
     resource: "products",
     operation: "list",
@@ -389,7 +389,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/products",
+    fastifyPath: "/projects/:project_id/products",
     stripePath: "/projects/{project_id}/products",
     resource: "products",
     operation: "create",
@@ -399,7 +399,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies",
+    fastifyPath: "/projects/:project_id/virtual_currencies",
     stripePath: "/projects/{project_id}/virtual_currencies",
     resource: "virtual_currencies",
     operation: "list",
@@ -409,7 +409,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies",
+    fastifyPath: "/projects/:project_id/virtual_currencies",
     stripePath: "/projects/{project_id}/virtual_currencies",
     resource: "virtual_currencies",
     operation: "create",
@@ -419,7 +419,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies/:virtual_currency_code",
+    fastifyPath: "/projects/:project_id/virtual_currencies/:virtual_currency_code",
     stripePath: "/projects/{project_id}/virtual_currencies/{virtual_currency_code}",
     resource: "virtual_currencies",
     operation: "retrieve",
@@ -430,7 +430,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies/:virtual_currency_code",
+    fastifyPath: "/projects/:project_id/virtual_currencies/:virtual_currency_code",
     stripePath: "/projects/{project_id}/virtual_currencies/{virtual_currency_code}",
     resource: "virtual_currencies",
     operation: "update",
@@ -441,7 +441,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies/:virtual_currency_code",
+    fastifyPath: "/projects/:project_id/virtual_currencies/:virtual_currency_code",
     stripePath: "/projects/{project_id}/virtual_currencies/{virtual_currency_code}",
     resource: "virtual_currencies",
     operation: "delete",
@@ -452,7 +452,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies/:virtual_currency_code/actions/archive",
+    fastifyPath: "/projects/:project_id/virtual_currencies/:virtual_currency_code/actions/archive",
     stripePath: "/projects/{project_id}/virtual_currencies/{virtual_currency_code}/actions/archive",
     resource: "virtual_currencies",
     operation: "action",
@@ -463,7 +463,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/virtual_currencies/:virtual_currency_code/actions/unarchive",
+    fastifyPath: "/projects/:project_id/virtual_currencies/:virtual_currency_code/actions/unarchive",
     stripePath: "/projects/{project_id}/virtual_currencies/{virtual_currency_code}/actions/unarchive",
     resource: "virtual_currencies",
     operation: "action",
@@ -474,7 +474,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}",
     resource: "entitlements",
     operation: "retrieve",
@@ -485,7 +485,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}",
     resource: "entitlements",
     operation: "update",
@@ -496,7 +496,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}",
     resource: "entitlements",
     operation: "delete",
@@ -507,7 +507,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements",
+    fastifyPath: "/projects/:project_id/entitlements",
     stripePath: "/projects/{project_id}/entitlements",
     resource: "entitlements",
     operation: "list",
@@ -517,7 +517,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements",
+    fastifyPath: "/projects/:project_id/entitlements",
     stripePath: "/projects/{project_id}/entitlements",
     resource: "entitlements",
     operation: "create",
@@ -527,7 +527,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id/products",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id/products",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}/products",
     resource: "entitlement_products",
     operation: "list",
@@ -537,7 +537,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/archive",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id/actions/archive",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}/actions/archive",
     resource: "entitlements",
     operation: "action",
@@ -548,7 +548,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/unarchive",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id/actions/unarchive",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}/actions/unarchive",
     resource: "entitlements",
     operation: "action",
@@ -559,7 +559,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/attach_products",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id/actions/attach_products",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}/actions/attach_products",
     resource: "entitlements",
     operation: "action",
@@ -570,7 +570,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/detach_products",
+    fastifyPath: "/projects/:project_id/entitlements/:entitlement_id/actions/detach_products",
     stripePath: "/projects/{project_id}/entitlements/{entitlement_id}/actions/detach_products",
     resource: "entitlements",
     operation: "action",
@@ -581,7 +581,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id",
     stripePath: "/projects/{project_id}/offerings/{offering_id}",
     resource: "offerings",
     operation: "retrieve",
@@ -592,7 +592,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id",
     stripePath: "/projects/{project_id}/offerings/{offering_id}",
     resource: "offerings",
     operation: "update",
@@ -603,7 +603,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id",
     stripePath: "/projects/{project_id}/offerings/{offering_id}",
     resource: "offerings",
     operation: "delete",
@@ -614,7 +614,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id/actions/archive",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id/actions/archive",
     stripePath: "/projects/{project_id}/offerings/{offering_id}/actions/archive",
     resource: "offerings",
     operation: "action",
@@ -625,7 +625,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id/actions/unarchive",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id/actions/unarchive",
     stripePath: "/projects/{project_id}/offerings/{offering_id}/actions/unarchive",
     resource: "offerings",
     operation: "action",
@@ -636,7 +636,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings",
+    fastifyPath: "/projects/:project_id/offerings",
     stripePath: "/projects/{project_id}/offerings",
     resource: "offerings",
     operation: "list",
@@ -646,7 +646,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings",
+    fastifyPath: "/projects/:project_id/offerings",
     stripePath: "/projects/{project_id}/offerings",
     resource: "offerings",
     operation: "create",
@@ -656,7 +656,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id",
+    fastifyPath: "/projects/:project_id/packages/:package_id",
     stripePath: "/projects/{project_id}/packages/{package_id}",
     resource: "packages",
     operation: "retrieve",
@@ -667,7 +667,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id",
+    fastifyPath: "/projects/:project_id/packages/:package_id",
     stripePath: "/projects/{project_id}/packages/{package_id}",
     resource: "packages",
     operation: "update",
@@ -678,7 +678,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id",
+    fastifyPath: "/projects/:project_id/packages/:package_id",
     stripePath: "/projects/{project_id}/packages/{package_id}",
     resource: "packages",
     operation: "delete",
@@ -689,7 +689,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id/packages",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id/packages",
     stripePath: "/projects/{project_id}/offerings/{offering_id}/packages",
     resource: "packages",
     operation: "list",
@@ -700,7 +700,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/offerings/:offering_id/packages",
+    fastifyPath: "/projects/:project_id/offerings/:offering_id/packages",
     stripePath: "/projects/{project_id}/offerings/{offering_id}/packages",
     resource: "packages",
     operation: "create",
@@ -711,7 +711,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id/products",
+    fastifyPath: "/projects/:project_id/packages/:package_id/products",
     stripePath: "/projects/{project_id}/packages/{package_id}/products",
     resource: "package_products",
     operation: "list",
@@ -721,7 +721,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id/actions/attach_products",
+    fastifyPath: "/projects/:project_id/packages/:package_id/actions/attach_products",
     stripePath: "/projects/{project_id}/packages/{package_id}/actions/attach_products",
     resource: "packages",
     operation: "action",
@@ -732,7 +732,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/packages/:package_id/actions/detach_products",
+    fastifyPath: "/projects/:project_id/packages/:package_id/actions/detach_products",
     stripePath: "/projects/{project_id}/packages/{package_id}/actions/detach_products",
     resource: "packages",
     operation: "action",
@@ -743,7 +743,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -754,7 +754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/transactions",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/transactions",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/transactions",
     resource: "subscription_transactions",
     operation: "list",
@@ -764,7 +764,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/transactions/:transaction_id/actions/refund",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/transactions/:transaction_id/actions/refund",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/transactions/{transaction_id}/actions/refund",
     resource: "subscription_transactions",
     operation: "action",
@@ -774,7 +774,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/entitlements",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/entitlements",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/entitlements",
     resource: "subscription_entitlements",
     operation: "list",
@@ -784,7 +784,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/actions/cancel",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/actions/cancel",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/actions/cancel",
     resource: "subscriptions",
     operation: "action",
@@ -795,7 +795,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/actions/refund",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/actions/refund",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/actions/refund",
     resource: "subscriptions",
     operation: "action",
@@ -806,7 +806,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions/:subscription_id/authenticated_management_url",
+    fastifyPath: "/projects/:project_id/subscriptions/:subscription_id/authenticated_management_url",
     stripePath: "/projects/{project_id}/subscriptions/{subscription_id}/authenticated_management_url",
     resource: "subscriptions",
     operation: "action",
@@ -817,7 +817,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/subscriptions",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/subscriptions",
     stripePath: "/projects/{project_id}/customers/{customer_id}/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -828,7 +828,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/purchases/:purchase_id",
+    fastifyPath: "/projects/:project_id/purchases/:purchase_id",
     stripePath: "/projects/{project_id}/purchases/{purchase_id}",
     resource: "purchases",
     operation: "retrieve",
@@ -839,7 +839,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/purchases/:purchase_id/entitlements",
+    fastifyPath: "/projects/:project_id/purchases/:purchase_id/entitlements",
     stripePath: "/projects/{project_id}/purchases/{purchase_id}/entitlements",
     resource: "purchase_entitlements",
     operation: "list",
@@ -849,7 +849,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/purchases/:purchase_id/actions/refund",
+    fastifyPath: "/projects/:project_id/purchases/:purchase_id/actions/refund",
     stripePath: "/projects/{project_id}/purchases/{purchase_id}/actions/refund",
     resource: "purchases",
     operation: "action",
@@ -860,7 +860,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/purchases",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/purchases",
     stripePath: "/projects/{project_id}/customers/{customer_id}/purchases",
     resource: "purchases",
     operation: "list",
@@ -871,7 +871,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/active_entitlements",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/active_entitlements",
     stripePath: "/projects/{project_id}/customers/{customer_id}/active_entitlements",
     resource: "active_entitlements",
     operation: "list",
@@ -881,7 +881,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/aliases",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/aliases",
     stripePath: "/projects/{project_id}/customers/{customer_id}/aliases",
     resource: "aliases",
     operation: "list",
@@ -891,7 +891,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/virtual_currencies",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/virtual_currencies",
     stripePath: "/projects/{project_id}/customers/{customer_id}/virtual_currencies",
     resource: "virtual_currencies",
     operation: "list",
@@ -902,7 +902,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/virtual_currencies/transactions",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/virtual_currencies/transactions",
     stripePath: "/projects/{project_id}/customers/{customer_id}/virtual_currencies/transactions",
     resource: "virtual_currency_transactions",
     operation: "create",
@@ -912,7 +912,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/virtual_currencies/update_balance",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/virtual_currencies/update_balance",
     stripePath: "/projects/{project_id}/customers/{customer_id}/virtual_currencies/update_balance",
     resource: "virtual_currency_transactions",
     operation: "action",
@@ -922,7 +922,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/attributes",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/attributes",
     stripePath: "/projects/{project_id}/customers/{customer_id}/attributes",
     resource: "attributes",
     operation: "list",
@@ -932,7 +932,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/attributes",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/attributes",
     stripePath: "/projects/{project_id}/customers/{customer_id}/attributes",
     resource: "attributes",
     operation: "create",
@@ -942,7 +942,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/invoices",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/invoices",
     stripePath: "/projects/{project_id}/customers/{customer_id}/invoices",
     resource: "invoices",
     operation: "list",
@@ -953,7 +953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/customers/:customer_id/invoices/:invoice_id/file",
+    fastifyPath: "/projects/:project_id/customers/:customer_id/invoices/:invoice_id/file",
     stripePath: "/projects/{project_id}/customers/{customer_id}/invoices/{invoice_id}/file",
     resource: "invoices",
     operation: "action",
@@ -964,7 +964,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/metrics/overview",
+    fastifyPath: "/projects/:project_id/metrics/overview",
     stripePath: "/projects/{project_id}/metrics/overview",
     resource: "metrics",
     operation: "list",
@@ -973,7 +973,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/charts/:chart_name",
+    fastifyPath: "/projects/:project_id/charts/:chart_name",
     stripePath: "/projects/{project_id}/charts/{chart_name}",
     resource: "charts",
     operation: "retrieve",
@@ -983,7 +983,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/charts/:chart_name/options",
+    fastifyPath: "/projects/:project_id/charts/:chart_name/options",
     stripePath: "/projects/{project_id}/charts/{chart_name}/options",
     resource: "charts",
     operation: "list",
@@ -993,7 +993,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/subscriptions",
+    fastifyPath: "/projects/:project_id/subscriptions",
     stripePath: "/projects/{project_id}/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -1003,7 +1003,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/revenuecat/projects/:project_id/purchases",
+    fastifyPath: "/projects/:project_id/purchases",
     stripePath: "/projects/{project_id}/purchases",
     resource: "purchases",
     operation: "list",

--- a/packages/adapters/adapter-revenuecat/src/mcp.ts
+++ b/packages/adapters/adapter-revenuecat/src/mcp.ts
@@ -42,7 +42,7 @@ const PROJECT_ID = 'proj_mock';
 
 export function registerRevenueCatTools(server: McpServer, baseUrl: string = 'http://localhost:4100'): void {
   const call = makeCall(baseUrl);
-  const p = `/revenuecat/projects/${PROJECT_ID}`;
+  const p = `/projects/${PROJECT_ID}`;
 
   // Customers
   server.tool('list_customers', 'List RevenueCat customers', {

--- a/packages/adapters/adapter-revenuecat/src/revenuecat-adapter.ts
+++ b/packages/adapters/adapter-revenuecat/src/revenuecat-adapter.ts
@@ -153,27 +153,27 @@ export class RevenueCatAdapter extends OpenApiMockAdapter<RevenueCatConfig> {
 
   private mountOverrides(store: StateStore): void {
     // Subscription lifecycle
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/subscriptions/:subscription_id/actions/cancel',
+    this.registerOverride('POST', '/projects/:project_id/subscriptions/:subscription_id/actions/cancel',
       subscriptionOverrides.buildCancelHandler(store));
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/subscriptions/:subscription_id/actions/refund',
+    this.registerOverride('POST', '/projects/:project_id/subscriptions/:subscription_id/actions/refund',
       subscriptionOverrides.buildRefundHandler(store));
 
     // Entitlement archive/unarchive
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/archive',
+    this.registerOverride('POST', '/projects/:project_id/entitlements/:entitlement_id/actions/archive',
       entitlementOverrides.buildArchiveHandler(store));
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/entitlements/:entitlement_id/actions/unarchive',
+    this.registerOverride('POST', '/projects/:project_id/entitlements/:entitlement_id/actions/unarchive',
       entitlementOverrides.buildUnarchiveHandler(store));
 
     // Product archive/unarchive
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/products/:product_id/actions/archive',
+    this.registerOverride('POST', '/projects/:project_id/products/:product_id/actions/archive',
       productOverrides.buildArchiveHandler(store));
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/products/:product_id/actions/unarchive',
+    this.registerOverride('POST', '/projects/:project_id/products/:product_id/actions/unarchive',
       productOverrides.buildUnarchiveHandler(store));
 
     // Offering archive/unarchive
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/offerings/:offering_id/actions/archive',
+    this.registerOverride('POST', '/projects/:project_id/offerings/:offering_id/actions/archive',
       offeringOverrides.buildArchiveHandler(store));
-    this.registerOverride('POST', '/revenuecat/projects/:project_id/offerings/:offering_id/actions/unarchive',
+    this.registerOverride('POST', '/projects/:project_id/offerings/:offering_id/actions/unarchive',
       offeringOverrides.buildUnarchiveHandler(store));
   }
 }

--- a/packages/adapters/adapter-stripe/adapter.json
+++ b/packages/adapters/adapter-stripe/adapter.json
@@ -3,7 +3,7 @@
   "name": "Stripe API",
   "description": "Stripe payments, billing, subscriptions mock adapter",
   "type": "api-mock",
-  "basePath": "/stripe",
+  "basePath": "",
   "versions": [
     "2025-03-31.basil",
     "2025-09-30.clover",

--- a/packages/adapters/adapter-stripe/scripts/stripe-codegen.ts
+++ b/packages/adapters/adapter-stripe/scripts/stripe-codegen.ts
@@ -749,7 +749,7 @@ type RouteOperation = 'list' | 'create' | 'retrieve' | 'update' | 'delete' | 'ac
 interface ExtractedRoute {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   stripePath: string;        // original Stripe path, e.g. /v1/customers/{customer}
-  fastifyPath: string;       // Fastify path with colon params + basePath prefix
+  fastifyPath: string;       // Fastify route path with colon params
   resource: string;          // resource type, e.g. 'customers'
   operation: RouteOperation;
   description: string;
@@ -787,7 +787,7 @@ function extractRoutes(spec: OaSpec, resources: Map<string, ResourceInfo>): Extr
       const description = operation.summary ?? operation.description ?? '';
 
       // Convert Stripe path params {param} → Fastify :param
-      const fastifyPath = '/stripe' + stripePath.replace(/\{([^}]+)\}/g, ':$1');
+      const fastifyPath = stripePath.replace(/\{([^}]+)\}/g, ':$1');
 
       // Determine what resource this route belongs to
       const resource = detectRouteResource(stripePath, operation, resources, spec);
@@ -1104,7 +1104,7 @@ function generateRoutesTs(routes: ExtractedRoute[]): string {
     `export interface GeneratedRoute {`,
     `  /** HTTP method */`,
     `  method: RouteMethod;`,
-    `  /** Fastify route path with colon params and /stripe prefix */`,
+    `  /** Fastify route path with colon params */`,
     `  fastifyPath: string;`,
     `  /** Original Stripe path for documentation */`,
     `  stripePath: string;`,

--- a/packages/adapters/adapter-stripe/src/__tests__/stripe-adapter.test.ts
+++ b/packages/adapters/adapter-stripe/src/__tests__/stripe-adapter.test.ts
@@ -23,7 +23,7 @@ describe('StripeAdapter', () => {
       expect(adapter.id).toBe('stripe');
       expect(adapter.name).toBe('Stripe API');
       expect(adapter.type).toBe('api-mock');
-      expect(adapter.basePath).toBe('/stripe');
+      expect(adapter.basePath).toBe('');
     });
   });
 
@@ -50,7 +50,7 @@ describe('StripeAdapter', () => {
     it('should create a customer', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/customers',
+        url: '/v1/customers',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ email: 'test@example.com', name: 'Test User' }),
       });
@@ -66,7 +66,7 @@ describe('StripeAdapter', () => {
     it('should get a customer by id', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: `/stripe/v1/customers/${customerId}`,
+        url: `/v1/customers/${customerId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -77,7 +77,7 @@ describe('StripeAdapter', () => {
     it('should list customers', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/customers',
+        url: '/v1/customers',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -90,7 +90,7 @@ describe('StripeAdapter', () => {
     it('should update a customer', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/customers/${customerId}`,
+        url: `/v1/customers/${customerId}`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ name: 'Updated User' }),
       });
@@ -104,7 +104,7 @@ describe('StripeAdapter', () => {
     it('should delete a customer', async () => {
       const res = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/customers/${customerId}`,
+        url: `/v1/customers/${customerId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -122,7 +122,7 @@ describe('StripeAdapter', () => {
     it('should create a payment intent', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 5000, currency: 'usd' }),
       });
@@ -138,7 +138,7 @@ describe('StripeAdapter', () => {
     it('should list payment intents', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -149,7 +149,7 @@ describe('StripeAdapter', () => {
     it('should confirm a payment intent and create a charge', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/confirm`,
+        url: `/v1/payment_intents/${piId}/confirm`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -162,13 +162,13 @@ describe('StripeAdapter', () => {
     it('should retrieve the charge created by confirm', async () => {
       const piRes = await ts.server.inject({
         method: 'GET',
-        url: `/stripe/v1/payment_intents/${piId}`,
+        url: `/v1/payment_intents/${piId}`,
       });
       const chargeId = piRes.json().latest_charge;
 
       const res = await ts.server.inject({
         method: 'GET',
-        url: `/stripe/v1/charges/${chargeId}`,
+        url: `/v1/charges/${chargeId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -186,7 +186,7 @@ describe('StripeAdapter', () => {
     it('should create a PI with manual capture', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 10000, currency: 'usd' }),
       });
@@ -197,7 +197,7 @@ describe('StripeAdapter', () => {
     it('should confirm with capture_method=manual and get requires_capture', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/confirm`,
+        url: `/v1/payment_intents/${piId}/confirm`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ capture_method: 'manual' }),
       });
@@ -210,7 +210,7 @@ describe('StripeAdapter', () => {
     it('should capture and transition to succeeded', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/capture`,
+        url: `/v1/payment_intents/${piId}/capture`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -227,7 +227,7 @@ describe('StripeAdapter', () => {
     it('should cancel a payment intent', async () => {
       const createRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 3000, currency: 'usd' }),
       });
@@ -235,7 +235,7 @@ describe('StripeAdapter', () => {
 
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/cancel`,
+        url: `/v1/payment_intents/${piId}/cancel`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -253,7 +253,7 @@ describe('StripeAdapter', () => {
     it('should create a subscription', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/subscriptions',
+        url: '/v1/subscriptions',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           customer: customerId,
@@ -274,7 +274,7 @@ describe('StripeAdapter', () => {
     it('should list subscriptions filtered by customer', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: `/stripe/v1/subscriptions?customer=${customerId}`,
+        url: `/v1/subscriptions?customer=${customerId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -286,7 +286,7 @@ describe('StripeAdapter', () => {
     it('should update a subscription', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/subscriptions/${subId}`,
+        url: `/v1/subscriptions/${subId}`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ cancel_at_period_end: true }),
       });
@@ -299,7 +299,7 @@ describe('StripeAdapter', () => {
     it('should cancel (DELETE) a subscription', async () => {
       const res = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/subscriptions/${subId}`,
+        url: `/v1/subscriptions/${subId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -316,7 +316,7 @@ describe('StripeAdapter', () => {
     it('should create an invoice', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/invoices',
+        url: '/v1/invoices',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_inv1', amount_due: 2500 }),
       });
@@ -331,7 +331,7 @@ describe('StripeAdapter', () => {
     it('should finalize an invoice', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/invoices/${invoiceId}/finalize`,
+        url: `/v1/invoices/${invoiceId}/finalize`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -344,7 +344,7 @@ describe('StripeAdapter', () => {
     it('should pay an invoice', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/invoices/${invoiceId}/pay`,
+        url: `/v1/invoices/${invoiceId}/pay`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -361,7 +361,7 @@ describe('StripeAdapter', () => {
     it('should create an invoice item', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/invoiceitems',
+        url: '/v1/invoiceitems',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_test1', amount: 1500, description: 'Setup fee' }),
       });
@@ -380,7 +380,7 @@ describe('StripeAdapter', () => {
     it('should create a refund (no linked charge)', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/refunds',
+        url: '/v1/refunds',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 1000, charge: 'ch_test123' }),
       });
@@ -396,7 +396,7 @@ describe('StripeAdapter', () => {
       // Create a charge via PI confirm
       const piRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 5000, currency: 'usd' }),
       });
@@ -404,18 +404,18 @@ describe('StripeAdapter', () => {
 
       await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/confirm`,
+        url: `/v1/payment_intents/${piId}/confirm`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
 
-      const chargeId = (await ts.server.inject({ method: 'GET', url: `/stripe/v1/payment_intents/${piId}` }))
+      const chargeId = (await ts.server.inject({ method: 'GET', url: `/v1/payment_intents/${piId}` }))
         .json().latest_charge;
 
       // Create a partial refund
       const refundRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/refunds',
+        url: '/v1/refunds',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 2000, charge: chargeId }),
       });
@@ -423,7 +423,7 @@ describe('StripeAdapter', () => {
       expect(refundRes.json().charge).toBe(chargeId);
 
       // Charge should reflect the refund
-      const chargeRes = await ts.server.inject({ method: 'GET', url: `/stripe/v1/charges/${chargeId}` });
+      const chargeRes = await ts.server.inject({ method: 'GET', url: `/v1/charges/${chargeId}` });
       const charge = chargeRes.json();
       expect(charge.amount_refunded).toBe(2000);
       expect(charge.refunded).toBe(false); // partial refund, not fully refunded
@@ -432,65 +432,65 @@ describe('StripeAdapter', () => {
     it('should set charge.refunded=true on full refund', async () => {
       const piRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 3000, currency: 'usd' }),
       });
       const piId = piRes.json().id;
       await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/confirm`,
+        url: `/v1/payment_intents/${piId}/confirm`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
-      const chargeId = (await ts.server.inject({ method: 'GET', url: `/stripe/v1/payment_intents/${piId}` }))
+      const chargeId = (await ts.server.inject({ method: 'GET', url: `/v1/payment_intents/${piId}` }))
         .json().latest_charge;
 
       await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/refunds',
+        url: '/v1/refunds',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 3000, charge: chargeId }),
       });
 
-      const chargeRes = await ts.server.inject({ method: 'GET', url: `/stripe/v1/charges/${chargeId}` });
+      const chargeRes = await ts.server.inject({ method: 'GET', url: `/v1/charges/${chargeId}` });
       const charge = chargeRes.json();
       expect(charge.amount_refunded).toBe(3000);
       expect(charge.refunded).toBe(true);
     });
 
     it('should reflect refunds in GET /balance', async () => {
-      const balanceBefore = (await ts.server.inject({ method: 'GET', url: '/stripe/v1/balance' }))
+      const balanceBefore = (await ts.server.inject({ method: 'GET', url: '/v1/balance' }))
         .json().available[0].amount;
 
       const piRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_intents',
+        url: '/v1/payment_intents',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 4000, currency: 'usd' }),
       });
       const piId = piRes.json().id;
       await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_intents/${piId}/confirm`,
+        url: `/v1/payment_intents/${piId}/confirm`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
-      const chargeId = (await ts.server.inject({ method: 'GET', url: `/stripe/v1/payment_intents/${piId}` }))
+      const chargeId = (await ts.server.inject({ method: 'GET', url: `/v1/payment_intents/${piId}` }))
         .json().latest_charge;
 
-      const balanceAfterCharge = (await ts.server.inject({ method: 'GET', url: '/stripe/v1/balance' }))
+      const balanceAfterCharge = (await ts.server.inject({ method: 'GET', url: '/v1/balance' }))
         .json().available[0].amount;
       expect(balanceAfterCharge).toBe(balanceBefore + 4000);
 
       await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/refunds',
+        url: '/v1/refunds',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount: 4000, charge: chargeId }),
       });
 
-      const balanceAfterRefund = (await ts.server.inject({ method: 'GET', url: '/stripe/v1/balance' }))
+      const balanceAfterRefund = (await ts.server.inject({ method: 'GET', url: '/v1/balance' }))
         .json().available[0].amount;
       expect(balanceAfterRefund).toBe(balanceBefore);
     });
@@ -502,7 +502,7 @@ describe('StripeAdapter', () => {
     it('should create a product', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/products',
+        url: '/v1/products',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ name: 'Premium Plan' }),
       });
@@ -516,7 +516,7 @@ describe('StripeAdapter', () => {
     it('should create a price', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/prices',
+        url: '/v1/prices',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ unit_amount: 2999, currency: 'usd', product: 'prod_abc' }),
       });
@@ -536,7 +536,7 @@ describe('StripeAdapter', () => {
     it('should create a percentage coupon', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/coupons',
+        url: '/v1/coupons',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ percent_off: 25, duration: 'once' }),
       });
@@ -552,7 +552,7 @@ describe('StripeAdapter', () => {
     it('should create a fixed-amount coupon', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/coupons',
+        url: '/v1/coupons',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ amount_off: 500, currency: 'usd', duration: 'forever' }),
       });
@@ -565,7 +565,7 @@ describe('StripeAdapter', () => {
     it('should list coupons', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/coupons',
+        url: '/v1/coupons',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -576,7 +576,7 @@ describe('StripeAdapter', () => {
     it('should get a coupon by id', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: `/stripe/v1/coupons/${couponId}`,
+        url: `/v1/coupons/${couponId}`,
       });
       expect(res.statusCode).toBe(200);
       expect(res.json().id).toBe(couponId);
@@ -585,7 +585,7 @@ describe('StripeAdapter', () => {
     it('should delete a coupon', async () => {
       const res = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/coupons/${couponId}`,
+        url: `/v1/coupons/${couponId}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -599,7 +599,7 @@ describe('StripeAdapter', () => {
     it('should list disputes (empty initially)', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/disputes',
+        url: '/v1/disputes',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -610,7 +610,7 @@ describe('StripeAdapter', () => {
     it('should return 404 for non-existent dispute', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/disputes/dp_nonexistent',
+        url: '/v1/disputes/dp_nonexistent',
       });
       expect(res.statusCode).toBe(404);
       expect(res.json().error.code).toBe('resource_missing');
@@ -623,7 +623,7 @@ describe('StripeAdapter', () => {
     it('should create a payment link', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_links',
+        url: '/v1/payment_links',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           line_items: [{ price: 'price_abc', quantity: 1 }],
@@ -640,7 +640,7 @@ describe('StripeAdapter', () => {
     it('should list payment links', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/payment_links',
+        url: '/v1/payment_links',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -655,7 +655,7 @@ describe('StripeAdapter', () => {
     it('should create a billing portal session', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/billing_portal/sessions',
+        url: '/v1/billing_portal/sessions',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_test1', return_url: 'https://example.com' }),
       });
@@ -675,7 +675,7 @@ describe('StripeAdapter', () => {
     it('should return account info', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/account',
+        url: '/v1/account',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -692,7 +692,7 @@ describe('StripeAdapter', () => {
     it('should return a balance object', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/balance',
+        url: '/v1/balance',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -708,7 +708,7 @@ describe('StripeAdapter', () => {
     it('should return Stripe error format for non-existent customer', async () => {
       const res = await ts.server.inject({
         method: 'GET',
-        url: '/stripe/v1/customers/cus_doesnotexist',
+        url: '/v1/customers/cus_doesnotexist',
       });
       expect(res.statusCode).toBe(404);
       const body = res.json();
@@ -756,7 +756,7 @@ describe('StripeAdapter', () => {
     it('should create a payment method', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/payment_methods',
+        url: '/v1/payment_methods',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ type: 'card' }),
       });
@@ -770,7 +770,7 @@ describe('StripeAdapter', () => {
     it('should attach a payment method to a customer', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_methods/${pmId}/attach`,
+        url: `/v1/payment_methods/${pmId}/attach`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_attach_test' }),
       });
@@ -781,7 +781,7 @@ describe('StripeAdapter', () => {
     });
 
     it('should retrieve the same PM with updated customer field', async () => {
-      const res = await ts.server.inject({ method: 'GET', url: `/stripe/v1/payment_methods/${pmId}` });
+      const res = await ts.server.inject({ method: 'GET', url: `/v1/payment_methods/${pmId}` });
       expect(res.statusCode).toBe(200);
       expect(res.json().customer).toBe('cus_attach_test');
     });
@@ -789,7 +789,7 @@ describe('StripeAdapter', () => {
     it('should detach a payment method from a customer', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_methods/${pmId}/detach`,
+        url: `/v1/payment_methods/${pmId}/detach`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -802,7 +802,7 @@ describe('StripeAdapter', () => {
     it('should return 400 when detaching an already-detached payment method', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/payment_methods/${pmId}/detach`,
+        url: `/v1/payment_methods/${pmId}/detach`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
@@ -818,7 +818,7 @@ describe('StripeAdapter', () => {
       // Create a customer
       const cusRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/customers',
+        url: '/v1/customers',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ email: 'cascade@test.com' }),
       });
@@ -827,7 +827,7 @@ describe('StripeAdapter', () => {
       // Create a subscription for that customer
       const subRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/subscriptions',
+        url: '/v1/subscriptions',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: cusId, items: [{ price: 'price_cascade' }] }),
       });
@@ -837,17 +837,17 @@ describe('StripeAdapter', () => {
       // Delete the customer
       const delRes = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/customers/${cusId}`,
+        url: `/v1/customers/${cusId}`,
       });
       expect(delRes.statusCode).toBe(200);
       expect(delRes.json().deleted).toBe(true);
 
       // Customer should be gone
-      const cusCheck = await ts.server.inject({ method: 'GET', url: `/stripe/v1/customers/${cusId}` });
+      const cusCheck = await ts.server.inject({ method: 'GET', url: `/v1/customers/${cusId}` });
       expect(cusCheck.statusCode).toBe(404);
 
       // Subscription should be canceled
-      const subCheck = await ts.server.inject({ method: 'GET', url: `/stripe/v1/subscriptions/${subId}` });
+      const subCheck = await ts.server.inject({ method: 'GET', url: `/v1/subscriptions/${subId}` });
       expect(subCheck.statusCode).toBe(200);
       expect(subCheck.json().status).toBe('canceled');
     });
@@ -859,7 +859,7 @@ describe('StripeAdapter', () => {
     it('should delete a draft invoice', async () => {
       const createRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/invoices',
+        url: '/v1/invoices',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_del_test', amount_due: 500 }),
       });
@@ -868,19 +868,19 @@ describe('StripeAdapter', () => {
 
       const delRes = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/invoices/${invId}`,
+        url: `/v1/invoices/${invId}`,
       });
       expect(delRes.statusCode).toBe(200);
       expect(delRes.json().deleted).toBe(true);
 
-      const check = await ts.server.inject({ method: 'GET', url: `/stripe/v1/invoices/${invId}` });
+      const check = await ts.server.inject({ method: 'GET', url: `/v1/invoices/${invId}` });
       expect(check.statusCode).toBe(404);
     });
 
     it('should reject deleting an open invoice', async () => {
       const createRes = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/invoices',
+        url: '/v1/invoices',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ customer: 'cus_del_test2', amount_due: 800 }),
       });
@@ -888,14 +888,14 @@ describe('StripeAdapter', () => {
 
       await ts.server.inject({
         method: 'POST',
-        url: `/stripe/v1/invoices/${invId}/finalize`,
+        url: `/v1/invoices/${invId}/finalize`,
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({}),
       });
 
       const delRes = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/invoices/${invId}`,
+        url: `/v1/invoices/${invId}`,
       });
       expect(delRes.statusCode).toBe(400);
       expect(delRes.json().error.code).toBe('invoice_not_editable');
@@ -911,7 +911,7 @@ describe('StripeAdapter', () => {
     it('should create a subscription with one item', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/subscriptions',
+        url: '/v1/subscriptions',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({
           customer: 'cus_si_test',
@@ -926,7 +926,7 @@ describe('StripeAdapter', () => {
     it('should add a subscription item and update parent subscription', async () => {
       const res = await ts.server.inject({
         method: 'POST',
-        url: '/stripe/v1/subscription_items',
+        url: '/v1/subscription_items',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ subscription: subId, price: 'price_addon', quantity: 2 }),
       });
@@ -938,20 +938,20 @@ describe('StripeAdapter', () => {
       itemId = body.id;
 
       // Parent subscription should now have 2 items
-      const subRes = await ts.server.inject({ method: 'GET', url: `/stripe/v1/subscriptions/${subId}` });
+      const subRes = await ts.server.inject({ method: 'GET', url: `/v1/subscriptions/${subId}` });
       expect(subRes.json().items.data.length).toBe(2);
     });
 
     it('should delete a subscription item and update parent subscription', async () => {
       const delRes = await ts.server.inject({
         method: 'DELETE',
-        url: `/stripe/v1/subscription_items/${itemId}`,
+        url: `/v1/subscription_items/${itemId}`,
       });
       expect(delRes.statusCode).toBe(200);
       expect(delRes.json().deleted).toBe(true);
 
       // Parent subscription should be back to 1 item
-      const subRes = await ts.server.inject({ method: 'GET', url: `/stripe/v1/subscriptions/${subId}` });
+      const subRes = await ts.server.inject({ method: 'GET', url: `/v1/subscriptions/${subId}` });
       expect(subRes.json().items.data.length).toBe(1);
       expect(subRes.json().items.data.some((i: Record<string, unknown>) => i.id === itemId)).toBe(false);
     });
@@ -1015,7 +1015,7 @@ describe('StripeAdapter', () => {
     });
 
     it('should list pre-seeded customers', async () => {
-      const res = await seededTs.server.inject({ method: 'GET', url: '/stripe/v1/customers' });
+      const res = await seededTs.server.inject({ method: 'GET', url: '/v1/customers' });
       expect(res.statusCode).toBe(200);
       const body = res.json();
       expect(body.data.length).toBe(2);
@@ -1024,7 +1024,7 @@ describe('StripeAdapter', () => {
     });
 
     it('should retrieve a pre-seeded customer by ID', async () => {
-      const res = await seededTs.server.inject({ method: 'GET', url: '/stripe/v1/customers/cus_seeded1' });
+      const res = await seededTs.server.inject({ method: 'GET', url: '/v1/customers/cus_seeded1' });
       expect(res.statusCode).toBe(200);
       const body = res.json();
       expect(body.id).toBe('cus_seeded1');
@@ -1037,7 +1037,7 @@ describe('StripeAdapter', () => {
     it('should list pre-seeded subscriptions filtered by customer', async () => {
       const res = await seededTs.server.inject({
         method: 'GET',
-        url: '/stripe/v1/subscriptions?customer=cus_seeded1',
+        url: '/v1/subscriptions?customer=cus_seeded1',
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -1049,13 +1049,13 @@ describe('StripeAdapter', () => {
     it('should allow creating new resources alongside pre-seeded ones', async () => {
       const createRes = await seededTs.server.inject({
         method: 'POST',
-        url: '/stripe/v1/customers',
+        url: '/v1/customers',
         headers: { 'content-type': 'application/json' },
         payload: JSON.stringify({ email: 'new@example.com', name: 'New User' }),
       });
       expect(createRes.statusCode).toBe(200);
 
-      const listRes = await seededTs.server.inject({ method: 'GET', url: '/stripe/v1/customers' });
+      const listRes = await seededTs.server.inject({ method: 'GET', url: '/v1/customers' });
       expect(listRes.json().data.length).toBe(3);
     });
   });

--- a/packages/adapters/adapter-stripe/src/__tests__/stripe-e2e.test.ts
+++ b/packages/adapters/adapter-stripe/src/__tests__/stripe-e2e.test.ts
@@ -22,7 +22,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 1. Create a customer ──────────────────────────────────
     const createCust = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/customers',
+      url: '/v1/customers',
       payload: { name: 'Jane Doe', email: 'jane@acme.com', phone: '+15551234567' },
     });
     expect(createCust.statusCode).toBe(200);
@@ -35,7 +35,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 2. Create a product + price ───────────────────────────
     const createProd = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/products',
+      url: '/v1/products',
       payload: { name: 'Pro Plan' },
     });
     expect(createProd.statusCode).toBe(200);
@@ -45,7 +45,7 @@ describe('Stripe E2E Lifecycle', () => {
 
     const createPrice = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/prices',
+      url: '/v1/prices',
       payload: { unit_amount: 9900, currency: 'usd', product: prod.id, recurring: { interval: 'month' } },
     });
     expect(createPrice.statusCode).toBe(200);
@@ -57,7 +57,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 3. Create a subscription ──────────────────────────────
     const createSub = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/subscriptions',
+      url: '/v1/subscriptions',
       payload: { customer: cust.id, price: price.id },
     });
     expect(createSub.statusCode).toBe(200);
@@ -70,7 +70,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 4. Create a payment intent + confirm ──────────────────
     const createPI = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/payment_intents',
+      url: '/v1/payment_intents',
       payload: { amount: 9900, currency: 'usd', customer: cust.id, description: 'Pro plan monthly' },
     });
     expect(createPI.statusCode).toBe(200);
@@ -82,7 +82,7 @@ describe('Stripe E2E Lifecycle', () => {
 
     const confirmPI = await ts.server.inject({
       method: 'POST',
-      url: `/stripe/v1/payment_intents/${pi.id}/confirm`,
+      url: `/v1/payment_intents/${pi.id}/confirm`,
     });
     expect(confirmPI.statusCode).toBe(200);
     const confirmedPI = confirmPI.json();
@@ -91,7 +91,7 @@ describe('Stripe E2E Lifecycle', () => {
     console.log(`✓ Confirmed PI: ${confirmedPI.id} → ${confirmedPI.status}, charge: ${confirmedPI.latest_charge}`);
 
     // ── 5. Verify charge was created ──────────────────────────
-    const listCharges = await ts.server.inject({ method: 'GET', url: '/stripe/v1/charges' });
+    const listCharges = await ts.server.inject({ method: 'GET', url: '/v1/charges' });
     const charges = listCharges.json();
     expect(charges.object).toBe('list');
     expect(charges.data.length).toBeGreaterThanOrEqual(1);
@@ -104,7 +104,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 6. Create invoice + pay ───────────────────────────────
     const createInv = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/invoices',
+      url: '/v1/invoices',
       payload: { customer: cust.id },
     });
     expect(createInv.statusCode).toBe(200);
@@ -115,7 +115,7 @@ describe('Stripe E2E Lifecycle', () => {
 
     const payInv = await ts.server.inject({
       method: 'POST',
-      url: `/stripe/v1/invoices/${inv.id}/pay`,
+      url: `/v1/invoices/${inv.id}/pay`,
     });
     expect(payInv.statusCode).toBe(200);
     const paidInv = payInv.json();
@@ -125,7 +125,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 7. Create refund ──────────────────────────────────────
     const createRefund = await ts.server.inject({
       method: 'POST',
-      url: '/stripe/v1/refunds',
+      url: '/v1/refunds',
       payload: { payment_intent: pi.id, amount: 5000, reason: 'requested_by_customer' },
     });
     expect(createRefund.statusCode).toBe(200);
@@ -138,7 +138,7 @@ describe('Stripe E2E Lifecycle', () => {
     // ── 8. Cancel subscription ────────────────────────────────
     const cancelSub = await ts.server.inject({
       method: 'DELETE',
-      url: `/stripe/v1/subscriptions/${sub.id}`,
+      url: `/v1/subscriptions/${sub.id}`,
     });
     expect(cancelSub.statusCode).toBe(200);
     const canceledSub = cancelSub.json();
@@ -146,7 +146,7 @@ describe('Stripe E2E Lifecycle', () => {
     console.log(`✓ Cancelled subscription: ${canceledSub.id} [${canceledSub.status}]`);
 
     // ── 9. Get balance ────────────────────────────────────────
-    const balance = await ts.server.inject({ method: 'GET', url: '/stripe/v1/balance' });
+    const balance = await ts.server.inject({ method: 'GET', url: '/v1/balance' });
     expect(balance.statusCode).toBe(200);
     const bal = balance.json();
     expect(bal.object).toBe('balance');
@@ -155,12 +155,12 @@ describe('Stripe E2E Lifecycle', () => {
 
     // ── 10. List all resources ────────────────────────────────
     const [custs, subs, invs, refunds, prods, prices] = await Promise.all([
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/customers' }).then(r => r.json()),
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/subscriptions' }).then(r => r.json()),
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/invoices' }).then(r => r.json()),
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/refunds' }).then(r => r.json()),
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/products' }).then(r => r.json()),
-      ts.server.inject({ method: 'GET', url: '/stripe/v1/prices' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/customers' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/subscriptions' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/invoices' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/refunds' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/products' }).then(r => r.json()),
+      ts.server.inject({ method: 'GET', url: '/v1/prices' }).then(r => r.json()),
     ]);
 
     console.log('\n── Final State ──');
@@ -172,7 +172,7 @@ describe('Stripe E2E Lifecycle', () => {
     console.log(`Prices: ${prices.data.length}`);
 
     // ── 11. Error handling ────────────────────────────────────
-    const notFound = await ts.server.inject({ method: 'GET', url: '/stripe/v1/customers/cus_nonexistent' });
+    const notFound = await ts.server.inject({ method: 'GET', url: '/v1/customers/cus_nonexistent' });
     expect(notFound.statusCode).toBe(404);
     const err = notFound.json();
     expect(err.error.type).toBe('invalid_request_error');

--- a/packages/adapters/adapter-stripe/src/generated/meta.ts
+++ b/packages/adapters/adapter-stripe/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-stripe generate
 // Stripe OpenAPI spec version: 2026-02-25.clover
-// Generated at: 2026-03-12T09:50:35.300Z
+// Generated at: 2026-03-20T10:59:31.216Z
 
 export const STRIPE_SPEC_VERSION = "2026-02-25.clover";
-export const STRIPE_SPEC_GENERATED_AT = "2026-03-12T09:50:35.300Z";
+export const STRIPE_SPEC_GENERATED_AT = "2026-03-20T10:59:31.216Z";

--- a/packages/adapters/adapter-stripe/src/generated/routes.ts
+++ b/packages/adapters/adapter-stripe/src/generated/routes.ts
@@ -6,7 +6,7 @@ export type RouteOperation = 'list' | 'create' | 'retrieve' | 'update' | 'delete
 export interface GeneratedRoute {
   /** HTTP method */
   method: RouteMethod;
-  /** Fastify route path with colon params and /stripe prefix */
+  /** Fastify route path with colon params */
   fastifyPath: string;
   /** Original Stripe path for documentation */
   stripePath: string;
@@ -27,7 +27,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/account",
+    fastifyPath: "/v1/account",
     stripePath: "/v1/account",
     resource: "account",
     operation: "retrieve",
@@ -37,7 +37,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/account_links",
+    fastifyPath: "/v1/account_links",
     stripePath: "/v1/account_links",
     resource: "account_links",
     operation: "create",
@@ -47,7 +47,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/account_sessions",
+    fastifyPath: "/v1/account_sessions",
     stripePath: "/v1/account_sessions",
     resource: "account_sessions",
     operation: "create",
@@ -57,7 +57,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts",
+    fastifyPath: "/v1/accounts",
     stripePath: "/v1/accounts",
     resource: "accounts",
     operation: "list",
@@ -66,7 +66,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts",
+    fastifyPath: "/v1/accounts",
     stripePath: "/v1/accounts",
     resource: "accounts",
     operation: "create",
@@ -75,7 +75,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account",
+    fastifyPath: "/v1/accounts/:account",
     stripePath: "/v1/accounts/{account}",
     resource: "accounts",
     operation: "retrieve",
@@ -85,7 +85,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account",
+    fastifyPath: "/v1/accounts/:account",
     stripePath: "/v1/accounts/{account}",
     resource: "accounts",
     operation: "update",
@@ -95,7 +95,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/accounts/:account",
+    fastifyPath: "/v1/accounts/:account",
     stripePath: "/v1/accounts/{account}",
     resource: "accounts",
     operation: "delete",
@@ -105,7 +105,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/bank_accounts",
+    fastifyPath: "/v1/accounts/:account/bank_accounts",
     stripePath: "/v1/accounts/{account}/bank_accounts",
     resource: "bank_accounts",
     operation: "create",
@@ -116,7 +116,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/bank_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/bank_accounts/:id",
     stripePath: "/v1/accounts/{account}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "retrieve",
@@ -127,7 +127,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/bank_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/bank_accounts/:id",
     stripePath: "/v1/accounts/{account}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "update",
@@ -138,7 +138,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/accounts/:account/bank_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/bank_accounts/:id",
     stripePath: "/v1/accounts/{account}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "delete",
@@ -149,7 +149,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/capabilities",
+    fastifyPath: "/v1/accounts/:account/capabilities",
     stripePath: "/v1/accounts/{account}/capabilities",
     resource: "capabilities",
     operation: "list",
@@ -160,7 +160,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/capabilities/:capability",
+    fastifyPath: "/v1/accounts/:account/capabilities/:capability",
     stripePath: "/v1/accounts/{account}/capabilities/{capability}",
     resource: "capabilities",
     operation: "retrieve",
@@ -171,7 +171,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/capabilities/:capability",
+    fastifyPath: "/v1/accounts/:account/capabilities/:capability",
     stripePath: "/v1/accounts/{account}/capabilities/{capability}",
     resource: "capabilities",
     operation: "update",
@@ -182,7 +182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/external_accounts",
+    fastifyPath: "/v1/accounts/:account/external_accounts",
     stripePath: "/v1/accounts/{account}/external_accounts",
     resource: "external_accounts",
     operation: "list",
@@ -193,7 +193,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/external_accounts",
+    fastifyPath: "/v1/accounts/:account/external_accounts",
     stripePath: "/v1/accounts/{account}/external_accounts",
     resource: "external_accounts",
     operation: "create",
@@ -204,7 +204,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/external_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/external_accounts/:id",
     stripePath: "/v1/accounts/{account}/external_accounts/{id}",
     resource: "external_accounts",
     operation: "retrieve",
@@ -215,7 +215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/external_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/external_accounts/:id",
     stripePath: "/v1/accounts/{account}/external_accounts/{id}",
     resource: "external_accounts",
     operation: "update",
@@ -226,7 +226,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/accounts/:account/external_accounts/:id",
+    fastifyPath: "/v1/accounts/:account/external_accounts/:id",
     stripePath: "/v1/accounts/{account}/external_accounts/{id}",
     resource: "external_accounts",
     operation: "delete",
@@ -237,7 +237,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/login_links",
+    fastifyPath: "/v1/accounts/:account/login_links",
     stripePath: "/v1/accounts/{account}/login_links",
     resource: "login_links",
     operation: "create",
@@ -248,7 +248,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/people",
+    fastifyPath: "/v1/accounts/:account/people",
     stripePath: "/v1/accounts/{account}/people",
     resource: "accounts",
     operation: "list",
@@ -258,7 +258,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/people",
+    fastifyPath: "/v1/accounts/:account/people",
     stripePath: "/v1/accounts/{account}/people",
     resource: "accounts",
     operation: "create",
@@ -268,7 +268,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/people/:person",
+    fastifyPath: "/v1/accounts/:account/people/:person",
     stripePath: "/v1/accounts/{account}/people/{person}",
     resource: "accounts",
     operation: "retrieve",
@@ -278,7 +278,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/people/:person",
+    fastifyPath: "/v1/accounts/:account/people/:person",
     stripePath: "/v1/accounts/{account}/people/{person}",
     resource: "accounts",
     operation: "update",
@@ -288,7 +288,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/accounts/:account/people/:person",
+    fastifyPath: "/v1/accounts/:account/people/:person",
     stripePath: "/v1/accounts/{account}/people/{person}",
     resource: "accounts",
     operation: "delete",
@@ -298,7 +298,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/persons",
+    fastifyPath: "/v1/accounts/:account/persons",
     stripePath: "/v1/accounts/{account}/persons",
     resource: "persons",
     operation: "list",
@@ -309,7 +309,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/persons",
+    fastifyPath: "/v1/accounts/:account/persons",
     stripePath: "/v1/accounts/{account}/persons",
     resource: "persons",
     operation: "create",
@@ -320,7 +320,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/accounts/:account/persons/:person",
+    fastifyPath: "/v1/accounts/:account/persons/:person",
     stripePath: "/v1/accounts/{account}/persons/{person}",
     resource: "persons",
     operation: "retrieve",
@@ -331,7 +331,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/persons/:person",
+    fastifyPath: "/v1/accounts/:account/persons/:person",
     stripePath: "/v1/accounts/{account}/persons/{person}",
     resource: "persons",
     operation: "update",
@@ -342,7 +342,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/accounts/:account/persons/:person",
+    fastifyPath: "/v1/accounts/:account/persons/:person",
     stripePath: "/v1/accounts/{account}/persons/{person}",
     resource: "persons",
     operation: "delete",
@@ -353,7 +353,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/accounts/:account/reject",
+    fastifyPath: "/v1/accounts/:account/reject",
     stripePath: "/v1/accounts/{account}/reject",
     resource: "accounts",
     operation: "create",
@@ -363,7 +363,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/apple_pay/domains",
+    fastifyPath: "/v1/apple_pay/domains",
     stripePath: "/v1/apple_pay/domains",
     resource: "apple_pay",
     operation: "list",
@@ -372,7 +372,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/apple_pay/domains",
+    fastifyPath: "/v1/apple_pay/domains",
     stripePath: "/v1/apple_pay/domains",
     resource: "apple_pay",
     operation: "create",
@@ -381,7 +381,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/apple_pay/domains/:domain",
+    fastifyPath: "/v1/apple_pay/domains/:domain",
     stripePath: "/v1/apple_pay/domains/{domain}",
     resource: "apple_pay",
     operation: "retrieve",
@@ -391,7 +391,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/apple_pay/domains/:domain",
+    fastifyPath: "/v1/apple_pay/domains/:domain",
     stripePath: "/v1/apple_pay/domains/{domain}",
     resource: "apple_pay",
     operation: "delete",
@@ -401,7 +401,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/application_fees",
+    fastifyPath: "/v1/application_fees",
     stripePath: "/v1/application_fees",
     resource: "application_fees",
     operation: "list",
@@ -411,7 +411,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/application_fees/:fee/refunds/:id",
+    fastifyPath: "/v1/application_fees/:fee/refunds/:id",
     stripePath: "/v1/application_fees/{fee}/refunds/{id}",
     resource: "refunds",
     operation: "retrieve",
@@ -422,7 +422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/application_fees/:fee/refunds/:id",
+    fastifyPath: "/v1/application_fees/:fee/refunds/:id",
     stripePath: "/v1/application_fees/{fee}/refunds/{id}",
     resource: "refunds",
     operation: "update",
@@ -433,7 +433,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/application_fees/:id",
+    fastifyPath: "/v1/application_fees/:id",
     stripePath: "/v1/application_fees/{id}",
     resource: "application_fees",
     operation: "retrieve",
@@ -444,7 +444,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/application_fees/:id/refund",
+    fastifyPath: "/v1/application_fees/:id/refund",
     stripePath: "/v1/application_fees/{id}/refund",
     resource: "application_fees",
     operation: "create",
@@ -455,7 +455,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/application_fees/:id/refunds",
+    fastifyPath: "/v1/application_fees/:id/refunds",
     stripePath: "/v1/application_fees/{id}/refunds",
     resource: "refunds",
     operation: "list",
@@ -466,7 +466,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/application_fees/:id/refunds",
+    fastifyPath: "/v1/application_fees/:id/refunds",
     stripePath: "/v1/application_fees/{id}/refunds",
     resource: "refunds",
     operation: "create",
@@ -477,7 +477,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/apps/secrets",
+    fastifyPath: "/v1/apps/secrets",
     stripePath: "/v1/apps/secrets",
     resource: "apps",
     operation: "list",
@@ -486,7 +486,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/apps/secrets",
+    fastifyPath: "/v1/apps/secrets",
     stripePath: "/v1/apps/secrets",
     resource: "apps",
     operation: "create",
@@ -495,7 +495,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/apps/secrets/delete",
+    fastifyPath: "/v1/apps/secrets/delete",
     stripePath: "/v1/apps/secrets/delete",
     resource: "apps",
     operation: "create",
@@ -504,7 +504,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/apps/secrets/find",
+    fastifyPath: "/v1/apps/secrets/find",
     stripePath: "/v1/apps/secrets/find",
     resource: "apps",
     operation: "list",
@@ -513,7 +513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance",
+    fastifyPath: "/v1/balance",
     stripePath: "/v1/balance",
     resource: "balance",
     operation: "retrieve",
@@ -523,7 +523,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance/history",
+    fastifyPath: "/v1/balance/history",
     stripePath: "/v1/balance/history",
     resource: "balance",
     operation: "retrieve",
@@ -533,7 +533,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance/history/:id",
+    fastifyPath: "/v1/balance/history/:id",
     stripePath: "/v1/balance/history/{id}",
     resource: "balance",
     operation: "retrieve",
@@ -544,7 +544,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance_settings",
+    fastifyPath: "/v1/balance_settings",
     stripePath: "/v1/balance_settings",
     resource: "balance_settings",
     operation: "list",
@@ -554,7 +554,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/balance_settings",
+    fastifyPath: "/v1/balance_settings",
     stripePath: "/v1/balance_settings",
     resource: "balance_settings",
     operation: "create",
@@ -564,7 +564,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance_transactions",
+    fastifyPath: "/v1/balance_transactions",
     stripePath: "/v1/balance_transactions",
     resource: "balance_transactions",
     operation: "list",
@@ -574,7 +574,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/balance_transactions/:id",
+    fastifyPath: "/v1/balance_transactions/:id",
     stripePath: "/v1/balance_transactions/{id}",
     resource: "balance_transactions",
     operation: "retrieve",
@@ -585,7 +585,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/alerts",
+    fastifyPath: "/v1/billing/alerts",
     stripePath: "/v1/billing/alerts",
     resource: "billing",
     operation: "list",
@@ -594,7 +594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/alerts",
+    fastifyPath: "/v1/billing/alerts",
     stripePath: "/v1/billing/alerts",
     resource: "billing",
     operation: "create",
@@ -603,7 +603,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/alerts/:id",
+    fastifyPath: "/v1/billing/alerts/:id",
     stripePath: "/v1/billing/alerts/{id}",
     resource: "billing",
     operation: "retrieve",
@@ -613,7 +613,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/alerts/:id/activate",
+    fastifyPath: "/v1/billing/alerts/:id/activate",
     stripePath: "/v1/billing/alerts/{id}/activate",
     resource: "billing",
     operation: "create",
@@ -623,7 +623,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/alerts/:id/archive",
+    fastifyPath: "/v1/billing/alerts/:id/archive",
     stripePath: "/v1/billing/alerts/{id}/archive",
     resource: "billing",
     operation: "create",
@@ -633,7 +633,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/alerts/:id/deactivate",
+    fastifyPath: "/v1/billing/alerts/:id/deactivate",
     stripePath: "/v1/billing/alerts/{id}/deactivate",
     resource: "billing",
     operation: "create",
@@ -643,7 +643,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/credit_balance_summary",
+    fastifyPath: "/v1/billing/credit_balance_summary",
     stripePath: "/v1/billing/credit_balance_summary",
     resource: "billing",
     operation: "list",
@@ -652,7 +652,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/credit_balance_transactions",
+    fastifyPath: "/v1/billing/credit_balance_transactions",
     stripePath: "/v1/billing/credit_balance_transactions",
     resource: "billing",
     operation: "list",
@@ -661,7 +661,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/credit_balance_transactions/:id",
+    fastifyPath: "/v1/billing/credit_balance_transactions/:id",
     stripePath: "/v1/billing/credit_balance_transactions/{id}",
     resource: "billing",
     operation: "retrieve",
@@ -671,7 +671,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/credit_grants",
+    fastifyPath: "/v1/billing/credit_grants",
     stripePath: "/v1/billing/credit_grants",
     resource: "billing",
     operation: "list",
@@ -680,7 +680,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/credit_grants",
+    fastifyPath: "/v1/billing/credit_grants",
     stripePath: "/v1/billing/credit_grants",
     resource: "billing",
     operation: "create",
@@ -689,7 +689,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/credit_grants/:id",
+    fastifyPath: "/v1/billing/credit_grants/:id",
     stripePath: "/v1/billing/credit_grants/{id}",
     resource: "billing",
     operation: "retrieve",
@@ -699,7 +699,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/credit_grants/:id",
+    fastifyPath: "/v1/billing/credit_grants/:id",
     stripePath: "/v1/billing/credit_grants/{id}",
     resource: "billing",
     operation: "update",
@@ -709,7 +709,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/credit_grants/:id/expire",
+    fastifyPath: "/v1/billing/credit_grants/:id/expire",
     stripePath: "/v1/billing/credit_grants/{id}/expire",
     resource: "billing",
     operation: "create",
@@ -719,7 +719,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/credit_grants/:id/void",
+    fastifyPath: "/v1/billing/credit_grants/:id/void",
     stripePath: "/v1/billing/credit_grants/{id}/void",
     resource: "billing",
     operation: "create",
@@ -729,7 +729,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meter_event_adjustments",
+    fastifyPath: "/v1/billing/meter_event_adjustments",
     stripePath: "/v1/billing/meter_event_adjustments",
     resource: "billing",
     operation: "create",
@@ -738,7 +738,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meter_events",
+    fastifyPath: "/v1/billing/meter_events",
     stripePath: "/v1/billing/meter_events",
     resource: "billing",
     operation: "create",
@@ -747,7 +747,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/meters",
+    fastifyPath: "/v1/billing/meters",
     stripePath: "/v1/billing/meters",
     resource: "billing",
     operation: "list",
@@ -756,7 +756,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meters",
+    fastifyPath: "/v1/billing/meters",
     stripePath: "/v1/billing/meters",
     resource: "billing",
     operation: "create",
@@ -765,7 +765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/meters/:id",
+    fastifyPath: "/v1/billing/meters/:id",
     stripePath: "/v1/billing/meters/{id}",
     resource: "billing",
     operation: "retrieve",
@@ -775,7 +775,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meters/:id",
+    fastifyPath: "/v1/billing/meters/:id",
     stripePath: "/v1/billing/meters/{id}",
     resource: "billing",
     operation: "update",
@@ -785,7 +785,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meters/:id/deactivate",
+    fastifyPath: "/v1/billing/meters/:id/deactivate",
     stripePath: "/v1/billing/meters/{id}/deactivate",
     resource: "billing",
     operation: "create",
@@ -795,7 +795,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing/meters/:id/event_summaries",
+    fastifyPath: "/v1/billing/meters/:id/event_summaries",
     stripePath: "/v1/billing/meters/{id}/event_summaries",
     resource: "billing",
     operation: "list",
@@ -805,7 +805,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing/meters/:id/reactivate",
+    fastifyPath: "/v1/billing/meters/:id/reactivate",
     stripePath: "/v1/billing/meters/{id}/reactivate",
     resource: "billing",
     operation: "create",
@@ -815,7 +815,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing_portal/configurations",
+    fastifyPath: "/v1/billing_portal/configurations",
     stripePath: "/v1/billing_portal/configurations",
     resource: "billing_portal",
     operation: "list",
@@ -824,7 +824,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing_portal/configurations",
+    fastifyPath: "/v1/billing_portal/configurations",
     stripePath: "/v1/billing_portal/configurations",
     resource: "billing_portal",
     operation: "create",
@@ -833,7 +833,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/billing_portal/configurations/:configuration",
+    fastifyPath: "/v1/billing_portal/configurations/:configuration",
     stripePath: "/v1/billing_portal/configurations/{configuration}",
     resource: "billing_portal",
     operation: "retrieve",
@@ -843,7 +843,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing_portal/configurations/:configuration",
+    fastifyPath: "/v1/billing_portal/configurations/:configuration",
     stripePath: "/v1/billing_portal/configurations/{configuration}",
     resource: "billing_portal",
     operation: "update",
@@ -853,7 +853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/billing_portal/sessions",
+    fastifyPath: "/v1/billing_portal/sessions",
     stripePath: "/v1/billing_portal/sessions",
     resource: "billing_portal",
     operation: "create",
@@ -862,7 +862,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges",
+    fastifyPath: "/v1/charges",
     stripePath: "/v1/charges",
     resource: "charges",
     operation: "list",
@@ -872,7 +872,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges",
+    fastifyPath: "/v1/charges",
     stripePath: "/v1/charges",
     resource: "charges",
     operation: "create",
@@ -882,7 +882,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges/search",
+    fastifyPath: "/v1/charges/search",
     stripePath: "/v1/charges/search",
     resource: "charges",
     operation: "list",
@@ -892,7 +892,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges/:charge",
+    fastifyPath: "/v1/charges/:charge",
     stripePath: "/v1/charges/{charge}",
     resource: "charges",
     operation: "retrieve",
@@ -903,7 +903,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge",
+    fastifyPath: "/v1/charges/:charge",
     stripePath: "/v1/charges/{charge}",
     resource: "charges",
     operation: "update",
@@ -914,7 +914,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/capture",
+    fastifyPath: "/v1/charges/:charge/capture",
     stripePath: "/v1/charges/{charge}/capture",
     resource: "charges",
     operation: "create",
@@ -925,7 +925,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges/:charge/dispute",
+    fastifyPath: "/v1/charges/:charge/dispute",
     stripePath: "/v1/charges/{charge}/dispute",
     resource: "charges",
     operation: "list",
@@ -936,7 +936,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/dispute",
+    fastifyPath: "/v1/charges/:charge/dispute",
     stripePath: "/v1/charges/{charge}/dispute",
     resource: "charges",
     operation: "create",
@@ -947,7 +947,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/dispute/close",
+    fastifyPath: "/v1/charges/:charge/dispute/close",
     stripePath: "/v1/charges/{charge}/dispute/close",
     resource: "charges",
     operation: "action",
@@ -958,7 +958,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/refund",
+    fastifyPath: "/v1/charges/:charge/refund",
     stripePath: "/v1/charges/{charge}/refund",
     resource: "charges",
     operation: "create",
@@ -969,7 +969,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges/:charge/refunds",
+    fastifyPath: "/v1/charges/:charge/refunds",
     stripePath: "/v1/charges/{charge}/refunds",
     resource: "refunds",
     operation: "list",
@@ -980,7 +980,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/refunds",
+    fastifyPath: "/v1/charges/:charge/refunds",
     stripePath: "/v1/charges/{charge}/refunds",
     resource: "refunds",
     operation: "create",
@@ -991,7 +991,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/charges/:charge/refunds/:refund",
+    fastifyPath: "/v1/charges/:charge/refunds/:refund",
     stripePath: "/v1/charges/{charge}/refunds/{refund}",
     resource: "refunds",
     operation: "retrieve",
@@ -1002,7 +1002,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/charges/:charge/refunds/:refund",
+    fastifyPath: "/v1/charges/:charge/refunds/:refund",
     stripePath: "/v1/charges/{charge}/refunds/{refund}",
     resource: "refunds",
     operation: "update",
@@ -1013,7 +1013,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/checkout/sessions",
+    fastifyPath: "/v1/checkout/sessions",
     stripePath: "/v1/checkout/sessions",
     resource: "checkout",
     operation: "list",
@@ -1022,7 +1022,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/checkout/sessions",
+    fastifyPath: "/v1/checkout/sessions",
     stripePath: "/v1/checkout/sessions",
     resource: "checkout",
     operation: "create",
@@ -1031,7 +1031,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/checkout/sessions/:session",
+    fastifyPath: "/v1/checkout/sessions/:session",
     stripePath: "/v1/checkout/sessions/{session}",
     resource: "checkout",
     operation: "retrieve",
@@ -1041,7 +1041,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/checkout/sessions/:session",
+    fastifyPath: "/v1/checkout/sessions/:session",
     stripePath: "/v1/checkout/sessions/{session}",
     resource: "checkout",
     operation: "update",
@@ -1051,7 +1051,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/checkout/sessions/:session/expire",
+    fastifyPath: "/v1/checkout/sessions/:session/expire",
     stripePath: "/v1/checkout/sessions/{session}/expire",
     resource: "checkout",
     operation: "create",
@@ -1061,7 +1061,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/checkout/sessions/:session/line_items",
+    fastifyPath: "/v1/checkout/sessions/:session/line_items",
     stripePath: "/v1/checkout/sessions/{session}/line_items",
     resource: "line_items",
     operation: "list",
@@ -1072,7 +1072,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/orders",
+    fastifyPath: "/v1/climate/orders",
     stripePath: "/v1/climate/orders",
     resource: "climate",
     operation: "list",
@@ -1081,7 +1081,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/climate/orders",
+    fastifyPath: "/v1/climate/orders",
     stripePath: "/v1/climate/orders",
     resource: "climate",
     operation: "create",
@@ -1090,7 +1090,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/orders/:order",
+    fastifyPath: "/v1/climate/orders/:order",
     stripePath: "/v1/climate/orders/{order}",
     resource: "climate",
     operation: "retrieve",
@@ -1100,7 +1100,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/climate/orders/:order",
+    fastifyPath: "/v1/climate/orders/:order",
     stripePath: "/v1/climate/orders/{order}",
     resource: "climate",
     operation: "update",
@@ -1110,7 +1110,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/climate/orders/:order/cancel",
+    fastifyPath: "/v1/climate/orders/:order/cancel",
     stripePath: "/v1/climate/orders/{order}/cancel",
     resource: "climate",
     operation: "create",
@@ -1120,7 +1120,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/products",
+    fastifyPath: "/v1/climate/products",
     stripePath: "/v1/climate/products",
     resource: "products",
     operation: "list",
@@ -1130,7 +1130,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/products/:product",
+    fastifyPath: "/v1/climate/products/:product",
     stripePath: "/v1/climate/products/{product}",
     resource: "products",
     operation: "retrieve",
@@ -1141,7 +1141,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/suppliers",
+    fastifyPath: "/v1/climate/suppliers",
     stripePath: "/v1/climate/suppliers",
     resource: "climate",
     operation: "list",
@@ -1150,7 +1150,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/climate/suppliers/:supplier",
+    fastifyPath: "/v1/climate/suppliers/:supplier",
     stripePath: "/v1/climate/suppliers/{supplier}",
     resource: "climate",
     operation: "retrieve",
@@ -1160,7 +1160,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/confirmation_tokens/:confirmation_token",
+    fastifyPath: "/v1/confirmation_tokens/:confirmation_token",
     stripePath: "/v1/confirmation_tokens/{confirmation_token}",
     resource: "confirmation_tokens",
     operation: "retrieve",
@@ -1171,7 +1171,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/country_specs",
+    fastifyPath: "/v1/country_specs",
     stripePath: "/v1/country_specs",
     resource: "country_specs",
     operation: "list",
@@ -1181,7 +1181,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/country_specs/:country",
+    fastifyPath: "/v1/country_specs/:country",
     stripePath: "/v1/country_specs/{country}",
     resource: "country_specs",
     operation: "retrieve",
@@ -1192,7 +1192,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/coupons",
+    fastifyPath: "/v1/coupons",
     stripePath: "/v1/coupons",
     resource: "coupons",
     operation: "list",
@@ -1202,7 +1202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/coupons",
+    fastifyPath: "/v1/coupons",
     stripePath: "/v1/coupons",
     resource: "coupons",
     operation: "create",
@@ -1212,7 +1212,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/coupons/:coupon",
+    fastifyPath: "/v1/coupons/:coupon",
     stripePath: "/v1/coupons/{coupon}",
     resource: "coupons",
     operation: "retrieve",
@@ -1223,7 +1223,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/coupons/:coupon",
+    fastifyPath: "/v1/coupons/:coupon",
     stripePath: "/v1/coupons/{coupon}",
     resource: "coupons",
     operation: "update",
@@ -1234,7 +1234,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/coupons/:coupon",
+    fastifyPath: "/v1/coupons/:coupon",
     stripePath: "/v1/coupons/{coupon}",
     resource: "coupons",
     operation: "delete",
@@ -1245,7 +1245,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/credit_notes",
+    fastifyPath: "/v1/credit_notes",
     stripePath: "/v1/credit_notes",
     resource: "credit_notes",
     operation: "list",
@@ -1255,7 +1255,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/credit_notes",
+    fastifyPath: "/v1/credit_notes",
     stripePath: "/v1/credit_notes",
     resource: "credit_notes",
     operation: "create",
@@ -1265,7 +1265,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/credit_notes/preview",
+    fastifyPath: "/v1/credit_notes/preview",
     stripePath: "/v1/credit_notes/preview",
     resource: "credit_notes",
     operation: "list",
@@ -1275,7 +1275,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/credit_notes/preview/lines",
+    fastifyPath: "/v1/credit_notes/preview/lines",
     stripePath: "/v1/credit_notes/preview/lines",
     resource: "credit_notes",
     operation: "list",
@@ -1285,7 +1285,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/credit_notes/:credit_note/lines",
+    fastifyPath: "/v1/credit_notes/:credit_note/lines",
     stripePath: "/v1/credit_notes/{credit_note}/lines",
     resource: "credit_notes",
     operation: "list",
@@ -1296,7 +1296,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/credit_notes/:id",
+    fastifyPath: "/v1/credit_notes/:id",
     stripePath: "/v1/credit_notes/{id}",
     resource: "credit_notes",
     operation: "retrieve",
@@ -1307,7 +1307,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/credit_notes/:id",
+    fastifyPath: "/v1/credit_notes/:id",
     stripePath: "/v1/credit_notes/{id}",
     resource: "credit_notes",
     operation: "update",
@@ -1318,7 +1318,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/credit_notes/:id/void",
+    fastifyPath: "/v1/credit_notes/:id/void",
     stripePath: "/v1/credit_notes/{id}/void",
     resource: "credit_notes",
     operation: "create",
@@ -1329,7 +1329,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customer_sessions",
+    fastifyPath: "/v1/customer_sessions",
     stripePath: "/v1/customer_sessions",
     resource: "customer_sessions",
     operation: "create",
@@ -1339,7 +1339,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers",
+    fastifyPath: "/v1/customers",
     stripePath: "/v1/customers",
     resource: "customers",
     operation: "list",
@@ -1349,7 +1349,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers",
+    fastifyPath: "/v1/customers",
     stripePath: "/v1/customers",
     resource: "customers",
     operation: "create",
@@ -1359,7 +1359,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/search",
+    fastifyPath: "/v1/customers/search",
     stripePath: "/v1/customers/search",
     resource: "customers",
     operation: "list",
@@ -1369,7 +1369,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer",
+    fastifyPath: "/v1/customers/:customer",
     stripePath: "/v1/customers/{customer}",
     resource: "customers",
     operation: "retrieve",
@@ -1380,7 +1380,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer",
+    fastifyPath: "/v1/customers/:customer",
     stripePath: "/v1/customers/{customer}",
     resource: "customers",
     operation: "update",
@@ -1391,7 +1391,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer",
+    fastifyPath: "/v1/customers/:customer",
     stripePath: "/v1/customers/{customer}",
     resource: "customers",
     operation: "delete",
@@ -1402,7 +1402,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/balance_transactions",
+    fastifyPath: "/v1/customers/:customer/balance_transactions",
     stripePath: "/v1/customers/{customer}/balance_transactions",
     resource: "balance_transactions",
     operation: "list",
@@ -1413,7 +1413,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/balance_transactions",
+    fastifyPath: "/v1/customers/:customer/balance_transactions",
     stripePath: "/v1/customers/{customer}/balance_transactions",
     resource: "balance_transactions",
     operation: "create",
@@ -1424,7 +1424,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/balance_transactions/:transaction",
+    fastifyPath: "/v1/customers/:customer/balance_transactions/:transaction",
     stripePath: "/v1/customers/{customer}/balance_transactions/{transaction}",
     resource: "balance_transactions",
     operation: "retrieve",
@@ -1435,7 +1435,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/balance_transactions/:transaction",
+    fastifyPath: "/v1/customers/:customer/balance_transactions/:transaction",
     stripePath: "/v1/customers/{customer}/balance_transactions/{transaction}",
     resource: "balance_transactions",
     operation: "update",
@@ -1446,7 +1446,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts",
+    fastifyPath: "/v1/customers/:customer/bank_accounts",
     stripePath: "/v1/customers/{customer}/bank_accounts",
     resource: "bank_accounts",
     operation: "list",
@@ -1457,7 +1457,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts",
+    fastifyPath: "/v1/customers/:customer/bank_accounts",
     stripePath: "/v1/customers/{customer}/bank_accounts",
     resource: "bank_accounts",
     operation: "create",
@@ -1468,7 +1468,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts/:id",
+    fastifyPath: "/v1/customers/:customer/bank_accounts/:id",
     stripePath: "/v1/customers/{customer}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "retrieve",
@@ -1479,7 +1479,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts/:id",
+    fastifyPath: "/v1/customers/:customer/bank_accounts/:id",
     stripePath: "/v1/customers/{customer}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "update",
@@ -1490,7 +1490,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts/:id",
+    fastifyPath: "/v1/customers/:customer/bank_accounts/:id",
     stripePath: "/v1/customers/{customer}/bank_accounts/{id}",
     resource: "bank_accounts",
     operation: "delete",
@@ -1501,7 +1501,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/bank_accounts/:id/verify",
+    fastifyPath: "/v1/customers/:customer/bank_accounts/:id/verify",
     stripePath: "/v1/customers/{customer}/bank_accounts/{id}/verify",
     resource: "bank_accounts",
     operation: "create",
@@ -1512,7 +1512,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/cards",
+    fastifyPath: "/v1/customers/:customer/cards",
     stripePath: "/v1/customers/{customer}/cards",
     resource: "cards",
     operation: "list",
@@ -1523,7 +1523,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/cards",
+    fastifyPath: "/v1/customers/:customer/cards",
     stripePath: "/v1/customers/{customer}/cards",
     resource: "cards",
     operation: "create",
@@ -1534,7 +1534,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/cards/:id",
+    fastifyPath: "/v1/customers/:customer/cards/:id",
     stripePath: "/v1/customers/{customer}/cards/{id}",
     resource: "cards",
     operation: "retrieve",
@@ -1545,7 +1545,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/cards/:id",
+    fastifyPath: "/v1/customers/:customer/cards/:id",
     stripePath: "/v1/customers/{customer}/cards/{id}",
     resource: "cards",
     operation: "update",
@@ -1556,7 +1556,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/cards/:id",
+    fastifyPath: "/v1/customers/:customer/cards/:id",
     stripePath: "/v1/customers/{customer}/cards/{id}",
     resource: "cards",
     operation: "delete",
@@ -1567,7 +1567,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/cash_balance",
+    fastifyPath: "/v1/customers/:customer/cash_balance",
     stripePath: "/v1/customers/{customer}/cash_balance",
     resource: "customers",
     operation: "list",
@@ -1578,7 +1578,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/cash_balance",
+    fastifyPath: "/v1/customers/:customer/cash_balance",
     stripePath: "/v1/customers/{customer}/cash_balance",
     resource: "customers",
     operation: "create",
@@ -1589,7 +1589,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/cash_balance_transactions",
+    fastifyPath: "/v1/customers/:customer/cash_balance_transactions",
     stripePath: "/v1/customers/{customer}/cash_balance_transactions",
     resource: "customers",
     operation: "list",
@@ -1600,7 +1600,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/cash_balance_transactions/:transaction",
+    fastifyPath: "/v1/customers/:customer/cash_balance_transactions/:transaction",
     stripePath: "/v1/customers/{customer}/cash_balance_transactions/{transaction}",
     resource: "customers",
     operation: "retrieve",
@@ -1611,7 +1611,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/discount",
+    fastifyPath: "/v1/customers/:customer/discount",
     stripePath: "/v1/customers/{customer}/discount",
     resource: "customers",
     operation: "list",
@@ -1622,7 +1622,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/discount",
+    fastifyPath: "/v1/customers/:customer/discount",
     stripePath: "/v1/customers/{customer}/discount",
     resource: "customers",
     operation: "delete",
@@ -1633,7 +1633,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/funding_instructions",
+    fastifyPath: "/v1/customers/:customer/funding_instructions",
     stripePath: "/v1/customers/{customer}/funding_instructions",
     resource: "customers",
     operation: "create",
@@ -1644,7 +1644,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/payment_methods",
+    fastifyPath: "/v1/customers/:customer/payment_methods",
     stripePath: "/v1/customers/{customer}/payment_methods",
     resource: "payment_methods",
     operation: "list",
@@ -1655,7 +1655,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/payment_methods/:payment_method",
+    fastifyPath: "/v1/customers/:customer/payment_methods/:payment_method",
     stripePath: "/v1/customers/{customer}/payment_methods/{payment_method}",
     resource: "payment_methods",
     operation: "retrieve",
@@ -1666,7 +1666,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/sources",
+    fastifyPath: "/v1/customers/:customer/sources",
     stripePath: "/v1/customers/{customer}/sources",
     resource: "sources",
     operation: "list",
@@ -1677,7 +1677,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/sources",
+    fastifyPath: "/v1/customers/:customer/sources",
     stripePath: "/v1/customers/{customer}/sources",
     resource: "sources",
     operation: "create",
@@ -1688,7 +1688,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/sources/:id",
+    fastifyPath: "/v1/customers/:customer/sources/:id",
     stripePath: "/v1/customers/{customer}/sources/{id}",
     resource: "sources",
     operation: "retrieve",
@@ -1699,7 +1699,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/sources/:id",
+    fastifyPath: "/v1/customers/:customer/sources/:id",
     stripePath: "/v1/customers/{customer}/sources/{id}",
     resource: "sources",
     operation: "update",
@@ -1710,7 +1710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/sources/:id",
+    fastifyPath: "/v1/customers/:customer/sources/:id",
     stripePath: "/v1/customers/{customer}/sources/{id}",
     resource: "sources",
     operation: "delete",
@@ -1721,7 +1721,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/sources/:id/verify",
+    fastifyPath: "/v1/customers/:customer/sources/:id/verify",
     stripePath: "/v1/customers/{customer}/sources/{id}/verify",
     resource: "sources",
     operation: "create",
@@ -1732,7 +1732,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions",
+    fastifyPath: "/v1/customers/:customer/subscriptions",
     stripePath: "/v1/customers/{customer}/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -1743,7 +1743,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions",
+    fastifyPath: "/v1/customers/:customer/subscriptions",
     stripePath: "/v1/customers/{customer}/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -1754,7 +1754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/customers/:customer/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1765,7 +1765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/customers/:customer/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "update",
@@ -1776,7 +1776,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/customers/:customer/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "delete",
@@ -1787,7 +1787,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions/:subscription_exposed_id/discount",
+    fastifyPath: "/v1/customers/:customer/subscriptions/:subscription_exposed_id/discount",
     stripePath: "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}/discount",
     resource: "subscriptions",
     operation: "list",
@@ -1798,7 +1798,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/subscriptions/:subscription_exposed_id/discount",
+    fastifyPath: "/v1/customers/:customer/subscriptions/:subscription_exposed_id/discount",
     stripePath: "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}/discount",
     resource: "subscriptions",
     operation: "delete",
@@ -1809,7 +1809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/tax_ids",
+    fastifyPath: "/v1/customers/:customer/tax_ids",
     stripePath: "/v1/customers/{customer}/tax_ids",
     resource: "tax_ids",
     operation: "list",
@@ -1820,7 +1820,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/customers/:customer/tax_ids",
+    fastifyPath: "/v1/customers/:customer/tax_ids",
     stripePath: "/v1/customers/{customer}/tax_ids",
     resource: "tax_ids",
     operation: "create",
@@ -1831,7 +1831,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/customers/:customer/tax_ids/:id",
+    fastifyPath: "/v1/customers/:customer/tax_ids/:id",
     stripePath: "/v1/customers/{customer}/tax_ids/{id}",
     resource: "tax_ids",
     operation: "retrieve",
@@ -1842,7 +1842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/customers/:customer/tax_ids/:id",
+    fastifyPath: "/v1/customers/:customer/tax_ids/:id",
     stripePath: "/v1/customers/{customer}/tax_ids/{id}",
     resource: "tax_ids",
     operation: "delete",
@@ -1853,7 +1853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/disputes",
+    fastifyPath: "/v1/disputes",
     stripePath: "/v1/disputes",
     resource: "disputes",
     operation: "list",
@@ -1863,7 +1863,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/disputes/:dispute",
+    fastifyPath: "/v1/disputes/:dispute",
     stripePath: "/v1/disputes/{dispute}",
     resource: "disputes",
     operation: "retrieve",
@@ -1874,7 +1874,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/disputes/:dispute",
+    fastifyPath: "/v1/disputes/:dispute",
     stripePath: "/v1/disputes/{dispute}",
     resource: "disputes",
     operation: "update",
@@ -1885,7 +1885,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/disputes/:dispute/close",
+    fastifyPath: "/v1/disputes/:dispute/close",
     stripePath: "/v1/disputes/{dispute}/close",
     resource: "disputes",
     operation: "create",
@@ -1896,7 +1896,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/entitlements/active_entitlements",
+    fastifyPath: "/v1/entitlements/active_entitlements",
     stripePath: "/v1/entitlements/active_entitlements",
     resource: "entitlements",
     operation: "list",
@@ -1905,7 +1905,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/entitlements/active_entitlements/:id",
+    fastifyPath: "/v1/entitlements/active_entitlements/:id",
     stripePath: "/v1/entitlements/active_entitlements/{id}",
     resource: "entitlements",
     operation: "retrieve",
@@ -1915,7 +1915,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/entitlements/features",
+    fastifyPath: "/v1/entitlements/features",
     stripePath: "/v1/entitlements/features",
     resource: "entitlements",
     operation: "list",
@@ -1924,7 +1924,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/entitlements/features",
+    fastifyPath: "/v1/entitlements/features",
     stripePath: "/v1/entitlements/features",
     resource: "entitlements",
     operation: "create",
@@ -1933,7 +1933,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/entitlements/features/:id",
+    fastifyPath: "/v1/entitlements/features/:id",
     stripePath: "/v1/entitlements/features/{id}",
     resource: "entitlements",
     operation: "retrieve",
@@ -1943,7 +1943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/entitlements/features/:id",
+    fastifyPath: "/v1/entitlements/features/:id",
     stripePath: "/v1/entitlements/features/{id}",
     resource: "entitlements",
     operation: "update",
@@ -1953,7 +1953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/ephemeral_keys",
+    fastifyPath: "/v1/ephemeral_keys",
     stripePath: "/v1/ephemeral_keys",
     resource: "ephemeral_keys",
     operation: "create",
@@ -1963,7 +1963,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/ephemeral_keys/:key",
+    fastifyPath: "/v1/ephemeral_keys/:key",
     stripePath: "/v1/ephemeral_keys/{key}",
     resource: "ephemeral_keys",
     operation: "delete",
@@ -1974,7 +1974,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/events",
+    fastifyPath: "/v1/events",
     stripePath: "/v1/events",
     resource: "events",
     operation: "list",
@@ -1984,7 +1984,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/events/:id",
+    fastifyPath: "/v1/events/:id",
     stripePath: "/v1/events/{id}",
     resource: "events",
     operation: "retrieve",
@@ -1995,7 +1995,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/exchange_rates",
+    fastifyPath: "/v1/exchange_rates",
     stripePath: "/v1/exchange_rates",
     resource: "exchange_rates",
     operation: "list",
@@ -2005,7 +2005,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/exchange_rates/:rate_id",
+    fastifyPath: "/v1/exchange_rates/:rate_id",
     stripePath: "/v1/exchange_rates/{rate_id}",
     resource: "exchange_rates",
     operation: "retrieve",
@@ -2016,7 +2016,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/external_accounts/:id",
+    fastifyPath: "/v1/external_accounts/:id",
     stripePath: "/v1/external_accounts/{id}",
     resource: "external_accounts",
     operation: "update",
@@ -2027,7 +2027,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/file_links",
+    fastifyPath: "/v1/file_links",
     stripePath: "/v1/file_links",
     resource: "file_links",
     operation: "list",
@@ -2037,7 +2037,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/file_links",
+    fastifyPath: "/v1/file_links",
     stripePath: "/v1/file_links",
     resource: "file_links",
     operation: "create",
@@ -2047,7 +2047,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/file_links/:link",
+    fastifyPath: "/v1/file_links/:link",
     stripePath: "/v1/file_links/{link}",
     resource: "file_links",
     operation: "retrieve",
@@ -2058,7 +2058,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/file_links/:link",
+    fastifyPath: "/v1/file_links/:link",
     stripePath: "/v1/file_links/{link}",
     resource: "file_links",
     operation: "update",
@@ -2069,7 +2069,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/files",
+    fastifyPath: "/v1/files",
     stripePath: "/v1/files",
     resource: "files",
     operation: "list",
@@ -2079,7 +2079,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/files",
+    fastifyPath: "/v1/files",
     stripePath: "/v1/files",
     resource: "files",
     operation: "create",
@@ -2089,7 +2089,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/files/:file",
+    fastifyPath: "/v1/files/:file",
     stripePath: "/v1/files/{file}",
     resource: "files",
     operation: "retrieve",
@@ -2100,7 +2100,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/accounts",
+    fastifyPath: "/v1/financial_connections/accounts",
     stripePath: "/v1/financial_connections/accounts",
     resource: "financial_connections",
     operation: "list",
@@ -2109,7 +2109,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account",
+    fastifyPath: "/v1/financial_connections/accounts/:account",
     stripePath: "/v1/financial_connections/accounts/{account}",
     resource: "financial_connections",
     operation: "retrieve",
@@ -2119,7 +2119,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account/disconnect",
+    fastifyPath: "/v1/financial_connections/accounts/:account/disconnect",
     stripePath: "/v1/financial_connections/accounts/{account}/disconnect",
     resource: "financial_connections",
     operation: "create",
@@ -2129,7 +2129,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account/owners",
+    fastifyPath: "/v1/financial_connections/accounts/:account/owners",
     stripePath: "/v1/financial_connections/accounts/{account}/owners",
     resource: "financial_connections",
     operation: "list",
@@ -2139,7 +2139,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account/refresh",
+    fastifyPath: "/v1/financial_connections/accounts/:account/refresh",
     stripePath: "/v1/financial_connections/accounts/{account}/refresh",
     resource: "financial_connections",
     operation: "create",
@@ -2149,7 +2149,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account/subscribe",
+    fastifyPath: "/v1/financial_connections/accounts/:account/subscribe",
     stripePath: "/v1/financial_connections/accounts/{account}/subscribe",
     resource: "financial_connections",
     operation: "create",
@@ -2159,7 +2159,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/financial_connections/accounts/:account/unsubscribe",
+    fastifyPath: "/v1/financial_connections/accounts/:account/unsubscribe",
     stripePath: "/v1/financial_connections/accounts/{account}/unsubscribe",
     resource: "financial_connections",
     operation: "create",
@@ -2169,7 +2169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/financial_connections/sessions",
+    fastifyPath: "/v1/financial_connections/sessions",
     stripePath: "/v1/financial_connections/sessions",
     resource: "financial_connections",
     operation: "create",
@@ -2178,7 +2178,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/sessions/:session",
+    fastifyPath: "/v1/financial_connections/sessions/:session",
     stripePath: "/v1/financial_connections/sessions/{session}",
     resource: "financial_connections",
     operation: "retrieve",
@@ -2188,7 +2188,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/transactions",
+    fastifyPath: "/v1/financial_connections/transactions",
     stripePath: "/v1/financial_connections/transactions",
     resource: "financial_connections",
     operation: "list",
@@ -2197,7 +2197,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/financial_connections/transactions/:transaction",
+    fastifyPath: "/v1/financial_connections/transactions/:transaction",
     stripePath: "/v1/financial_connections/transactions/{transaction}",
     resource: "financial_connections",
     operation: "retrieve",
@@ -2207,7 +2207,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/forwarding/requests",
+    fastifyPath: "/v1/forwarding/requests",
     stripePath: "/v1/forwarding/requests",
     resource: "forwarding",
     operation: "list",
@@ -2216,7 +2216,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/forwarding/requests",
+    fastifyPath: "/v1/forwarding/requests",
     stripePath: "/v1/forwarding/requests",
     resource: "forwarding",
     operation: "create",
@@ -2225,7 +2225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/forwarding/requests/:id",
+    fastifyPath: "/v1/forwarding/requests/:id",
     stripePath: "/v1/forwarding/requests/{id}",
     resource: "forwarding",
     operation: "retrieve",
@@ -2235,7 +2235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/identity/verification_reports",
+    fastifyPath: "/v1/identity/verification_reports",
     stripePath: "/v1/identity/verification_reports",
     resource: "identity",
     operation: "list",
@@ -2244,7 +2244,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/identity/verification_reports/:report",
+    fastifyPath: "/v1/identity/verification_reports/:report",
     stripePath: "/v1/identity/verification_reports/{report}",
     resource: "identity",
     operation: "retrieve",
@@ -2254,7 +2254,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/identity/verification_sessions",
+    fastifyPath: "/v1/identity/verification_sessions",
     stripePath: "/v1/identity/verification_sessions",
     resource: "identity",
     operation: "list",
@@ -2263,7 +2263,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/identity/verification_sessions",
+    fastifyPath: "/v1/identity/verification_sessions",
     stripePath: "/v1/identity/verification_sessions",
     resource: "identity",
     operation: "create",
@@ -2272,7 +2272,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/identity/verification_sessions/:session",
+    fastifyPath: "/v1/identity/verification_sessions/:session",
     stripePath: "/v1/identity/verification_sessions/{session}",
     resource: "identity",
     operation: "retrieve",
@@ -2282,7 +2282,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/identity/verification_sessions/:session",
+    fastifyPath: "/v1/identity/verification_sessions/:session",
     stripePath: "/v1/identity/verification_sessions/{session}",
     resource: "identity",
     operation: "update",
@@ -2292,7 +2292,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/identity/verification_sessions/:session/cancel",
+    fastifyPath: "/v1/identity/verification_sessions/:session/cancel",
     stripePath: "/v1/identity/verification_sessions/{session}/cancel",
     resource: "identity",
     operation: "create",
@@ -2302,7 +2302,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/identity/verification_sessions/:session/redact",
+    fastifyPath: "/v1/identity/verification_sessions/:session/redact",
     stripePath: "/v1/identity/verification_sessions/{session}/redact",
     resource: "identity",
     operation: "create",
@@ -2312,7 +2312,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoice_payments",
+    fastifyPath: "/v1/invoice_payments",
     stripePath: "/v1/invoice_payments",
     resource: "invoice_payments",
     operation: "list",
@@ -2322,7 +2322,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoice_payments/:invoice_payment",
+    fastifyPath: "/v1/invoice_payments/:invoice_payment",
     stripePath: "/v1/invoice_payments/{invoice_payment}",
     resource: "invoice_payments",
     operation: "retrieve",
@@ -2333,7 +2333,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoice_rendering_templates",
+    fastifyPath: "/v1/invoice_rendering_templates",
     stripePath: "/v1/invoice_rendering_templates",
     resource: "invoice_rendering_templates",
     operation: "list",
@@ -2343,7 +2343,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoice_rendering_templates/:template",
+    fastifyPath: "/v1/invoice_rendering_templates/:template",
     stripePath: "/v1/invoice_rendering_templates/{template}",
     resource: "invoice_rendering_templates",
     operation: "retrieve",
@@ -2354,7 +2354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoice_rendering_templates/:template/archive",
+    fastifyPath: "/v1/invoice_rendering_templates/:template/archive",
     stripePath: "/v1/invoice_rendering_templates/{template}/archive",
     resource: "invoice_rendering_templates",
     operation: "create",
@@ -2365,7 +2365,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoice_rendering_templates/:template/unarchive",
+    fastifyPath: "/v1/invoice_rendering_templates/:template/unarchive",
     stripePath: "/v1/invoice_rendering_templates/{template}/unarchive",
     resource: "invoice_rendering_templates",
     operation: "create",
@@ -2376,7 +2376,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoiceitems",
+    fastifyPath: "/v1/invoiceitems",
     stripePath: "/v1/invoiceitems",
     resource: "invoiceitems",
     operation: "list",
@@ -2386,7 +2386,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoiceitems",
+    fastifyPath: "/v1/invoiceitems",
     stripePath: "/v1/invoiceitems",
     resource: "invoiceitems",
     operation: "create",
@@ -2396,7 +2396,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoiceitems/:invoiceitem",
+    fastifyPath: "/v1/invoiceitems/:invoiceitem",
     stripePath: "/v1/invoiceitems/{invoiceitem}",
     resource: "invoiceitems",
     operation: "retrieve",
@@ -2407,7 +2407,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoiceitems/:invoiceitem",
+    fastifyPath: "/v1/invoiceitems/:invoiceitem",
     stripePath: "/v1/invoiceitems/{invoiceitem}",
     resource: "invoiceitems",
     operation: "update",
@@ -2418,7 +2418,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/invoiceitems/:invoiceitem",
+    fastifyPath: "/v1/invoiceitems/:invoiceitem",
     stripePath: "/v1/invoiceitems/{invoiceitem}",
     resource: "invoiceitems",
     operation: "delete",
@@ -2429,7 +2429,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoices",
+    fastifyPath: "/v1/invoices",
     stripePath: "/v1/invoices",
     resource: "invoices",
     operation: "list",
@@ -2439,7 +2439,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices",
+    fastifyPath: "/v1/invoices",
     stripePath: "/v1/invoices",
     resource: "invoices",
     operation: "create",
@@ -2449,7 +2449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/create_preview",
+    fastifyPath: "/v1/invoices/create_preview",
     stripePath: "/v1/invoices/create_preview",
     resource: "invoices",
     operation: "create",
@@ -2459,7 +2459,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoices/search",
+    fastifyPath: "/v1/invoices/search",
     stripePath: "/v1/invoices/search",
     resource: "invoices",
     operation: "list",
@@ -2469,7 +2469,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoices/:invoice",
+    fastifyPath: "/v1/invoices/:invoice",
     stripePath: "/v1/invoices/{invoice}",
     resource: "invoices",
     operation: "retrieve",
@@ -2480,7 +2480,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice",
+    fastifyPath: "/v1/invoices/:invoice",
     stripePath: "/v1/invoices/{invoice}",
     resource: "invoices",
     operation: "update",
@@ -2491,7 +2491,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/invoices/:invoice",
+    fastifyPath: "/v1/invoices/:invoice",
     stripePath: "/v1/invoices/{invoice}",
     resource: "invoices",
     operation: "delete",
@@ -2502,7 +2502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/add_lines",
+    fastifyPath: "/v1/invoices/:invoice/add_lines",
     stripePath: "/v1/invoices/{invoice}/add_lines",
     resource: "invoices",
     operation: "create",
@@ -2513,7 +2513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/attach_payment",
+    fastifyPath: "/v1/invoices/:invoice/attach_payment",
     stripePath: "/v1/invoices/{invoice}/attach_payment",
     resource: "invoices",
     operation: "create",
@@ -2524,7 +2524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/finalize",
+    fastifyPath: "/v1/invoices/:invoice/finalize",
     stripePath: "/v1/invoices/{invoice}/finalize",
     resource: "invoices",
     operation: "create",
@@ -2535,7 +2535,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/invoices/:invoice/lines",
+    fastifyPath: "/v1/invoices/:invoice/lines",
     stripePath: "/v1/invoices/{invoice}/lines",
     resource: "invoices",
     operation: "list",
@@ -2546,7 +2546,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/lines/:line_item_id",
+    fastifyPath: "/v1/invoices/:invoice/lines/:line_item_id",
     stripePath: "/v1/invoices/{invoice}/lines/{line_item_id}",
     resource: "invoices",
     operation: "update",
@@ -2557,7 +2557,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/mark_uncollectible",
+    fastifyPath: "/v1/invoices/:invoice/mark_uncollectible",
     stripePath: "/v1/invoices/{invoice}/mark_uncollectible",
     resource: "invoices",
     operation: "create",
@@ -2568,7 +2568,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/pay",
+    fastifyPath: "/v1/invoices/:invoice/pay",
     stripePath: "/v1/invoices/{invoice}/pay",
     resource: "invoices",
     operation: "create",
@@ -2579,7 +2579,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/remove_lines",
+    fastifyPath: "/v1/invoices/:invoice/remove_lines",
     stripePath: "/v1/invoices/{invoice}/remove_lines",
     resource: "invoices",
     operation: "create",
@@ -2590,7 +2590,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/send",
+    fastifyPath: "/v1/invoices/:invoice/send",
     stripePath: "/v1/invoices/{invoice}/send",
     resource: "invoices",
     operation: "create",
@@ -2601,7 +2601,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/update_lines",
+    fastifyPath: "/v1/invoices/:invoice/update_lines",
     stripePath: "/v1/invoices/{invoice}/update_lines",
     resource: "invoices",
     operation: "create",
@@ -2612,7 +2612,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/invoices/:invoice/void",
+    fastifyPath: "/v1/invoices/:invoice/void",
     stripePath: "/v1/invoices/{invoice}/void",
     resource: "invoices",
     operation: "create",
@@ -2623,7 +2623,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/authorizations",
+    fastifyPath: "/v1/issuing/authorizations",
     stripePath: "/v1/issuing/authorizations",
     resource: "issuing",
     operation: "list",
@@ -2632,7 +2632,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/authorizations/:authorization",
+    fastifyPath: "/v1/issuing/authorizations/:authorization",
     stripePath: "/v1/issuing/authorizations/{authorization}",
     resource: "issuing",
     operation: "retrieve",
@@ -2642,7 +2642,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/authorizations/:authorization",
+    fastifyPath: "/v1/issuing/authorizations/:authorization",
     stripePath: "/v1/issuing/authorizations/{authorization}",
     resource: "issuing",
     operation: "update",
@@ -2652,7 +2652,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/authorizations/:authorization/approve",
+    fastifyPath: "/v1/issuing/authorizations/:authorization/approve",
     stripePath: "/v1/issuing/authorizations/{authorization}/approve",
     resource: "issuing",
     operation: "create",
@@ -2662,7 +2662,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/authorizations/:authorization/decline",
+    fastifyPath: "/v1/issuing/authorizations/:authorization/decline",
     stripePath: "/v1/issuing/authorizations/{authorization}/decline",
     resource: "issuing",
     operation: "create",
@@ -2672,7 +2672,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/cardholders",
+    fastifyPath: "/v1/issuing/cardholders",
     stripePath: "/v1/issuing/cardholders",
     resource: "issuing",
     operation: "list",
@@ -2681,7 +2681,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/cardholders",
+    fastifyPath: "/v1/issuing/cardholders",
     stripePath: "/v1/issuing/cardholders",
     resource: "issuing",
     operation: "create",
@@ -2690,7 +2690,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/cardholders/:cardholder",
+    fastifyPath: "/v1/issuing/cardholders/:cardholder",
     stripePath: "/v1/issuing/cardholders/{cardholder}",
     resource: "issuing",
     operation: "retrieve",
@@ -2700,7 +2700,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/cardholders/:cardholder",
+    fastifyPath: "/v1/issuing/cardholders/:cardholder",
     stripePath: "/v1/issuing/cardholders/{cardholder}",
     resource: "issuing",
     operation: "update",
@@ -2710,7 +2710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/cards",
+    fastifyPath: "/v1/issuing/cards",
     stripePath: "/v1/issuing/cards",
     resource: "cards",
     operation: "list",
@@ -2720,7 +2720,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/cards",
+    fastifyPath: "/v1/issuing/cards",
     stripePath: "/v1/issuing/cards",
     resource: "cards",
     operation: "create",
@@ -2730,7 +2730,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/cards/:card",
+    fastifyPath: "/v1/issuing/cards/:card",
     stripePath: "/v1/issuing/cards/{card}",
     resource: "cards",
     operation: "retrieve",
@@ -2741,7 +2741,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/cards/:card",
+    fastifyPath: "/v1/issuing/cards/:card",
     stripePath: "/v1/issuing/cards/{card}",
     resource: "cards",
     operation: "update",
@@ -2752,7 +2752,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/disputes",
+    fastifyPath: "/v1/issuing/disputes",
     stripePath: "/v1/issuing/disputes",
     resource: "disputes",
     operation: "list",
@@ -2762,7 +2762,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/disputes",
+    fastifyPath: "/v1/issuing/disputes",
     stripePath: "/v1/issuing/disputes",
     resource: "disputes",
     operation: "create",
@@ -2772,7 +2772,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/disputes/:dispute",
+    fastifyPath: "/v1/issuing/disputes/:dispute",
     stripePath: "/v1/issuing/disputes/{dispute}",
     resource: "disputes",
     operation: "retrieve",
@@ -2783,7 +2783,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/disputes/:dispute",
+    fastifyPath: "/v1/issuing/disputes/:dispute",
     stripePath: "/v1/issuing/disputes/{dispute}",
     resource: "disputes",
     operation: "update",
@@ -2794,7 +2794,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/disputes/:dispute/submit",
+    fastifyPath: "/v1/issuing/disputes/:dispute/submit",
     stripePath: "/v1/issuing/disputes/{dispute}/submit",
     resource: "disputes",
     operation: "create",
@@ -2805,7 +2805,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/personalization_designs",
+    fastifyPath: "/v1/issuing/personalization_designs",
     stripePath: "/v1/issuing/personalization_designs",
     resource: "issuing",
     operation: "list",
@@ -2814,7 +2814,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/personalization_designs",
+    fastifyPath: "/v1/issuing/personalization_designs",
     stripePath: "/v1/issuing/personalization_designs",
     resource: "issuing",
     operation: "create",
@@ -2823,7 +2823,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/personalization_designs/:personalization_design",
+    fastifyPath: "/v1/issuing/personalization_designs/:personalization_design",
     stripePath: "/v1/issuing/personalization_designs/{personalization_design}",
     resource: "issuing",
     operation: "retrieve",
@@ -2833,7 +2833,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/personalization_designs/:personalization_design",
+    fastifyPath: "/v1/issuing/personalization_designs/:personalization_design",
     stripePath: "/v1/issuing/personalization_designs/{personalization_design}",
     resource: "issuing",
     operation: "update",
@@ -2843,7 +2843,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/physical_bundles",
+    fastifyPath: "/v1/issuing/physical_bundles",
     stripePath: "/v1/issuing/physical_bundles",
     resource: "issuing",
     operation: "list",
@@ -2852,7 +2852,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/physical_bundles/:physical_bundle",
+    fastifyPath: "/v1/issuing/physical_bundles/:physical_bundle",
     stripePath: "/v1/issuing/physical_bundles/{physical_bundle}",
     resource: "issuing",
     operation: "retrieve",
@@ -2862,7 +2862,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/settlements/:settlement",
+    fastifyPath: "/v1/issuing/settlements/:settlement",
     stripePath: "/v1/issuing/settlements/{settlement}",
     resource: "issuing",
     operation: "retrieve",
@@ -2872,7 +2872,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/settlements/:settlement",
+    fastifyPath: "/v1/issuing/settlements/:settlement",
     stripePath: "/v1/issuing/settlements/{settlement}",
     resource: "issuing",
     operation: "update",
@@ -2882,7 +2882,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/tokens",
+    fastifyPath: "/v1/issuing/tokens",
     stripePath: "/v1/issuing/tokens",
     resource: "tokens",
     operation: "list",
@@ -2892,7 +2892,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/tokens/:token",
+    fastifyPath: "/v1/issuing/tokens/:token",
     stripePath: "/v1/issuing/tokens/{token}",
     resource: "tokens",
     operation: "retrieve",
@@ -2903,7 +2903,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/tokens/:token",
+    fastifyPath: "/v1/issuing/tokens/:token",
     stripePath: "/v1/issuing/tokens/{token}",
     resource: "tokens",
     operation: "update",
@@ -2914,7 +2914,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/transactions",
+    fastifyPath: "/v1/issuing/transactions",
     stripePath: "/v1/issuing/transactions",
     resource: "issuing",
     operation: "list",
@@ -2923,7 +2923,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/issuing/transactions/:transaction",
+    fastifyPath: "/v1/issuing/transactions/:transaction",
     stripePath: "/v1/issuing/transactions/{transaction}",
     resource: "issuing",
     operation: "retrieve",
@@ -2933,7 +2933,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/issuing/transactions/:transaction",
+    fastifyPath: "/v1/issuing/transactions/:transaction",
     stripePath: "/v1/issuing/transactions/{transaction}",
     resource: "issuing",
     operation: "update",
@@ -2943,7 +2943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/link_account_sessions",
+    fastifyPath: "/v1/link_account_sessions",
     stripePath: "/v1/link_account_sessions",
     resource: "link_account_sessions",
     operation: "create",
@@ -2952,7 +2952,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/link_account_sessions/:session",
+    fastifyPath: "/v1/link_account_sessions/:session",
     stripePath: "/v1/link_account_sessions/{session}",
     resource: "link_account_sessions",
     operation: "retrieve",
@@ -2962,7 +2962,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/linked_accounts",
+    fastifyPath: "/v1/linked_accounts",
     stripePath: "/v1/linked_accounts",
     resource: "linked_accounts",
     operation: "list",
@@ -2971,7 +2971,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/linked_accounts/:account",
+    fastifyPath: "/v1/linked_accounts/:account",
     stripePath: "/v1/linked_accounts/{account}",
     resource: "linked_accounts",
     operation: "retrieve",
@@ -2981,7 +2981,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/linked_accounts/:account/disconnect",
+    fastifyPath: "/v1/linked_accounts/:account/disconnect",
     stripePath: "/v1/linked_accounts/{account}/disconnect",
     resource: "linked_accounts",
     operation: "create",
@@ -2991,7 +2991,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/linked_accounts/:account/owners",
+    fastifyPath: "/v1/linked_accounts/:account/owners",
     stripePath: "/v1/linked_accounts/{account}/owners",
     resource: "linked_accounts",
     operation: "list",
@@ -3001,7 +3001,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/linked_accounts/:account/refresh",
+    fastifyPath: "/v1/linked_accounts/:account/refresh",
     stripePath: "/v1/linked_accounts/{account}/refresh",
     resource: "linked_accounts",
     operation: "create",
@@ -3011,7 +3011,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/mandates/:mandate",
+    fastifyPath: "/v1/mandates/:mandate",
     stripePath: "/v1/mandates/{mandate}",
     resource: "mandates",
     operation: "retrieve",
@@ -3022,7 +3022,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_attempt_records",
+    fastifyPath: "/v1/payment_attempt_records",
     stripePath: "/v1/payment_attempt_records",
     resource: "payment_attempt_records",
     operation: "list",
@@ -3032,7 +3032,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_attempt_records/:id",
+    fastifyPath: "/v1/payment_attempt_records/:id",
     stripePath: "/v1/payment_attempt_records/{id}",
     resource: "payment_attempt_records",
     operation: "retrieve",
@@ -3043,7 +3043,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_intents",
+    fastifyPath: "/v1/payment_intents",
     stripePath: "/v1/payment_intents",
     resource: "payment_intents",
     operation: "list",
@@ -3053,7 +3053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents",
+    fastifyPath: "/v1/payment_intents",
     stripePath: "/v1/payment_intents",
     resource: "payment_intents",
     operation: "create",
@@ -3063,7 +3063,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_intents/search",
+    fastifyPath: "/v1/payment_intents/search",
     stripePath: "/v1/payment_intents/search",
     resource: "payment_intents",
     operation: "list",
@@ -3073,7 +3073,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_intents/:intent",
+    fastifyPath: "/v1/payment_intents/:intent",
     stripePath: "/v1/payment_intents/{intent}",
     resource: "payment_intents",
     operation: "retrieve",
@@ -3084,7 +3084,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent",
+    fastifyPath: "/v1/payment_intents/:intent",
     stripePath: "/v1/payment_intents/{intent}",
     resource: "payment_intents",
     operation: "update",
@@ -3095,7 +3095,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/amount_details_line_items",
+    fastifyPath: "/v1/payment_intents/:intent/amount_details_line_items",
     stripePath: "/v1/payment_intents/{intent}/amount_details_line_items",
     resource: "payment_intents",
     operation: "list",
@@ -3106,7 +3106,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/apply_customer_balance",
+    fastifyPath: "/v1/payment_intents/:intent/apply_customer_balance",
     stripePath: "/v1/payment_intents/{intent}/apply_customer_balance",
     resource: "payment_intents",
     operation: "create",
@@ -3117,7 +3117,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/cancel",
+    fastifyPath: "/v1/payment_intents/:intent/cancel",
     stripePath: "/v1/payment_intents/{intent}/cancel",
     resource: "payment_intents",
     operation: "create",
@@ -3128,7 +3128,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/capture",
+    fastifyPath: "/v1/payment_intents/:intent/capture",
     stripePath: "/v1/payment_intents/{intent}/capture",
     resource: "payment_intents",
     operation: "create",
@@ -3139,7 +3139,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/confirm",
+    fastifyPath: "/v1/payment_intents/:intent/confirm",
     stripePath: "/v1/payment_intents/{intent}/confirm",
     resource: "payment_intents",
     operation: "create",
@@ -3150,7 +3150,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/increment_authorization",
+    fastifyPath: "/v1/payment_intents/:intent/increment_authorization",
     stripePath: "/v1/payment_intents/{intent}/increment_authorization",
     resource: "payment_intents",
     operation: "create",
@@ -3161,7 +3161,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_intents/:intent/verify_microdeposits",
+    fastifyPath: "/v1/payment_intents/:intent/verify_microdeposits",
     stripePath: "/v1/payment_intents/{intent}/verify_microdeposits",
     resource: "payment_intents",
     operation: "create",
@@ -3172,7 +3172,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_links",
+    fastifyPath: "/v1/payment_links",
     stripePath: "/v1/payment_links",
     resource: "payment_links",
     operation: "list",
@@ -3182,7 +3182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_links",
+    fastifyPath: "/v1/payment_links",
     stripePath: "/v1/payment_links",
     resource: "payment_links",
     operation: "create",
@@ -3192,7 +3192,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_links/:payment_link",
+    fastifyPath: "/v1/payment_links/:payment_link",
     stripePath: "/v1/payment_links/{payment_link}",
     resource: "payment_links",
     operation: "retrieve",
@@ -3203,7 +3203,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_links/:payment_link",
+    fastifyPath: "/v1/payment_links/:payment_link",
     stripePath: "/v1/payment_links/{payment_link}",
     resource: "payment_links",
     operation: "update",
@@ -3214,7 +3214,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_links/:payment_link/line_items",
+    fastifyPath: "/v1/payment_links/:payment_link/line_items",
     stripePath: "/v1/payment_links/{payment_link}/line_items",
     resource: "line_items",
     operation: "list",
@@ -3225,7 +3225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_method_configurations",
+    fastifyPath: "/v1/payment_method_configurations",
     stripePath: "/v1/payment_method_configurations",
     resource: "payment_method_configurations",
     operation: "list",
@@ -3235,7 +3235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_method_configurations",
+    fastifyPath: "/v1/payment_method_configurations",
     stripePath: "/v1/payment_method_configurations",
     resource: "payment_method_configurations",
     operation: "create",
@@ -3245,7 +3245,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_method_configurations/:configuration",
+    fastifyPath: "/v1/payment_method_configurations/:configuration",
     stripePath: "/v1/payment_method_configurations/{configuration}",
     resource: "payment_method_configurations",
     operation: "retrieve",
@@ -3256,7 +3256,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_method_configurations/:configuration",
+    fastifyPath: "/v1/payment_method_configurations/:configuration",
     stripePath: "/v1/payment_method_configurations/{configuration}",
     resource: "payment_method_configurations",
     operation: "update",
@@ -3267,7 +3267,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_method_domains",
+    fastifyPath: "/v1/payment_method_domains",
     stripePath: "/v1/payment_method_domains",
     resource: "payment_method_domains",
     operation: "list",
@@ -3277,7 +3277,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_method_domains",
+    fastifyPath: "/v1/payment_method_domains",
     stripePath: "/v1/payment_method_domains",
     resource: "payment_method_domains",
     operation: "create",
@@ -3287,7 +3287,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_method_domains/:payment_method_domain",
+    fastifyPath: "/v1/payment_method_domains/:payment_method_domain",
     stripePath: "/v1/payment_method_domains/{payment_method_domain}",
     resource: "payment_method_domains",
     operation: "retrieve",
@@ -3298,7 +3298,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_method_domains/:payment_method_domain",
+    fastifyPath: "/v1/payment_method_domains/:payment_method_domain",
     stripePath: "/v1/payment_method_domains/{payment_method_domain}",
     resource: "payment_method_domains",
     operation: "update",
@@ -3309,7 +3309,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_method_domains/:payment_method_domain/validate",
+    fastifyPath: "/v1/payment_method_domains/:payment_method_domain/validate",
     stripePath: "/v1/payment_method_domains/{payment_method_domain}/validate",
     resource: "payment_method_domains",
     operation: "create",
@@ -3320,7 +3320,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_methods",
+    fastifyPath: "/v1/payment_methods",
     stripePath: "/v1/payment_methods",
     resource: "payment_methods",
     operation: "list",
@@ -3330,7 +3330,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_methods",
+    fastifyPath: "/v1/payment_methods",
     stripePath: "/v1/payment_methods",
     resource: "payment_methods",
     operation: "create",
@@ -3340,7 +3340,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_methods/:payment_method",
+    fastifyPath: "/v1/payment_methods/:payment_method",
     stripePath: "/v1/payment_methods/{payment_method}",
     resource: "payment_methods",
     operation: "retrieve",
@@ -3351,7 +3351,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_methods/:payment_method",
+    fastifyPath: "/v1/payment_methods/:payment_method",
     stripePath: "/v1/payment_methods/{payment_method}",
     resource: "payment_methods",
     operation: "update",
@@ -3362,7 +3362,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_methods/:payment_method/attach",
+    fastifyPath: "/v1/payment_methods/:payment_method/attach",
     stripePath: "/v1/payment_methods/{payment_method}/attach",
     resource: "payment_methods",
     operation: "create",
@@ -3373,7 +3373,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_methods/:payment_method/detach",
+    fastifyPath: "/v1/payment_methods/:payment_method/detach",
     stripePath: "/v1/payment_methods/{payment_method}/detach",
     resource: "payment_methods",
     operation: "create",
@@ -3384,7 +3384,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/report_payment",
+    fastifyPath: "/v1/payment_records/report_payment",
     stripePath: "/v1/payment_records/report_payment",
     resource: "payment_records",
     operation: "create",
@@ -3394,7 +3394,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payment_records/:id",
+    fastifyPath: "/v1/payment_records/:id",
     stripePath: "/v1/payment_records/{id}",
     resource: "payment_records",
     operation: "retrieve",
@@ -3405,7 +3405,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_payment_attempt",
+    fastifyPath: "/v1/payment_records/:id/report_payment_attempt",
     stripePath: "/v1/payment_records/{id}/report_payment_attempt",
     resource: "payment_records",
     operation: "create",
@@ -3416,7 +3416,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_payment_attempt_canceled",
+    fastifyPath: "/v1/payment_records/:id/report_payment_attempt_canceled",
     stripePath: "/v1/payment_records/{id}/report_payment_attempt_canceled",
     resource: "payment_records",
     operation: "create",
@@ -3427,7 +3427,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_payment_attempt_failed",
+    fastifyPath: "/v1/payment_records/:id/report_payment_attempt_failed",
     stripePath: "/v1/payment_records/{id}/report_payment_attempt_failed",
     resource: "payment_records",
     operation: "create",
@@ -3438,7 +3438,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_payment_attempt_guaranteed",
+    fastifyPath: "/v1/payment_records/:id/report_payment_attempt_guaranteed",
     stripePath: "/v1/payment_records/{id}/report_payment_attempt_guaranteed",
     resource: "payment_records",
     operation: "create",
@@ -3449,7 +3449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_payment_attempt_informational",
+    fastifyPath: "/v1/payment_records/:id/report_payment_attempt_informational",
     stripePath: "/v1/payment_records/{id}/report_payment_attempt_informational",
     resource: "payment_records",
     operation: "create",
@@ -3460,7 +3460,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payment_records/:id/report_refund",
+    fastifyPath: "/v1/payment_records/:id/report_refund",
     stripePath: "/v1/payment_records/{id}/report_refund",
     resource: "payment_records",
     operation: "create",
@@ -3471,7 +3471,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payouts",
+    fastifyPath: "/v1/payouts",
     stripePath: "/v1/payouts",
     resource: "payouts",
     operation: "list",
@@ -3481,7 +3481,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payouts",
+    fastifyPath: "/v1/payouts",
     stripePath: "/v1/payouts",
     resource: "payouts",
     operation: "create",
@@ -3491,7 +3491,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/payouts/:payout",
+    fastifyPath: "/v1/payouts/:payout",
     stripePath: "/v1/payouts/{payout}",
     resource: "payouts",
     operation: "retrieve",
@@ -3502,7 +3502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payouts/:payout",
+    fastifyPath: "/v1/payouts/:payout",
     stripePath: "/v1/payouts/{payout}",
     resource: "payouts",
     operation: "update",
@@ -3513,7 +3513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payouts/:payout/cancel",
+    fastifyPath: "/v1/payouts/:payout/cancel",
     stripePath: "/v1/payouts/{payout}/cancel",
     resource: "payouts",
     operation: "create",
@@ -3524,7 +3524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/payouts/:payout/reverse",
+    fastifyPath: "/v1/payouts/:payout/reverse",
     stripePath: "/v1/payouts/{payout}/reverse",
     resource: "payouts",
     operation: "create",
@@ -3535,7 +3535,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/plans",
+    fastifyPath: "/v1/plans",
     stripePath: "/v1/plans",
     resource: "plans",
     operation: "list",
@@ -3545,7 +3545,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/plans",
+    fastifyPath: "/v1/plans",
     stripePath: "/v1/plans",
     resource: "plans",
     operation: "create",
@@ -3555,7 +3555,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/plans/:plan",
+    fastifyPath: "/v1/plans/:plan",
     stripePath: "/v1/plans/{plan}",
     resource: "plans",
     operation: "retrieve",
@@ -3566,7 +3566,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/plans/:plan",
+    fastifyPath: "/v1/plans/:plan",
     stripePath: "/v1/plans/{plan}",
     resource: "plans",
     operation: "update",
@@ -3577,7 +3577,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/plans/:plan",
+    fastifyPath: "/v1/plans/:plan",
     stripePath: "/v1/plans/{plan}",
     resource: "plans",
     operation: "delete",
@@ -3588,7 +3588,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/prices",
+    fastifyPath: "/v1/prices",
     stripePath: "/v1/prices",
     resource: "prices",
     operation: "list",
@@ -3598,7 +3598,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/prices",
+    fastifyPath: "/v1/prices",
     stripePath: "/v1/prices",
     resource: "prices",
     operation: "create",
@@ -3608,7 +3608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/prices/search",
+    fastifyPath: "/v1/prices/search",
     stripePath: "/v1/prices/search",
     resource: "prices",
     operation: "list",
@@ -3618,7 +3618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/prices/:price",
+    fastifyPath: "/v1/prices/:price",
     stripePath: "/v1/prices/{price}",
     resource: "prices",
     operation: "retrieve",
@@ -3629,7 +3629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/prices/:price",
+    fastifyPath: "/v1/prices/:price",
     stripePath: "/v1/prices/{price}",
     resource: "prices",
     operation: "update",
@@ -3640,7 +3640,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/products",
+    fastifyPath: "/v1/products",
     stripePath: "/v1/products",
     resource: "products",
     operation: "list",
@@ -3650,7 +3650,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/products",
+    fastifyPath: "/v1/products",
     stripePath: "/v1/products",
     resource: "products",
     operation: "create",
@@ -3660,7 +3660,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/products/search",
+    fastifyPath: "/v1/products/search",
     stripePath: "/v1/products/search",
     resource: "products",
     operation: "list",
@@ -3670,7 +3670,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/products/:id",
+    fastifyPath: "/v1/products/:id",
     stripePath: "/v1/products/{id}",
     resource: "products",
     operation: "retrieve",
@@ -3681,7 +3681,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/products/:id",
+    fastifyPath: "/v1/products/:id",
     stripePath: "/v1/products/{id}",
     resource: "products",
     operation: "update",
@@ -3692,7 +3692,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/products/:id",
+    fastifyPath: "/v1/products/:id",
     stripePath: "/v1/products/{id}",
     resource: "products",
     operation: "delete",
@@ -3703,7 +3703,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/products/:product/features",
+    fastifyPath: "/v1/products/:product/features",
     stripePath: "/v1/products/{product}/features",
     resource: "products",
     operation: "list",
@@ -3714,7 +3714,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/products/:product/features",
+    fastifyPath: "/v1/products/:product/features",
     stripePath: "/v1/products/{product}/features",
     resource: "products",
     operation: "create",
@@ -3725,7 +3725,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/products/:product/features/:id",
+    fastifyPath: "/v1/products/:product/features/:id",
     stripePath: "/v1/products/{product}/features/{id}",
     resource: "products",
     operation: "retrieve",
@@ -3736,7 +3736,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/products/:product/features/:id",
+    fastifyPath: "/v1/products/:product/features/:id",
     stripePath: "/v1/products/{product}/features/{id}",
     resource: "products",
     operation: "delete",
@@ -3747,7 +3747,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/promotion_codes",
+    fastifyPath: "/v1/promotion_codes",
     stripePath: "/v1/promotion_codes",
     resource: "promotion_codes",
     operation: "list",
@@ -3757,7 +3757,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/promotion_codes",
+    fastifyPath: "/v1/promotion_codes",
     stripePath: "/v1/promotion_codes",
     resource: "promotion_codes",
     operation: "create",
@@ -3767,7 +3767,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/promotion_codes/:promotion_code",
+    fastifyPath: "/v1/promotion_codes/:promotion_code",
     stripePath: "/v1/promotion_codes/{promotion_code}",
     resource: "promotion_codes",
     operation: "retrieve",
@@ -3778,7 +3778,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/promotion_codes/:promotion_code",
+    fastifyPath: "/v1/promotion_codes/:promotion_code",
     stripePath: "/v1/promotion_codes/{promotion_code}",
     resource: "promotion_codes",
     operation: "update",
@@ -3789,7 +3789,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/quotes",
+    fastifyPath: "/v1/quotes",
     stripePath: "/v1/quotes",
     resource: "quotes",
     operation: "list",
@@ -3799,7 +3799,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/quotes",
+    fastifyPath: "/v1/quotes",
     stripePath: "/v1/quotes",
     resource: "quotes",
     operation: "create",
@@ -3809,7 +3809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/quotes/:quote",
+    fastifyPath: "/v1/quotes/:quote",
     stripePath: "/v1/quotes/{quote}",
     resource: "quotes",
     operation: "retrieve",
@@ -3820,7 +3820,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/quotes/:quote",
+    fastifyPath: "/v1/quotes/:quote",
     stripePath: "/v1/quotes/{quote}",
     resource: "quotes",
     operation: "update",
@@ -3831,7 +3831,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/quotes/:quote/accept",
+    fastifyPath: "/v1/quotes/:quote/accept",
     stripePath: "/v1/quotes/{quote}/accept",
     resource: "quotes",
     operation: "create",
@@ -3842,7 +3842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/quotes/:quote/cancel",
+    fastifyPath: "/v1/quotes/:quote/cancel",
     stripePath: "/v1/quotes/{quote}/cancel",
     resource: "quotes",
     operation: "create",
@@ -3853,7 +3853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/quotes/:quote/computed_upfront_line_items",
+    fastifyPath: "/v1/quotes/:quote/computed_upfront_line_items",
     stripePath: "/v1/quotes/{quote}/computed_upfront_line_items",
     resource: "quotes",
     operation: "list",
@@ -3864,7 +3864,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/quotes/:quote/finalize",
+    fastifyPath: "/v1/quotes/:quote/finalize",
     stripePath: "/v1/quotes/{quote}/finalize",
     resource: "quotes",
     operation: "create",
@@ -3875,7 +3875,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/quotes/:quote/line_items",
+    fastifyPath: "/v1/quotes/:quote/line_items",
     stripePath: "/v1/quotes/{quote}/line_items",
     resource: "line_items",
     operation: "list",
@@ -3886,7 +3886,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/quotes/:quote/pdf",
+    fastifyPath: "/v1/quotes/:quote/pdf",
     stripePath: "/v1/quotes/{quote}/pdf",
     resource: "quotes",
     operation: "list",
@@ -3897,7 +3897,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/early_fraud_warnings",
+    fastifyPath: "/v1/radar/early_fraud_warnings",
     stripePath: "/v1/radar/early_fraud_warnings",
     resource: "radar",
     operation: "list",
@@ -3906,7 +3906,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/early_fraud_warnings/:early_fraud_warning",
+    fastifyPath: "/v1/radar/early_fraud_warnings/:early_fraud_warning",
     stripePath: "/v1/radar/early_fraud_warnings/{early_fraud_warning}",
     resource: "radar",
     operation: "retrieve",
@@ -3916,7 +3916,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/radar/payment_evaluations",
+    fastifyPath: "/v1/radar/payment_evaluations",
     stripePath: "/v1/radar/payment_evaluations",
     resource: "radar",
     operation: "create",
@@ -3925,7 +3925,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/value_list_items",
+    fastifyPath: "/v1/radar/value_list_items",
     stripePath: "/v1/radar/value_list_items",
     resource: "radar",
     operation: "list",
@@ -3934,7 +3934,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/radar/value_list_items",
+    fastifyPath: "/v1/radar/value_list_items",
     stripePath: "/v1/radar/value_list_items",
     resource: "radar",
     operation: "create",
@@ -3943,7 +3943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/value_list_items/:item",
+    fastifyPath: "/v1/radar/value_list_items/:item",
     stripePath: "/v1/radar/value_list_items/{item}",
     resource: "radar",
     operation: "retrieve",
@@ -3953,7 +3953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/radar/value_list_items/:item",
+    fastifyPath: "/v1/radar/value_list_items/:item",
     stripePath: "/v1/radar/value_list_items/{item}",
     resource: "radar",
     operation: "delete",
@@ -3963,7 +3963,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/value_lists",
+    fastifyPath: "/v1/radar/value_lists",
     stripePath: "/v1/radar/value_lists",
     resource: "radar",
     operation: "list",
@@ -3972,7 +3972,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/radar/value_lists",
+    fastifyPath: "/v1/radar/value_lists",
     stripePath: "/v1/radar/value_lists",
     resource: "radar",
     operation: "create",
@@ -3981,7 +3981,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/radar/value_lists/:value_list",
+    fastifyPath: "/v1/radar/value_lists/:value_list",
     stripePath: "/v1/radar/value_lists/{value_list}",
     resource: "radar",
     operation: "retrieve",
@@ -3991,7 +3991,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/radar/value_lists/:value_list",
+    fastifyPath: "/v1/radar/value_lists/:value_list",
     stripePath: "/v1/radar/value_lists/{value_list}",
     resource: "radar",
     operation: "update",
@@ -4001,7 +4001,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/radar/value_lists/:value_list",
+    fastifyPath: "/v1/radar/value_lists/:value_list",
     stripePath: "/v1/radar/value_lists/{value_list}",
     resource: "radar",
     operation: "delete",
@@ -4011,7 +4011,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/refunds",
+    fastifyPath: "/v1/refunds",
     stripePath: "/v1/refunds",
     resource: "refunds",
     operation: "list",
@@ -4021,7 +4021,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/refunds",
+    fastifyPath: "/v1/refunds",
     stripePath: "/v1/refunds",
     resource: "refunds",
     operation: "create",
@@ -4031,7 +4031,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/refunds/:refund",
+    fastifyPath: "/v1/refunds/:refund",
     stripePath: "/v1/refunds/{refund}",
     resource: "refunds",
     operation: "retrieve",
@@ -4042,7 +4042,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/refunds/:refund",
+    fastifyPath: "/v1/refunds/:refund",
     stripePath: "/v1/refunds/{refund}",
     resource: "refunds",
     operation: "update",
@@ -4053,7 +4053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/refunds/:refund/cancel",
+    fastifyPath: "/v1/refunds/:refund/cancel",
     stripePath: "/v1/refunds/{refund}/cancel",
     resource: "refunds",
     operation: "create",
@@ -4064,7 +4064,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reporting/report_runs",
+    fastifyPath: "/v1/reporting/report_runs",
     stripePath: "/v1/reporting/report_runs",
     resource: "reporting",
     operation: "list",
@@ -4073,7 +4073,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/reporting/report_runs",
+    fastifyPath: "/v1/reporting/report_runs",
     stripePath: "/v1/reporting/report_runs",
     resource: "reporting",
     operation: "create",
@@ -4082,7 +4082,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reporting/report_runs/:report_run",
+    fastifyPath: "/v1/reporting/report_runs/:report_run",
     stripePath: "/v1/reporting/report_runs/{report_run}",
     resource: "reporting",
     operation: "retrieve",
@@ -4092,7 +4092,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reporting/report_types",
+    fastifyPath: "/v1/reporting/report_types",
     stripePath: "/v1/reporting/report_types",
     resource: "reporting",
     operation: "list",
@@ -4101,7 +4101,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reporting/report_types/:report_type",
+    fastifyPath: "/v1/reporting/report_types/:report_type",
     stripePath: "/v1/reporting/report_types/{report_type}",
     resource: "reporting",
     operation: "retrieve",
@@ -4111,7 +4111,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reviews",
+    fastifyPath: "/v1/reviews",
     stripePath: "/v1/reviews",
     resource: "reviews",
     operation: "list",
@@ -4121,7 +4121,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/reviews/:review",
+    fastifyPath: "/v1/reviews/:review",
     stripePath: "/v1/reviews/{review}",
     resource: "reviews",
     operation: "retrieve",
@@ -4132,7 +4132,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/reviews/:review/approve",
+    fastifyPath: "/v1/reviews/:review/approve",
     stripePath: "/v1/reviews/{review}/approve",
     resource: "reviews",
     operation: "create",
@@ -4143,7 +4143,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/setup_attempts",
+    fastifyPath: "/v1/setup_attempts",
     stripePath: "/v1/setup_attempts",
     resource: "setup_attempts",
     operation: "list",
@@ -4153,7 +4153,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/setup_intents",
+    fastifyPath: "/v1/setup_intents",
     stripePath: "/v1/setup_intents",
     resource: "setup_intents",
     operation: "list",
@@ -4163,7 +4163,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/setup_intents",
+    fastifyPath: "/v1/setup_intents",
     stripePath: "/v1/setup_intents",
     resource: "setup_intents",
     operation: "create",
@@ -4173,7 +4173,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/setup_intents/:intent",
+    fastifyPath: "/v1/setup_intents/:intent",
     stripePath: "/v1/setup_intents/{intent}",
     resource: "setup_intents",
     operation: "retrieve",
@@ -4184,7 +4184,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/setup_intents/:intent",
+    fastifyPath: "/v1/setup_intents/:intent",
     stripePath: "/v1/setup_intents/{intent}",
     resource: "setup_intents",
     operation: "update",
@@ -4195,7 +4195,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/setup_intents/:intent/cancel",
+    fastifyPath: "/v1/setup_intents/:intent/cancel",
     stripePath: "/v1/setup_intents/{intent}/cancel",
     resource: "setup_intents",
     operation: "create",
@@ -4206,7 +4206,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/setup_intents/:intent/confirm",
+    fastifyPath: "/v1/setup_intents/:intent/confirm",
     stripePath: "/v1/setup_intents/{intent}/confirm",
     resource: "setup_intents",
     operation: "create",
@@ -4217,7 +4217,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/setup_intents/:intent/verify_microdeposits",
+    fastifyPath: "/v1/setup_intents/:intent/verify_microdeposits",
     stripePath: "/v1/setup_intents/{intent}/verify_microdeposits",
     resource: "setup_intents",
     operation: "create",
@@ -4228,7 +4228,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/shipping_rates",
+    fastifyPath: "/v1/shipping_rates",
     stripePath: "/v1/shipping_rates",
     resource: "shipping_rates",
     operation: "list",
@@ -4238,7 +4238,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/shipping_rates",
+    fastifyPath: "/v1/shipping_rates",
     stripePath: "/v1/shipping_rates",
     resource: "shipping_rates",
     operation: "create",
@@ -4248,7 +4248,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/shipping_rates/:shipping_rate_token",
+    fastifyPath: "/v1/shipping_rates/:shipping_rate_token",
     stripePath: "/v1/shipping_rates/{shipping_rate_token}",
     resource: "shipping_rates",
     operation: "retrieve",
@@ -4259,7 +4259,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/shipping_rates/:shipping_rate_token",
+    fastifyPath: "/v1/shipping_rates/:shipping_rate_token",
     stripePath: "/v1/shipping_rates/{shipping_rate_token}",
     resource: "shipping_rates",
     operation: "update",
@@ -4270,7 +4270,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/sigma/saved_queries/:id",
+    fastifyPath: "/v1/sigma/saved_queries/:id",
     stripePath: "/v1/sigma/saved_queries/{id}",
     resource: "sigma",
     operation: "update",
@@ -4280,7 +4280,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sigma/scheduled_query_runs",
+    fastifyPath: "/v1/sigma/scheduled_query_runs",
     stripePath: "/v1/sigma/scheduled_query_runs",
     resource: "scheduled_query_runs",
     operation: "list",
@@ -4290,7 +4290,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sigma/scheduled_query_runs/:scheduled_query_run",
+    fastifyPath: "/v1/sigma/scheduled_query_runs/:scheduled_query_run",
     stripePath: "/v1/sigma/scheduled_query_runs/{scheduled_query_run}",
     resource: "scheduled_query_runs",
     operation: "retrieve",
@@ -4301,7 +4301,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/sources",
+    fastifyPath: "/v1/sources",
     stripePath: "/v1/sources",
     resource: "sources",
     operation: "create",
@@ -4311,7 +4311,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sources/:source",
+    fastifyPath: "/v1/sources/:source",
     stripePath: "/v1/sources/{source}",
     resource: "sources",
     operation: "retrieve",
@@ -4322,7 +4322,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/sources/:source",
+    fastifyPath: "/v1/sources/:source",
     stripePath: "/v1/sources/{source}",
     resource: "sources",
     operation: "update",
@@ -4333,7 +4333,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sources/:source/mandate_notifications/:mandate_notification",
+    fastifyPath: "/v1/sources/:source/mandate_notifications/:mandate_notification",
     stripePath: "/v1/sources/{source}/mandate_notifications/{mandate_notification}",
     resource: "sources",
     operation: "retrieve",
@@ -4344,7 +4344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sources/:source/source_transactions",
+    fastifyPath: "/v1/sources/:source/source_transactions",
     stripePath: "/v1/sources/{source}/source_transactions",
     resource: "source_transactions",
     operation: "list",
@@ -4355,7 +4355,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/sources/:source/source_transactions/:source_transaction",
+    fastifyPath: "/v1/sources/:source/source_transactions/:source_transaction",
     stripePath: "/v1/sources/{source}/source_transactions/{source_transaction}",
     resource: "source_transactions",
     operation: "retrieve",
@@ -4366,7 +4366,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/sources/:source/verify",
+    fastifyPath: "/v1/sources/:source/verify",
     stripePath: "/v1/sources/{source}/verify",
     resource: "sources",
     operation: "create",
@@ -4377,7 +4377,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscription_items",
+    fastifyPath: "/v1/subscription_items",
     stripePath: "/v1/subscription_items",
     resource: "subscription_items",
     operation: "list",
@@ -4387,7 +4387,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_items",
+    fastifyPath: "/v1/subscription_items",
     stripePath: "/v1/subscription_items",
     resource: "subscription_items",
     operation: "create",
@@ -4397,7 +4397,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscription_items/:item",
+    fastifyPath: "/v1/subscription_items/:item",
     stripePath: "/v1/subscription_items/{item}",
     resource: "subscription_items",
     operation: "retrieve",
@@ -4408,7 +4408,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_items/:item",
+    fastifyPath: "/v1/subscription_items/:item",
     stripePath: "/v1/subscription_items/{item}",
     resource: "subscription_items",
     operation: "update",
@@ -4419,7 +4419,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/subscription_items/:item",
+    fastifyPath: "/v1/subscription_items/:item",
     stripePath: "/v1/subscription_items/{item}",
     resource: "subscription_items",
     operation: "delete",
@@ -4430,7 +4430,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscription_schedules",
+    fastifyPath: "/v1/subscription_schedules",
     stripePath: "/v1/subscription_schedules",
     resource: "subscription_schedules",
     operation: "list",
@@ -4440,7 +4440,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_schedules",
+    fastifyPath: "/v1/subscription_schedules",
     stripePath: "/v1/subscription_schedules",
     resource: "subscription_schedules",
     operation: "create",
@@ -4450,7 +4450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscription_schedules/:schedule",
+    fastifyPath: "/v1/subscription_schedules/:schedule",
     stripePath: "/v1/subscription_schedules/{schedule}",
     resource: "subscription_schedules",
     operation: "retrieve",
@@ -4461,7 +4461,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_schedules/:schedule",
+    fastifyPath: "/v1/subscription_schedules/:schedule",
     stripePath: "/v1/subscription_schedules/{schedule}",
     resource: "subscription_schedules",
     operation: "update",
@@ -4472,7 +4472,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_schedules/:schedule/cancel",
+    fastifyPath: "/v1/subscription_schedules/:schedule/cancel",
     stripePath: "/v1/subscription_schedules/{schedule}/cancel",
     resource: "subscription_schedules",
     operation: "create",
@@ -4483,7 +4483,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscription_schedules/:schedule/release",
+    fastifyPath: "/v1/subscription_schedules/:schedule/release",
     stripePath: "/v1/subscription_schedules/{schedule}/release",
     resource: "subscription_schedules",
     operation: "create",
@@ -4494,7 +4494,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscriptions",
+    fastifyPath: "/v1/subscriptions",
     stripePath: "/v1/subscriptions",
     resource: "subscriptions",
     operation: "list",
@@ -4504,7 +4504,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscriptions",
+    fastifyPath: "/v1/subscriptions",
     stripePath: "/v1/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -4514,7 +4514,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscriptions/search",
+    fastifyPath: "/v1/subscriptions/search",
     stripePath: "/v1/subscriptions/search",
     resource: "subscriptions",
     operation: "list",
@@ -4524,7 +4524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -4535,7 +4535,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "update",
@@ -4546,7 +4546,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription_exposed_id",
+    fastifyPath: "/v1/subscriptions/:subscription_exposed_id",
     stripePath: "/v1/subscriptions/{subscription_exposed_id}",
     resource: "subscriptions",
     operation: "delete",
@@ -4557,7 +4557,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription_exposed_id/discount",
+    fastifyPath: "/v1/subscriptions/:subscription_exposed_id/discount",
     stripePath: "/v1/subscriptions/{subscription_exposed_id}/discount",
     resource: "subscriptions",
     operation: "delete",
@@ -4568,7 +4568,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription/migrate",
+    fastifyPath: "/v1/subscriptions/:subscription/migrate",
     stripePath: "/v1/subscriptions/{subscription}/migrate",
     resource: "subscriptions",
     operation: "create",
@@ -4579,7 +4579,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/subscriptions/:subscription/resume",
+    fastifyPath: "/v1/subscriptions/:subscription/resume",
     stripePath: "/v1/subscriptions/{subscription}/resume",
     resource: "subscriptions",
     operation: "create",
@@ -4590,7 +4590,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/associations/find",
+    fastifyPath: "/v1/tax/associations/find",
     stripePath: "/v1/tax/associations/find",
     resource: "tax",
     operation: "list",
@@ -4599,7 +4599,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/calculations",
+    fastifyPath: "/v1/tax/calculations",
     stripePath: "/v1/tax/calculations",
     resource: "tax",
     operation: "create",
@@ -4608,7 +4608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/calculations/:calculation",
+    fastifyPath: "/v1/tax/calculations/:calculation",
     stripePath: "/v1/tax/calculations/{calculation}",
     resource: "tax",
     operation: "retrieve",
@@ -4618,7 +4618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/calculations/:calculation/line_items",
+    fastifyPath: "/v1/tax/calculations/:calculation/line_items",
     stripePath: "/v1/tax/calculations/{calculation}/line_items",
     resource: "line_items",
     operation: "list",
@@ -4629,7 +4629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/registrations",
+    fastifyPath: "/v1/tax/registrations",
     stripePath: "/v1/tax/registrations",
     resource: "tax",
     operation: "list",
@@ -4638,7 +4638,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/registrations",
+    fastifyPath: "/v1/tax/registrations",
     stripePath: "/v1/tax/registrations",
     resource: "tax",
     operation: "create",
@@ -4647,7 +4647,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/registrations/:id",
+    fastifyPath: "/v1/tax/registrations/:id",
     stripePath: "/v1/tax/registrations/{id}",
     resource: "tax",
     operation: "retrieve",
@@ -4657,7 +4657,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/registrations/:id",
+    fastifyPath: "/v1/tax/registrations/:id",
     stripePath: "/v1/tax/registrations/{id}",
     resource: "tax",
     operation: "update",
@@ -4667,7 +4667,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/settings",
+    fastifyPath: "/v1/tax/settings",
     stripePath: "/v1/tax/settings",
     resource: "tax",
     operation: "list",
@@ -4676,7 +4676,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/settings",
+    fastifyPath: "/v1/tax/settings",
     stripePath: "/v1/tax/settings",
     resource: "tax",
     operation: "create",
@@ -4685,7 +4685,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/transactions/create_from_calculation",
+    fastifyPath: "/v1/tax/transactions/create_from_calculation",
     stripePath: "/v1/tax/transactions/create_from_calculation",
     resource: "tax",
     operation: "create",
@@ -4694,7 +4694,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax/transactions/create_reversal",
+    fastifyPath: "/v1/tax/transactions/create_reversal",
     stripePath: "/v1/tax/transactions/create_reversal",
     resource: "tax",
     operation: "create",
@@ -4703,7 +4703,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/transactions/:transaction",
+    fastifyPath: "/v1/tax/transactions/:transaction",
     stripePath: "/v1/tax/transactions/{transaction}",
     resource: "tax",
     operation: "retrieve",
@@ -4713,7 +4713,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax/transactions/:transaction/line_items",
+    fastifyPath: "/v1/tax/transactions/:transaction/line_items",
     stripePath: "/v1/tax/transactions/{transaction}/line_items",
     resource: "line_items",
     operation: "list",
@@ -4724,7 +4724,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_codes",
+    fastifyPath: "/v1/tax_codes",
     stripePath: "/v1/tax_codes",
     resource: "tax_codes",
     operation: "list",
@@ -4734,7 +4734,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_codes/:id",
+    fastifyPath: "/v1/tax_codes/:id",
     stripePath: "/v1/tax_codes/{id}",
     resource: "tax_codes",
     operation: "retrieve",
@@ -4745,7 +4745,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_ids",
+    fastifyPath: "/v1/tax_ids",
     stripePath: "/v1/tax_ids",
     resource: "tax_ids",
     operation: "list",
@@ -4755,7 +4755,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax_ids",
+    fastifyPath: "/v1/tax_ids",
     stripePath: "/v1/tax_ids",
     resource: "tax_ids",
     operation: "create",
@@ -4765,7 +4765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_ids/:id",
+    fastifyPath: "/v1/tax_ids/:id",
     stripePath: "/v1/tax_ids/{id}",
     resource: "tax_ids",
     operation: "retrieve",
@@ -4776,7 +4776,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/tax_ids/:id",
+    fastifyPath: "/v1/tax_ids/:id",
     stripePath: "/v1/tax_ids/{id}",
     resource: "tax_ids",
     operation: "delete",
@@ -4787,7 +4787,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_rates",
+    fastifyPath: "/v1/tax_rates",
     stripePath: "/v1/tax_rates",
     resource: "tax_rates",
     operation: "list",
@@ -4797,7 +4797,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax_rates",
+    fastifyPath: "/v1/tax_rates",
     stripePath: "/v1/tax_rates",
     resource: "tax_rates",
     operation: "create",
@@ -4807,7 +4807,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tax_rates/:tax_rate",
+    fastifyPath: "/v1/tax_rates/:tax_rate",
     stripePath: "/v1/tax_rates/{tax_rate}",
     resource: "tax_rates",
     operation: "retrieve",
@@ -4818,7 +4818,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tax_rates/:tax_rate",
+    fastifyPath: "/v1/tax_rates/:tax_rate",
     stripePath: "/v1/tax_rates/{tax_rate}",
     resource: "tax_rates",
     operation: "update",
@@ -4829,7 +4829,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/configurations",
+    fastifyPath: "/v1/terminal/configurations",
     stripePath: "/v1/terminal/configurations",
     resource: "terminal",
     operation: "list",
@@ -4838,7 +4838,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/configurations",
+    fastifyPath: "/v1/terminal/configurations",
     stripePath: "/v1/terminal/configurations",
     resource: "terminal",
     operation: "create",
@@ -4847,7 +4847,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/configurations/:configuration",
+    fastifyPath: "/v1/terminal/configurations/:configuration",
     stripePath: "/v1/terminal/configurations/{configuration}",
     resource: "terminal",
     operation: "retrieve",
@@ -4857,7 +4857,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/configurations/:configuration",
+    fastifyPath: "/v1/terminal/configurations/:configuration",
     stripePath: "/v1/terminal/configurations/{configuration}",
     resource: "terminal",
     operation: "update",
@@ -4867,7 +4867,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/terminal/configurations/:configuration",
+    fastifyPath: "/v1/terminal/configurations/:configuration",
     stripePath: "/v1/terminal/configurations/{configuration}",
     resource: "terminal",
     operation: "delete",
@@ -4877,7 +4877,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/connection_tokens",
+    fastifyPath: "/v1/terminal/connection_tokens",
     stripePath: "/v1/terminal/connection_tokens",
     resource: "terminal",
     operation: "create",
@@ -4886,7 +4886,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/locations",
+    fastifyPath: "/v1/terminal/locations",
     stripePath: "/v1/terminal/locations",
     resource: "terminal",
     operation: "list",
@@ -4895,7 +4895,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/locations",
+    fastifyPath: "/v1/terminal/locations",
     stripePath: "/v1/terminal/locations",
     resource: "terminal",
     operation: "create",
@@ -4904,7 +4904,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/locations/:location",
+    fastifyPath: "/v1/terminal/locations/:location",
     stripePath: "/v1/terminal/locations/{location}",
     resource: "terminal",
     operation: "retrieve",
@@ -4914,7 +4914,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/locations/:location",
+    fastifyPath: "/v1/terminal/locations/:location",
     stripePath: "/v1/terminal/locations/{location}",
     resource: "terminal",
     operation: "update",
@@ -4924,7 +4924,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/terminal/locations/:location",
+    fastifyPath: "/v1/terminal/locations/:location",
     stripePath: "/v1/terminal/locations/{location}",
     resource: "terminal",
     operation: "delete",
@@ -4934,7 +4934,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/onboarding_links",
+    fastifyPath: "/v1/terminal/onboarding_links",
     stripePath: "/v1/terminal/onboarding_links",
     resource: "terminal",
     operation: "create",
@@ -4943,7 +4943,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/readers",
+    fastifyPath: "/v1/terminal/readers",
     stripePath: "/v1/terminal/readers",
     resource: "terminal",
     operation: "list",
@@ -4952,7 +4952,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers",
+    fastifyPath: "/v1/terminal/readers",
     stripePath: "/v1/terminal/readers",
     resource: "terminal",
     operation: "create",
@@ -4961,7 +4961,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader",
+    fastifyPath: "/v1/terminal/readers/:reader",
     stripePath: "/v1/terminal/readers/{reader}",
     resource: "terminal",
     operation: "retrieve",
@@ -4971,7 +4971,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader",
+    fastifyPath: "/v1/terminal/readers/:reader",
     stripePath: "/v1/terminal/readers/{reader}",
     resource: "terminal",
     operation: "update",
@@ -4981,7 +4981,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader",
+    fastifyPath: "/v1/terminal/readers/:reader",
     stripePath: "/v1/terminal/readers/{reader}",
     resource: "terminal",
     operation: "delete",
@@ -4991,7 +4991,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/cancel_action",
+    fastifyPath: "/v1/terminal/readers/:reader/cancel_action",
     stripePath: "/v1/terminal/readers/{reader}/cancel_action",
     resource: "terminal",
     operation: "create",
@@ -5001,7 +5001,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/collect_inputs",
+    fastifyPath: "/v1/terminal/readers/:reader/collect_inputs",
     stripePath: "/v1/terminal/readers/{reader}/collect_inputs",
     resource: "terminal",
     operation: "create",
@@ -5011,7 +5011,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/collect_payment_method",
+    fastifyPath: "/v1/terminal/readers/:reader/collect_payment_method",
     stripePath: "/v1/terminal/readers/{reader}/collect_payment_method",
     resource: "terminal",
     operation: "create",
@@ -5021,7 +5021,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/confirm_payment_intent",
+    fastifyPath: "/v1/terminal/readers/:reader/confirm_payment_intent",
     stripePath: "/v1/terminal/readers/{reader}/confirm_payment_intent",
     resource: "terminal",
     operation: "create",
@@ -5031,7 +5031,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/process_payment_intent",
+    fastifyPath: "/v1/terminal/readers/:reader/process_payment_intent",
     stripePath: "/v1/terminal/readers/{reader}/process_payment_intent",
     resource: "terminal",
     operation: "create",
@@ -5041,7 +5041,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/process_setup_intent",
+    fastifyPath: "/v1/terminal/readers/:reader/process_setup_intent",
     stripePath: "/v1/terminal/readers/{reader}/process_setup_intent",
     resource: "terminal",
     operation: "create",
@@ -5051,7 +5051,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/refund_payment",
+    fastifyPath: "/v1/terminal/readers/:reader/refund_payment",
     stripePath: "/v1/terminal/readers/{reader}/refund_payment",
     resource: "terminal",
     operation: "create",
@@ -5061,7 +5061,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/readers/:reader/set_reader_display",
+    fastifyPath: "/v1/terminal/readers/:reader/set_reader_display",
     stripePath: "/v1/terminal/readers/{reader}/set_reader_display",
     resource: "terminal",
     operation: "create",
@@ -5071,7 +5071,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/terminal/refunds",
+    fastifyPath: "/v1/terminal/refunds",
     stripePath: "/v1/terminal/refunds",
     resource: "refunds",
     operation: "create",
@@ -5081,7 +5081,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/confirmation_tokens",
+    fastifyPath: "/v1/test_helpers/confirmation_tokens",
     stripePath: "/v1/test_helpers/confirmation_tokens",
     resource: "confirmation_tokens",
     operation: "create",
@@ -5091,7 +5091,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/customers/:customer/fund_cash_balance",
+    fastifyPath: "/v1/test_helpers/customers/:customer/fund_cash_balance",
     stripePath: "/v1/test_helpers/customers/{customer}/fund_cash_balance",
     resource: "customers",
     operation: "create",
@@ -5102,7 +5102,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations",
     stripePath: "/v1/test_helpers/issuing/authorizations",
     resource: "test_helpers",
     operation: "create",
@@ -5111,7 +5111,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/capture",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/capture",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/capture",
     resource: "test_helpers",
     operation: "create",
@@ -5121,7 +5121,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/expire",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/expire",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/expire",
     resource: "test_helpers",
     operation: "create",
@@ -5131,7 +5131,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/finalize_amount",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/finalize_amount",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/finalize_amount",
     resource: "test_helpers",
     operation: "create",
@@ -5141,7 +5141,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/fraud_challenges/respond",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/fraud_challenges/respond",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/fraud_challenges/respond",
     resource: "test_helpers",
     operation: "action",
@@ -5151,7 +5151,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/increment",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/increment",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/increment",
     resource: "test_helpers",
     operation: "create",
@@ -5161,7 +5161,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/authorizations/:authorization/reverse",
+    fastifyPath: "/v1/test_helpers/issuing/authorizations/:authorization/reverse",
     stripePath: "/v1/test_helpers/issuing/authorizations/{authorization}/reverse",
     resource: "test_helpers",
     operation: "create",
@@ -5171,7 +5171,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/cards/:card/shipping/deliver",
+    fastifyPath: "/v1/test_helpers/issuing/cards/:card/shipping/deliver",
     stripePath: "/v1/test_helpers/issuing/cards/{card}/shipping/deliver",
     resource: "cards",
     operation: "action",
@@ -5182,7 +5182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/cards/:card/shipping/fail",
+    fastifyPath: "/v1/test_helpers/issuing/cards/:card/shipping/fail",
     stripePath: "/v1/test_helpers/issuing/cards/{card}/shipping/fail",
     resource: "cards",
     operation: "action",
@@ -5193,7 +5193,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/cards/:card/shipping/return",
+    fastifyPath: "/v1/test_helpers/issuing/cards/:card/shipping/return",
     stripePath: "/v1/test_helpers/issuing/cards/{card}/shipping/return",
     resource: "cards",
     operation: "action",
@@ -5204,7 +5204,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/cards/:card/shipping/ship",
+    fastifyPath: "/v1/test_helpers/issuing/cards/:card/shipping/ship",
     stripePath: "/v1/test_helpers/issuing/cards/{card}/shipping/ship",
     resource: "cards",
     operation: "action",
@@ -5215,7 +5215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/cards/:card/shipping/submit",
+    fastifyPath: "/v1/test_helpers/issuing/cards/:card/shipping/submit",
     stripePath: "/v1/test_helpers/issuing/cards/{card}/shipping/submit",
     resource: "cards",
     operation: "action",
@@ -5226,7 +5226,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/personalization_designs/:personalization_design/activate",
+    fastifyPath: "/v1/test_helpers/issuing/personalization_designs/:personalization_design/activate",
     stripePath: "/v1/test_helpers/issuing/personalization_designs/{personalization_design}/activate",
     resource: "test_helpers",
     operation: "create",
@@ -5236,7 +5236,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/personalization_designs/:personalization_design/deactivate",
+    fastifyPath: "/v1/test_helpers/issuing/personalization_designs/:personalization_design/deactivate",
     stripePath: "/v1/test_helpers/issuing/personalization_designs/{personalization_design}/deactivate",
     resource: "test_helpers",
     operation: "create",
@@ -5246,7 +5246,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/personalization_designs/:personalization_design/reject",
+    fastifyPath: "/v1/test_helpers/issuing/personalization_designs/:personalization_design/reject",
     stripePath: "/v1/test_helpers/issuing/personalization_designs/{personalization_design}/reject",
     resource: "test_helpers",
     operation: "create",
@@ -5256,7 +5256,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/settlements",
+    fastifyPath: "/v1/test_helpers/issuing/settlements",
     stripePath: "/v1/test_helpers/issuing/settlements",
     resource: "test_helpers",
     operation: "create",
@@ -5265,7 +5265,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/settlements/:settlement/complete",
+    fastifyPath: "/v1/test_helpers/issuing/settlements/:settlement/complete",
     stripePath: "/v1/test_helpers/issuing/settlements/{settlement}/complete",
     resource: "test_helpers",
     operation: "create",
@@ -5275,7 +5275,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/transactions/create_force_capture",
+    fastifyPath: "/v1/test_helpers/issuing/transactions/create_force_capture",
     stripePath: "/v1/test_helpers/issuing/transactions/create_force_capture",
     resource: "test_helpers",
     operation: "create",
@@ -5284,7 +5284,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/transactions/create_unlinked_refund",
+    fastifyPath: "/v1/test_helpers/issuing/transactions/create_unlinked_refund",
     stripePath: "/v1/test_helpers/issuing/transactions/create_unlinked_refund",
     resource: "test_helpers",
     operation: "create",
@@ -5293,7 +5293,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/issuing/transactions/:transaction/refund",
+    fastifyPath: "/v1/test_helpers/issuing/transactions/:transaction/refund",
     stripePath: "/v1/test_helpers/issuing/transactions/{transaction}/refund",
     resource: "test_helpers",
     operation: "create",
@@ -5303,7 +5303,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/refunds/:refund/expire",
+    fastifyPath: "/v1/test_helpers/refunds/:refund/expire",
     stripePath: "/v1/test_helpers/refunds/{refund}/expire",
     resource: "refunds",
     operation: "create",
@@ -5314,7 +5314,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/terminal/readers/:reader/present_payment_method",
+    fastifyPath: "/v1/test_helpers/terminal/readers/:reader/present_payment_method",
     stripePath: "/v1/test_helpers/terminal/readers/{reader}/present_payment_method",
     resource: "test_helpers",
     operation: "create",
@@ -5324,7 +5324,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/terminal/readers/:reader/succeed_input_collection",
+    fastifyPath: "/v1/test_helpers/terminal/readers/:reader/succeed_input_collection",
     stripePath: "/v1/test_helpers/terminal/readers/{reader}/succeed_input_collection",
     resource: "test_helpers",
     operation: "create",
@@ -5334,7 +5334,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/terminal/readers/:reader/timeout_input_collection",
+    fastifyPath: "/v1/test_helpers/terminal/readers/:reader/timeout_input_collection",
     stripePath: "/v1/test_helpers/terminal/readers/{reader}/timeout_input_collection",
     resource: "test_helpers",
     operation: "create",
@@ -5344,7 +5344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/test_helpers/test_clocks",
+    fastifyPath: "/v1/test_helpers/test_clocks",
     stripePath: "/v1/test_helpers/test_clocks",
     resource: "test_helpers",
     operation: "list",
@@ -5353,7 +5353,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/test_clocks",
+    fastifyPath: "/v1/test_helpers/test_clocks",
     stripePath: "/v1/test_helpers/test_clocks",
     resource: "test_helpers",
     operation: "create",
@@ -5362,7 +5362,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/test_helpers/test_clocks/:test_clock",
+    fastifyPath: "/v1/test_helpers/test_clocks/:test_clock",
     stripePath: "/v1/test_helpers/test_clocks/{test_clock}",
     resource: "test_helpers",
     operation: "retrieve",
@@ -5372,7 +5372,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/test_helpers/test_clocks/:test_clock",
+    fastifyPath: "/v1/test_helpers/test_clocks/:test_clock",
     stripePath: "/v1/test_helpers/test_clocks/{test_clock}",
     resource: "test_helpers",
     operation: "delete",
@@ -5382,7 +5382,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/test_clocks/:test_clock/advance",
+    fastifyPath: "/v1/test_helpers/test_clocks/:test_clock/advance",
     stripePath: "/v1/test_helpers/test_clocks/{test_clock}/advance",
     resource: "test_helpers",
     operation: "create",
@@ -5392,7 +5392,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/inbound_transfers/:id/fail",
+    fastifyPath: "/v1/test_helpers/treasury/inbound_transfers/:id/fail",
     stripePath: "/v1/test_helpers/treasury/inbound_transfers/{id}/fail",
     resource: "test_helpers",
     operation: "create",
@@ -5402,7 +5402,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/inbound_transfers/:id/return",
+    fastifyPath: "/v1/test_helpers/treasury/inbound_transfers/:id/return",
     stripePath: "/v1/test_helpers/treasury/inbound_transfers/{id}/return",
     resource: "test_helpers",
     operation: "create",
@@ -5412,7 +5412,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/inbound_transfers/:id/succeed",
+    fastifyPath: "/v1/test_helpers/treasury/inbound_transfers/:id/succeed",
     stripePath: "/v1/test_helpers/treasury/inbound_transfers/{id}/succeed",
     resource: "test_helpers",
     operation: "create",
@@ -5422,7 +5422,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_payments/:id",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_payments/:id",
     stripePath: "/v1/test_helpers/treasury/outbound_payments/{id}",
     resource: "test_helpers",
     operation: "update",
@@ -5432,7 +5432,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_payments/:id/fail",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_payments/:id/fail",
     stripePath: "/v1/test_helpers/treasury/outbound_payments/{id}/fail",
     resource: "test_helpers",
     operation: "create",
@@ -5442,7 +5442,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_payments/:id/post",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_payments/:id/post",
     stripePath: "/v1/test_helpers/treasury/outbound_payments/{id}/post",
     resource: "test_helpers",
     operation: "create",
@@ -5452,7 +5452,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_payments/:id/return",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_payments/:id/return",
     stripePath: "/v1/test_helpers/treasury/outbound_payments/{id}/return",
     resource: "test_helpers",
     operation: "create",
@@ -5462,7 +5462,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer",
     stripePath: "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}",
     resource: "test_helpers",
     operation: "update",
@@ -5472,7 +5472,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/fail",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/fail",
     stripePath: "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail",
     resource: "test_helpers",
     operation: "create",
@@ -5482,7 +5482,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/post",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/post",
     stripePath: "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post",
     resource: "test_helpers",
     operation: "create",
@@ -5492,7 +5492,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/return",
+    fastifyPath: "/v1/test_helpers/treasury/outbound_transfers/:outbound_transfer/return",
     stripePath: "/v1/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return",
     resource: "test_helpers",
     operation: "create",
@@ -5502,7 +5502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/received_credits",
+    fastifyPath: "/v1/test_helpers/treasury/received_credits",
     stripePath: "/v1/test_helpers/treasury/received_credits",
     resource: "test_helpers",
     operation: "create",
@@ -5511,7 +5511,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/test_helpers/treasury/received_debits",
+    fastifyPath: "/v1/test_helpers/treasury/received_debits",
     stripePath: "/v1/test_helpers/treasury/received_debits",
     resource: "test_helpers",
     operation: "create",
@@ -5520,7 +5520,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/tokens",
+    fastifyPath: "/v1/tokens",
     stripePath: "/v1/tokens",
     resource: "tokens",
     operation: "create",
@@ -5530,7 +5530,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/tokens/:token",
+    fastifyPath: "/v1/tokens/:token",
     stripePath: "/v1/tokens/{token}",
     resource: "tokens",
     operation: "retrieve",
@@ -5541,7 +5541,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/topups",
+    fastifyPath: "/v1/topups",
     stripePath: "/v1/topups",
     resource: "topups",
     operation: "list",
@@ -5551,7 +5551,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/topups",
+    fastifyPath: "/v1/topups",
     stripePath: "/v1/topups",
     resource: "topups",
     operation: "create",
@@ -5561,7 +5561,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/topups/:topup",
+    fastifyPath: "/v1/topups/:topup",
     stripePath: "/v1/topups/{topup}",
     resource: "topups",
     operation: "retrieve",
@@ -5572,7 +5572,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/topups/:topup",
+    fastifyPath: "/v1/topups/:topup",
     stripePath: "/v1/topups/{topup}",
     resource: "topups",
     operation: "update",
@@ -5583,7 +5583,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/topups/:topup/cancel",
+    fastifyPath: "/v1/topups/:topup/cancel",
     stripePath: "/v1/topups/{topup}/cancel",
     resource: "topups",
     operation: "create",
@@ -5594,7 +5594,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/transfers",
+    fastifyPath: "/v1/transfers",
     stripePath: "/v1/transfers",
     resource: "transfers",
     operation: "list",
@@ -5604,7 +5604,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/transfers",
+    fastifyPath: "/v1/transfers",
     stripePath: "/v1/transfers",
     resource: "transfers",
     operation: "create",
@@ -5614,7 +5614,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/transfers/:id/reversals",
+    fastifyPath: "/v1/transfers/:id/reversals",
     stripePath: "/v1/transfers/{id}/reversals",
     resource: "transfers",
     operation: "list",
@@ -5625,7 +5625,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/transfers/:id/reversals",
+    fastifyPath: "/v1/transfers/:id/reversals",
     stripePath: "/v1/transfers/{id}/reversals",
     resource: "transfers",
     operation: "create",
@@ -5636,7 +5636,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/transfers/:transfer",
+    fastifyPath: "/v1/transfers/:transfer",
     stripePath: "/v1/transfers/{transfer}",
     resource: "transfers",
     operation: "retrieve",
@@ -5647,7 +5647,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/transfers/:transfer",
+    fastifyPath: "/v1/transfers/:transfer",
     stripePath: "/v1/transfers/{transfer}",
     resource: "transfers",
     operation: "update",
@@ -5658,7 +5658,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/transfers/:transfer/reversals/:id",
+    fastifyPath: "/v1/transfers/:transfer/reversals/:id",
     stripePath: "/v1/transfers/{transfer}/reversals/{id}",
     resource: "transfers",
     operation: "retrieve",
@@ -5669,7 +5669,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/transfers/:transfer/reversals/:id",
+    fastifyPath: "/v1/transfers/:transfer/reversals/:id",
     stripePath: "/v1/transfers/{transfer}/reversals/{id}",
     resource: "transfers",
     operation: "update",
@@ -5680,7 +5680,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/credit_reversals",
+    fastifyPath: "/v1/treasury/credit_reversals",
     stripePath: "/v1/treasury/credit_reversals",
     resource: "treasury",
     operation: "list",
@@ -5689,7 +5689,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/credit_reversals",
+    fastifyPath: "/v1/treasury/credit_reversals",
     stripePath: "/v1/treasury/credit_reversals",
     resource: "treasury",
     operation: "create",
@@ -5698,7 +5698,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/credit_reversals/:credit_reversal",
+    fastifyPath: "/v1/treasury/credit_reversals/:credit_reversal",
     stripePath: "/v1/treasury/credit_reversals/{credit_reversal}",
     resource: "treasury",
     operation: "retrieve",
@@ -5708,7 +5708,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/debit_reversals",
+    fastifyPath: "/v1/treasury/debit_reversals",
     stripePath: "/v1/treasury/debit_reversals",
     resource: "treasury",
     operation: "list",
@@ -5717,7 +5717,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/debit_reversals",
+    fastifyPath: "/v1/treasury/debit_reversals",
     stripePath: "/v1/treasury/debit_reversals",
     resource: "treasury",
     operation: "create",
@@ -5726,7 +5726,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/debit_reversals/:debit_reversal",
+    fastifyPath: "/v1/treasury/debit_reversals/:debit_reversal",
     stripePath: "/v1/treasury/debit_reversals/{debit_reversal}",
     resource: "treasury",
     operation: "retrieve",
@@ -5736,7 +5736,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts",
+    fastifyPath: "/v1/treasury/financial_accounts",
     stripePath: "/v1/treasury/financial_accounts",
     resource: "treasury",
     operation: "list",
@@ -5745,7 +5745,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts",
+    fastifyPath: "/v1/treasury/financial_accounts",
     stripePath: "/v1/treasury/financial_accounts",
     resource: "treasury",
     operation: "create",
@@ -5754,7 +5754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts/:financial_account",
+    fastifyPath: "/v1/treasury/financial_accounts/:financial_account",
     stripePath: "/v1/treasury/financial_accounts/{financial_account}",
     resource: "treasury",
     operation: "retrieve",
@@ -5764,7 +5764,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts/:financial_account",
+    fastifyPath: "/v1/treasury/financial_accounts/:financial_account",
     stripePath: "/v1/treasury/financial_accounts/{financial_account}",
     resource: "treasury",
     operation: "update",
@@ -5774,7 +5774,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts/:financial_account/close",
+    fastifyPath: "/v1/treasury/financial_accounts/:financial_account/close",
     stripePath: "/v1/treasury/financial_accounts/{financial_account}/close",
     resource: "treasury",
     operation: "create",
@@ -5784,7 +5784,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts/:financial_account/features",
+    fastifyPath: "/v1/treasury/financial_accounts/:financial_account/features",
     stripePath: "/v1/treasury/financial_accounts/{financial_account}/features",
     resource: "treasury",
     operation: "list",
@@ -5794,7 +5794,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/financial_accounts/:financial_account/features",
+    fastifyPath: "/v1/treasury/financial_accounts/:financial_account/features",
     stripePath: "/v1/treasury/financial_accounts/{financial_account}/features",
     resource: "treasury",
     operation: "create",
@@ -5804,7 +5804,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/inbound_transfers",
+    fastifyPath: "/v1/treasury/inbound_transfers",
     stripePath: "/v1/treasury/inbound_transfers",
     resource: "treasury",
     operation: "list",
@@ -5813,7 +5813,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/inbound_transfers",
+    fastifyPath: "/v1/treasury/inbound_transfers",
     stripePath: "/v1/treasury/inbound_transfers",
     resource: "treasury",
     operation: "create",
@@ -5822,7 +5822,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/inbound_transfers/:id",
+    fastifyPath: "/v1/treasury/inbound_transfers/:id",
     stripePath: "/v1/treasury/inbound_transfers/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5832,7 +5832,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/inbound_transfers/:inbound_transfer/cancel",
+    fastifyPath: "/v1/treasury/inbound_transfers/:inbound_transfer/cancel",
     stripePath: "/v1/treasury/inbound_transfers/{inbound_transfer}/cancel",
     resource: "treasury",
     operation: "create",
@@ -5842,7 +5842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/outbound_payments",
+    fastifyPath: "/v1/treasury/outbound_payments",
     stripePath: "/v1/treasury/outbound_payments",
     resource: "treasury",
     operation: "list",
@@ -5851,7 +5851,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/outbound_payments",
+    fastifyPath: "/v1/treasury/outbound_payments",
     stripePath: "/v1/treasury/outbound_payments",
     resource: "treasury",
     operation: "create",
@@ -5860,7 +5860,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/outbound_payments/:id",
+    fastifyPath: "/v1/treasury/outbound_payments/:id",
     stripePath: "/v1/treasury/outbound_payments/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5870,7 +5870,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/outbound_payments/:id/cancel",
+    fastifyPath: "/v1/treasury/outbound_payments/:id/cancel",
     stripePath: "/v1/treasury/outbound_payments/{id}/cancel",
     resource: "treasury",
     operation: "create",
@@ -5880,7 +5880,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/outbound_transfers",
+    fastifyPath: "/v1/treasury/outbound_transfers",
     stripePath: "/v1/treasury/outbound_transfers",
     resource: "treasury",
     operation: "list",
@@ -5889,7 +5889,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/outbound_transfers",
+    fastifyPath: "/v1/treasury/outbound_transfers",
     stripePath: "/v1/treasury/outbound_transfers",
     resource: "treasury",
     operation: "create",
@@ -5898,7 +5898,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/outbound_transfers/:outbound_transfer",
+    fastifyPath: "/v1/treasury/outbound_transfers/:outbound_transfer",
     stripePath: "/v1/treasury/outbound_transfers/{outbound_transfer}",
     resource: "treasury",
     operation: "retrieve",
@@ -5908,7 +5908,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/treasury/outbound_transfers/:outbound_transfer/cancel",
+    fastifyPath: "/v1/treasury/outbound_transfers/:outbound_transfer/cancel",
     stripePath: "/v1/treasury/outbound_transfers/{outbound_transfer}/cancel",
     resource: "treasury",
     operation: "create",
@@ -5918,7 +5918,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/received_credits",
+    fastifyPath: "/v1/treasury/received_credits",
     stripePath: "/v1/treasury/received_credits",
     resource: "treasury",
     operation: "list",
@@ -5927,7 +5927,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/received_credits/:id",
+    fastifyPath: "/v1/treasury/received_credits/:id",
     stripePath: "/v1/treasury/received_credits/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5937,7 +5937,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/received_debits",
+    fastifyPath: "/v1/treasury/received_debits",
     stripePath: "/v1/treasury/received_debits",
     resource: "treasury",
     operation: "list",
@@ -5946,7 +5946,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/received_debits/:id",
+    fastifyPath: "/v1/treasury/received_debits/:id",
     stripePath: "/v1/treasury/received_debits/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5956,7 +5956,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/transaction_entries",
+    fastifyPath: "/v1/treasury/transaction_entries",
     stripePath: "/v1/treasury/transaction_entries",
     resource: "treasury",
     operation: "list",
@@ -5965,7 +5965,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/transaction_entries/:id",
+    fastifyPath: "/v1/treasury/transaction_entries/:id",
     stripePath: "/v1/treasury/transaction_entries/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5975,7 +5975,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/transactions",
+    fastifyPath: "/v1/treasury/transactions",
     stripePath: "/v1/treasury/transactions",
     resource: "treasury",
     operation: "list",
@@ -5984,7 +5984,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/treasury/transactions/:id",
+    fastifyPath: "/v1/treasury/transactions/:id",
     stripePath: "/v1/treasury/transactions/{id}",
     resource: "treasury",
     operation: "retrieve",
@@ -5994,7 +5994,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/webhook_endpoints",
+    fastifyPath: "/v1/webhook_endpoints",
     stripePath: "/v1/webhook_endpoints",
     resource: "webhook_endpoints",
     operation: "list",
@@ -6004,7 +6004,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/webhook_endpoints",
+    fastifyPath: "/v1/webhook_endpoints",
     stripePath: "/v1/webhook_endpoints",
     resource: "webhook_endpoints",
     operation: "create",
@@ -6014,7 +6014,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v1/webhook_endpoints/:webhook_endpoint",
+    fastifyPath: "/v1/webhook_endpoints/:webhook_endpoint",
     stripePath: "/v1/webhook_endpoints/{webhook_endpoint}",
     resource: "webhook_endpoints",
     operation: "retrieve",
@@ -6025,7 +6025,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v1/webhook_endpoints/:webhook_endpoint",
+    fastifyPath: "/v1/webhook_endpoints/:webhook_endpoint",
     stripePath: "/v1/webhook_endpoints/{webhook_endpoint}",
     resource: "webhook_endpoints",
     operation: "update",
@@ -6036,7 +6036,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v1/webhook_endpoints/:webhook_endpoint",
+    fastifyPath: "/v1/webhook_endpoints/:webhook_endpoint",
     stripePath: "/v1/webhook_endpoints/{webhook_endpoint}",
     resource: "webhook_endpoints",
     operation: "delete",
@@ -6047,7 +6047,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/billing/meter_event_adjustments",
+    fastifyPath: "/v2/billing/meter_event_adjustments",
     stripePath: "/v2/billing/meter_event_adjustments",
     resource: "billing",
     operation: "create",
@@ -6056,7 +6056,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/billing/meter_event_session",
+    fastifyPath: "/v2/billing/meter_event_session",
     stripePath: "/v2/billing/meter_event_session",
     resource: "billing",
     operation: "create",
@@ -6065,7 +6065,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/billing/meter_event_stream",
+    fastifyPath: "/v2/billing/meter_event_stream",
     stripePath: "/v2/billing/meter_event_stream",
     resource: "billing",
     operation: "create",
@@ -6074,7 +6074,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/billing/meter_events",
+    fastifyPath: "/v2/billing/meter_events",
     stripePath: "/v2/billing/meter_events",
     resource: "billing",
     operation: "create",
@@ -6083,7 +6083,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/account_links",
+    fastifyPath: "/v2/core/account_links",
     stripePath: "/v2/core/account_links",
     resource: "account_links",
     operation: "create",
@@ -6093,7 +6093,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/account_tokens",
+    fastifyPath: "/v2/core/account_tokens",
     stripePath: "/v2/core/account_tokens",
     resource: "core",
     operation: "create",
@@ -6102,7 +6102,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/account_tokens/:id",
+    fastifyPath: "/v2/core/account_tokens/:id",
     stripePath: "/v2/core/account_tokens/{id}",
     resource: "core",
     operation: "retrieve",
@@ -6112,7 +6112,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/accounts",
+    fastifyPath: "/v2/core/accounts",
     stripePath: "/v2/core/accounts",
     resource: "core",
     operation: "list",
@@ -6121,7 +6121,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts",
+    fastifyPath: "/v2/core/accounts",
     stripePath: "/v2/core/accounts",
     resource: "core",
     operation: "create",
@@ -6130,7 +6130,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/person_tokens",
+    fastifyPath: "/v2/core/accounts/:account_id/person_tokens",
     stripePath: "/v2/core/accounts/{account_id}/person_tokens",
     resource: "core",
     operation: "create",
@@ -6140,7 +6140,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/person_tokens/:id",
+    fastifyPath: "/v2/core/accounts/:account_id/person_tokens/:id",
     stripePath: "/v2/core/accounts/{account_id}/person_tokens/{id}",
     resource: "core",
     operation: "retrieve",
@@ -6150,7 +6150,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/persons",
+    fastifyPath: "/v2/core/accounts/:account_id/persons",
     stripePath: "/v2/core/accounts/{account_id}/persons",
     resource: "persons",
     operation: "list",
@@ -6161,7 +6161,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/persons",
+    fastifyPath: "/v2/core/accounts/:account_id/persons",
     stripePath: "/v2/core/accounts/{account_id}/persons",
     resource: "persons",
     operation: "create",
@@ -6172,7 +6172,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/persons/:id",
+    fastifyPath: "/v2/core/accounts/:account_id/persons/:id",
     stripePath: "/v2/core/accounts/{account_id}/persons/{id}",
     resource: "persons",
     operation: "retrieve",
@@ -6183,7 +6183,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/persons/:id",
+    fastifyPath: "/v2/core/accounts/:account_id/persons/:id",
     stripePath: "/v2/core/accounts/{account_id}/persons/{id}",
     resource: "persons",
     operation: "update",
@@ -6194,7 +6194,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v2/core/accounts/:account_id/persons/:id",
+    fastifyPath: "/v2/core/accounts/:account_id/persons/:id",
     stripePath: "/v2/core/accounts/{account_id}/persons/{id}",
     resource: "persons",
     operation: "delete",
@@ -6205,7 +6205,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/accounts/:id",
+    fastifyPath: "/v2/core/accounts/:id",
     stripePath: "/v2/core/accounts/{id}",
     resource: "core",
     operation: "retrieve",
@@ -6215,7 +6215,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts/:id",
+    fastifyPath: "/v2/core/accounts/:id",
     stripePath: "/v2/core/accounts/{id}",
     resource: "core",
     operation: "update",
@@ -6225,7 +6225,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/accounts/:id/close",
+    fastifyPath: "/v2/core/accounts/:id/close",
     stripePath: "/v2/core/accounts/{id}/close",
     resource: "core",
     operation: "create",
@@ -6235,7 +6235,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/event_destinations",
+    fastifyPath: "/v2/core/event_destinations",
     stripePath: "/v2/core/event_destinations",
     resource: "core",
     operation: "list",
@@ -6244,7 +6244,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/event_destinations",
+    fastifyPath: "/v2/core/event_destinations",
     stripePath: "/v2/core/event_destinations",
     resource: "core",
     operation: "create",
@@ -6253,7 +6253,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id",
+    fastifyPath: "/v2/core/event_destinations/:id",
     stripePath: "/v2/core/event_destinations/{id}",
     resource: "core",
     operation: "retrieve",
@@ -6263,7 +6263,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id",
+    fastifyPath: "/v2/core/event_destinations/:id",
     stripePath: "/v2/core/event_destinations/{id}",
     resource: "core",
     operation: "update",
@@ -6273,7 +6273,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id",
+    fastifyPath: "/v2/core/event_destinations/:id",
     stripePath: "/v2/core/event_destinations/{id}",
     resource: "core",
     operation: "delete",
@@ -6283,7 +6283,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id/disable",
+    fastifyPath: "/v2/core/event_destinations/:id/disable",
     stripePath: "/v2/core/event_destinations/{id}/disable",
     resource: "core",
     operation: "create",
@@ -6293,7 +6293,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id/enable",
+    fastifyPath: "/v2/core/event_destinations/:id/enable",
     stripePath: "/v2/core/event_destinations/{id}/enable",
     resource: "core",
     operation: "create",
@@ -6303,7 +6303,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/stripe/v2/core/event_destinations/:id/ping",
+    fastifyPath: "/v2/core/event_destinations/:id/ping",
     stripePath: "/v2/core/event_destinations/{id}/ping",
     resource: "core",
     operation: "create",
@@ -6313,7 +6313,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/events",
+    fastifyPath: "/v2/core/events",
     stripePath: "/v2/core/events",
     resource: "events",
     operation: "list",
@@ -6323,7 +6323,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/stripe/v2/core/events/:id",
+    fastifyPath: "/v2/core/events/:id",
     stripePath: "/v2/core/events/{id}",
     resource: "events",
     operation: "retrieve",

--- a/packages/adapters/adapter-stripe/src/mcp.ts
+++ b/packages/adapters/adapter-stripe/src/mcp.ts
@@ -50,13 +50,13 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
 
   // 1. get_stripe_account_info
   server.tool('get_stripe_account_info', 'Get information about the connected Stripe account', {}, async () => {
-    const data = await call('GET', '/stripe/v1/account') as any;
+    const data = await call('GET', '/v1/account') as any;
     return text(`Account ${data.id}: ${data.business_type}, ${data.country}, charges_enabled=${data.charges_enabled}`);
   });
 
   // 2. retrieve_balance
   server.tool('retrieve_balance', 'Retrieve the current Stripe account balance', {}, async () => {
-    const data = await call('GET', '/stripe/v1/balance') as any;
+    const data = await call('GET', '/v1/balance') as any;
     const fmtLine = (entry: any) => `${(entry.amount / 100).toFixed(2)} ${entry.currency}`;
     const avail = data.available?.map(fmtLine).join(', ') || 'none';
     const pending = data.pending?.map(fmtLine).join(', ') || 'none';
@@ -73,14 +73,14 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     max_redemptions: z.number().int().positive().optional().describe('Max number of times coupon can be redeemed'),
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/coupons', params) as any;
+    const data = await call('POST', '/v1/coupons', params) as any;
     const desc = data.percent_off ? `${data.percent_off}% off` : `${(data.amount_off / 100).toFixed(2)} ${data.currency} off`;
     return text(`Created coupon ${data.id}: ${desc} (${data.duration})`);
   });
 
   // 4. list_coupons
   server.tool('list_coupons', 'List all coupons', {}, async () => {
-    const data = await call('GET', '/stripe/v1/coupons') as any;
+    const data = await call('GET', '/v1/coupons') as any;
     if (!data.data?.length) return text('No coupons found.');
     const lines = data.data.map((c: any) => {
       const desc = c.percent_off ? `${c.percent_off}% off` : `${(c.amount_off / 100).toFixed(2)} ${c.currency} off`;
@@ -97,7 +97,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     description: z.string().optional().describe('Internal description'),
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/customers', params) as any;
+    const data = await call('POST', '/v1/customers', params) as any;
     return text(`Created customer ${data.id}: ${data.name ?? data.email ?? '(no name)'}`);
   });
 
@@ -106,7 +106,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     email: z.string().optional().describe('Filter by email address'),
     limit: z.number().int().min(1).max(100).optional().describe('Max results (default 10)'),
   }, async ({ email, limit }) => {
-    const data = await call('GET', `/stripe/v1/customers${qs({ email, limit: limit ?? 10 })}`) as any;
+    const data = await call('GET', `/v1/customers${qs({ email, limit: limit ?? 10 })}`) as any;
     if (!data.data?.length) return text('No customers found.');
     const lines = data.data.map((c: any) => `• ${c.id} — ${c.name ?? '(no name)'} (${c.email ?? 'no email'})`);
     return text(`Customers (${data.data.length}):\n${lines.join('\n')}`);
@@ -114,7 +114,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
 
   // 7. list_disputes
   server.tool('list_disputes', 'List all disputes', {}, async () => {
-    const data = await call('GET', '/stripe/v1/disputes') as any;
+    const data = await call('GET', '/v1/disputes') as any;
     if (!data.data?.length) return text('No disputes found.');
     const lines = data.data.map((d: any) => `• ${d.id} — ${(d.amount / 100).toFixed(2)} ${d.currency} [${d.status}]`);
     return text(`Disputes (${data.data.length}):\n${lines.join('\n')}`);
@@ -126,7 +126,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     evidence: z.record(z.string()).optional().describe('Evidence to submit'),
     metadata: z.record(z.string()).optional().describe('Metadata to update'),
   }, async ({ dispute_id, evidence, metadata }) => {
-    const data = await call('POST', `/stripe/v1/disputes/${dispute_id}`, { evidence, metadata }) as any;
+    const data = await call('POST', `/v1/disputes/${dispute_id}`, { evidence, metadata }) as any;
     return text(`Updated dispute ${data.id} [${data.status}]`);
   });
 
@@ -136,7 +136,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     description: z.string().optional().describe('Description'),
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/invoices', params) as any;
+    const data = await call('POST', '/v1/invoices', params) as any;
     return text(`Created invoice ${data.id} [${data.status}]`);
   });
 
@@ -150,7 +150,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     price: z.string().optional().describe('Price ID to use'),
     quantity: z.number().int().positive().optional().describe('Quantity'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/invoiceitems', params) as any;
+    const data = await call('POST', '/v1/invoiceitems', params) as any;
     return text(`Created invoice item ${data.id} for customer ${data.customer}`);
   });
 
@@ -158,7 +158,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('finalize_invoice', 'Finalize a draft invoice so it can be paid', {
     invoice_id: z.string().describe('Invoice ID to finalize'),
   }, async ({ invoice_id }) => {
-    const data = await call('POST', `/stripe/v1/invoices/${invoice_id}/finalize`) as any;
+    const data = await call('POST', `/v1/invoices/${invoice_id}/finalize`) as any;
     return text(`Finalized invoice ${data.id} [${data.status}]`);
   });
 
@@ -167,7 +167,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     customer: z.string().optional().describe('Filter by customer ID'),
     status: z.enum(['draft', 'open', 'paid', 'uncollectible', 'void']).optional().describe('Filter by status'),
   }, async ({ customer, status }) => {
-    const data = await call('GET', `/stripe/v1/invoices${qs({ customer, status })}`) as any;
+    const data = await call('GET', `/v1/invoices${qs({ customer, status })}`) as any;
     if (!data.data?.length) return text('No invoices found.');
     const lines = data.data.map((inv: any) => `• ${inv.id} — customer ${inv.customer} [${inv.status}]`);
     return text(`Invoices (${data.data.length}):\n${lines.join('\n')}`);
@@ -181,7 +181,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     })).describe('Line items for the payment link'),
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/payment_links', params) as any;
+    const data = await call('POST', '/v1/payment_links', params) as any;
     return text(`Created payment link ${data.id}: ${data.url}`);
   });
 
@@ -190,7 +190,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     customer: z.string().optional().describe('Filter by customer ID'),
     limit: z.number().int().min(1).max(100).optional().describe('Max results'),
   }, async ({ customer, limit }) => {
-    const data = await call('GET', `/stripe/v1/payment_intents${qs({ customer, limit })}`) as any;
+    const data = await call('GET', `/v1/payment_intents${qs({ customer, limit })}`) as any;
     if (!data.data?.length) return text('No payment intents found.');
     const lines = data.data.map((pi: any) => `• ${pi.id} — ${(pi.amount / 100).toFixed(2)} ${pi.currency} [${pi.status}]`);
     return text(`Payment intents (${data.data.length}):\n${lines.join('\n')}`);
@@ -206,7 +206,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
       interval_count: z.number().int().positive().optional(),
     }).optional().describe('Recurring billing config (omit for one-time prices)'),
   }, async ({ unit_amount, currency, product, recurring }) => {
-    const data = await call('POST', '/stripe/v1/prices', { unit_amount, currency, product, recurring }) as any;
+    const data = await call('POST', '/v1/prices', { unit_amount, currency, product, recurring }) as any;
     return text(`Created price ${data.id}`);
   });
 
@@ -214,7 +214,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('list_prices', 'List prices', {
     product: z.string().optional().describe('Filter by product ID'),
   }, async ({ product }) => {
-    const data = await call('GET', `/stripe/v1/prices${qs({ product })}`) as any;
+    const data = await call('GET', `/v1/prices${qs({ product })}`) as any;
     if (!data.data?.length) return text('No prices found.');
     const lines = data.data.map((p: any) => `• ${p.id} — ${(p.unit_amount / 100).toFixed(2)} ${p.currency}`);
     return text(`Prices (${data.data.length}):\n${lines.join('\n')}`);
@@ -226,13 +226,13 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     description: z.string().optional().describe('Product description'),
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/products', params) as any;
+    const data = await call('POST', '/v1/products', params) as any;
     return text(`Created product ${data.id}: ${data.name}`);
   });
 
   // 18. list_products
   server.tool('list_products', 'List products', {}, async () => {
-    const data = await call('GET', '/stripe/v1/products') as any;
+    const data = await call('GET', '/v1/products') as any;
     if (!data.data?.length) return text('No products found.');
     const lines = data.data.map((p: any) => `• ${p.id} — ${p.name} (${p.active ? 'active' : 'inactive'})`);
     return text(`Products (${data.data.length}):\n${lines.join('\n')}`);
@@ -245,7 +245,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     amount: z.number().int().positive().optional().describe('Amount to refund (full refund if omitted)'),
     reason: z.enum(['duplicate', 'fraudulent', 'requested_by_customer']).optional().describe('Reason for the refund'),
   }, async ({ payment_intent, charge, amount, reason }) => {
-    const data = await call('POST', '/stripe/v1/refunds', { payment_intent, charge, amount, reason }) as any;
+    const data = await call('POST', '/v1/refunds', { payment_intent, charge, amount, reason }) as any;
     return text(`Created refund ${data.id}`);
   });
 
@@ -253,7 +253,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('cancel_subscription', 'Cancel a subscription', {
     subscription_id: z.string().describe('Subscription ID to cancel'),
   }, async ({ subscription_id }) => {
-    const data = await call('DELETE', `/stripe/v1/subscriptions/${subscription_id}`) as any;
+    const data = await call('DELETE', `/v1/subscriptions/${subscription_id}`) as any;
     return text(`Cancelled subscription ${data.id}`);
   });
 
@@ -262,7 +262,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     customer: z.string().optional().describe('Filter by customer ID'),
     status: z.enum(['active', 'past_due', 'canceled', 'unpaid', 'trialing']).optional().describe('Filter by status'),
   }, async ({ customer, status }) => {
-    const data = await call('GET', `/stripe/v1/subscriptions${qs({ customer, status })}`) as any;
+    const data = await call('GET', `/v1/subscriptions${qs({ customer, status })}`) as any;
     if (!data.data?.length) return text('No subscriptions found.');
     const lines = data.data.map((s: any) => `• ${s.id} — customer ${s.customer} [${s.status}]`);
     return text(`Subscriptions (${data.data.length}):\n${lines.join('\n')}`);
@@ -274,7 +274,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     cancel_at_period_end: z.boolean().optional().describe('Cancel at end of billing period'),
     metadata: z.record(z.string()).optional().describe('Metadata to update'),
   }, async ({ subscription_id, ...rest }) => {
-    const data = await call('POST', `/stripe/v1/subscriptions/${subscription_id}`, rest) as any;
+    const data = await call('POST', `/v1/subscriptions/${subscription_id}`, rest) as any;
     return text(`Updated subscription ${data.id} [${data.status}]`);
   });
 
@@ -283,7 +283,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     customer: z.string().describe('Customer ID'),
     return_url: z.string().optional().describe('URL to redirect to after portal session'),
   }, async (params) => {
-    const data = await call('POST', '/stripe/v1/billing_portal/sessions', params) as any;
+    const data = await call('POST', '/v1/billing_portal/sessions', params) as any;
     return text(`Created billing portal session ${data.id}: ${data.url}`);
   });
 
@@ -297,8 +297,8 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
 
     for (const type of types) {
       const path = type === 'payment_intents'
-        ? '/stripe/v1/payment_intents'
-        : `/stripe/v1/${type}`;
+        ? '/v1/payment_intents'
+        : `/v1/${type}`;
       try {
         const data = await call('GET', path) as any;
         if (!data.data?.length) continue;
@@ -324,7 +324,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     ]).describe('The type of resource to fetch'),
     resource_id: z.string().describe('The ID of the resource'),
   }, async ({ resource_type, resource_id }) => {
-    const path = `/stripe/v1/${resource_type}/${resource_id}`;
+    const path = `/v1/${resource_type}/${resource_id}`;
     const data = await call('GET', path) as any;
     return text(JSON.stringify(data, null, 2));
   });
@@ -357,7 +357,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     metadata: z.record(z.string()).optional().describe('Arbitrary key-value metadata'),
   }, async ({ amount, currency, customer, description, metadata }) => {
     const cur = currency ?? 'usd';
-    const data = await call('POST', '/stripe/v1/payment_intents', { amount, currency: cur, customer, description, metadata }) as any;
+    const data = await call('POST', '/v1/payment_intents', { amount, currency: cur, customer, description, metadata }) as any;
     return text(`Created payment intent ${data.id} for ${(data.amount / 100).toFixed(2)} ${data.currency}`);
   });
 
@@ -365,7 +365,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('confirm_payment_intent', 'Confirm a payment intent', {
     payment_intent_id: z.string().describe('Payment intent ID to confirm'),
   }, async ({ payment_intent_id }) => {
-    const data = await call('POST', `/stripe/v1/payment_intents/${payment_intent_id}/confirm`) as any;
+    const data = await call('POST', `/v1/payment_intents/${payment_intent_id}/confirm`) as any;
     return text(`Confirmed ${data.id}, status: ${data.status}`);
   });
 
@@ -375,7 +375,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
     amount_to_capture: z.number().int().positive().optional().describe('Amount to capture (captures full amount if omitted)'),
   }, async ({ payment_intent_id, amount_to_capture }) => {
     const body = amount_to_capture !== undefined ? { amount_to_capture } : undefined;
-    const data = await call('POST', `/stripe/v1/payment_intents/${payment_intent_id}/capture`, body) as any;
+    const data = await call('POST', `/v1/payment_intents/${payment_intent_id}/capture`, body) as any;
     return text(`Captured ${data.id}`);
   });
 
@@ -383,7 +383,7 @@ export function registerStripeTools(server: McpServer, baseUrl: string = 'http:/
   server.tool('cancel_payment_intent', 'Cancel a payment intent', {
     payment_intent_id: z.string().describe('Payment intent ID to cancel'),
   }, async ({ payment_intent_id }) => {
-    const data = await call('POST', `/stripe/v1/payment_intents/${payment_intent_id}/cancel`) as any;
+    const data = await call('POST', `/v1/payment_intents/${payment_intent_id}/cancel`) as any;
     return text(`Cancelled ${data.id}`);
   });
 }

--- a/packages/adapters/adapter-stripe/src/stripe-adapter.ts
+++ b/packages/adapters/adapter-stripe/src/stripe-adapter.ts
@@ -105,65 +105,65 @@ export class StripeAdapter extends OpenApiMockAdapter<StripeConfig> {
   private mountOverrides(store: StateStore): void {
     // ── Payment Intents ───────────────────────────────────────────────────────
     this.registerOverride(
-      'POST', '/stripe/v1/payment_intents/:intent/confirm',
+      'POST', '/v1/payment_intents/:intent/confirm',
       piOverrides.buildConfirmHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/payment_intents/:intent/capture',
+      'POST', '/v1/payment_intents/:intent/capture',
       piOverrides.buildCaptureHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/payment_intents/:intent/cancel',
+      'POST', '/v1/payment_intents/:intent/cancel',
       piOverrides.buildCancelHandler(store),
     );
 
     // ── Setup Intents ─────────────────────────────────────────────────────────
     this.registerOverride(
-      'POST', '/stripe/v1/setup_intents/:intent/confirm',
+      'POST', '/v1/setup_intents/:intent/confirm',
       siOverrides.buildConfirmHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/setup_intents/:intent/cancel',
+      'POST', '/v1/setup_intents/:intent/cancel',
       siOverrides.buildCancelHandler(store),
     );
 
     // ── Invoices ──────────────────────────────────────────────────────────────
     this.registerOverride(
-      'POST', '/stripe/v1/invoices/:invoice/finalize',
+      'POST', '/v1/invoices/:invoice/finalize',
       invOverrides.buildFinalizeHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/invoices/:invoice/pay',
+      'POST', '/v1/invoices/:invoice/pay',
       invOverrides.buildPayHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/invoices/:invoice/void',
+      'POST', '/v1/invoices/:invoice/void',
       invOverrides.buildVoidHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/invoices/:invoice/mark_uncollectible',
+      'POST', '/v1/invoices/:invoice/mark_uncollectible',
       invOverrides.buildMarkUncollectibleHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/invoices/:invoice/send',
+      'POST', '/v1/invoices/:invoice/send',
       invOverrides.buildSendHandler(store),
     );
 
     // ── Charges ───────────────────────────────────────────────────────────────
     this.registerOverride(
-      'POST', '/stripe/v1/charges/:charge/capture',
+      'POST', '/v1/charges/:charge/capture',
       chOverrides.buildCaptureHandler(store),
     );
 
     // ── Billing Portal ────────────────────────────────────────────────────────
     this.registerOverride(
-      'POST', '/stripe/v1/billing_portal/sessions',
+      'POST', '/v1/billing_portal/sessions',
       bpOverrides.buildCreateSessionHandler(store),
     );
 
     // ── Subscriptions — create converts items array to Stripe list format ────────
     this.registerOverride(
-      'POST', '/stripe/v1/subscriptions',
+      'POST', '/v1/subscriptions',
       async (req, reply) => {
         const body = (req.body ?? {}) as Record<string, unknown>;
         const now = unixNow();
@@ -215,7 +215,7 @@ export class StripeAdapter extends OpenApiMockAdapter<StripeConfig> {
 
     // ── Subscriptions — cancel returns updated object, not deleted stub ────────
     this.registerOverride(
-      'DELETE', '/stripe/v1/subscriptions/:subscription_exposed_id',
+      'DELETE', '/v1/subscriptions/:subscription_exposed_id',
       async (req, reply) => {
         const { subscription_exposed_id } = (req.params as { subscription_exposed_id: string });
         const sub = store.get<Record<string, unknown>>(ns('subscriptions'), subscription_exposed_id);
@@ -233,49 +233,49 @@ export class StripeAdapter extends OpenApiMockAdapter<StripeConfig> {
 
     // ── Refunds — sync charge.amount_refunded on create/cancel ───────────────
     this.registerOverride(
-      'POST', '/stripe/v1/refunds',
+      'POST', '/v1/refunds',
       refundOverrides.buildCreateHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/refunds/:refund/cancel',
+      'POST', '/v1/refunds/:refund/cancel',
       refundOverrides.buildCancelHandler(store),
     );
 
     // ── Payment Methods — attach/detach mutate existing PM, not create new ────
     this.registerOverride(
-      'POST', '/stripe/v1/payment_methods/:payment_method/attach',
+      'POST', '/v1/payment_methods/:payment_method/attach',
       pmOverrides.buildAttachHandler(store),
     );
     this.registerOverride(
-      'POST', '/stripe/v1/payment_methods/:payment_method/detach',
+      'POST', '/v1/payment_methods/:payment_method/detach',
       pmOverrides.buildDetachHandler(store),
     );
 
     // ── Customers — cascade-cancel subscriptions on delete ───────────────────
     this.registerOverride(
-      'DELETE', '/stripe/v1/customers/:customer',
+      'DELETE', '/v1/customers/:customer',
       custOverrides.buildDeleteHandler(store),
     );
 
     // ── Invoices — only draft invoices can be deleted ─────────────────────────
     this.registerOverride(
-      'DELETE', '/stripe/v1/invoices/:invoice',
+      'DELETE', '/v1/invoices/:invoice',
       invOverrides.buildDeleteHandler(store),
     );
 
     // ── Subscription Items — keep parent subscription.items in sync ───────────
     this.registerOverride(
-      'POST', '/stripe/v1/subscription_items',
+      'POST', '/v1/subscription_items',
       subItemOverrides.buildCreateHandler(store),
     );
     this.registerOverride(
-      'DELETE', '/stripe/v1/subscription_items/:item',
+      'DELETE', '/v1/subscription_items/:item',
       subItemOverrides.buildDeleteHandler(store),
     );
 
     // ── Balance — computed from store charges/refunds ─────────────────────────
     this.registerOverride(
-      'GET', '/stripe/v1/balance',
+      'GET', '/v1/balance',
       async (_req, reply) => {
         const charges = store.list<Record<string, unknown>>(ns('charges'));
         const refunds = store.list<Record<string, unknown>>(ns('refunds'));
@@ -300,7 +300,7 @@ export class StripeAdapter extends OpenApiMockAdapter<StripeConfig> {
 
     // ── Account — return first seeded account or domain-derived default ────────
     this.registerOverride(
-      'GET', '/stripe/v1/account',
+      'GET', '/v1/account',
       async (_req, reply) => {
         const accounts = store.list<Record<string, unknown>>(ns('accounts'));
         if (accounts.length > 0) {

--- a/packages/adapters/adapter-zuora/adapter.json
+++ b/packages/adapters/adapter-zuora/adapter.json
@@ -3,7 +3,7 @@
   "name": "Zuora API",
   "description": "Zuora API mock adapter for enterprise subscription management, orders, billing, invoicing, revenue recognition",
   "type": "api-mock",
-  "basePath": "/zuora/v1",
+  "basePath": "",
   "versions": ["v1"],
   "logoFile": "logo.svg",
   "documentationUrl": "https://developer.zuora.com/api-references/api/overview",

--- a/packages/adapters/adapter-zuora/scripts/zuora-codegen.ts
+++ b/packages/adapters/adapter-zuora/scripts/zuora-codegen.ts
@@ -683,8 +683,8 @@ function extractRoutes(spec: OaSpec): ExtractedRoute[] {
       const description = operation.summary ?? operation.operationId ?? '';
 
       // Convert {param-name} to :paramName for Fastify (camelCase — Fastify
-      // doesn't support hyphens in param names), prefix with /zuora
-      const fastifyPath = '/zuora' + specPath.replace(/\{([^}]+)\}/g, (_, p) => ':' + kebabToCamel(p));
+      // doesn't support hyphens in param names), 
+      const fastifyPath = specPath.replace(/\{([^}]+)\}/g, (_, p) => ':' + kebabToCamel(p));
 
       const resource = detectZuoraResource(specPath);
       const op = detectZuoraOperation(specPath, method);

--- a/packages/adapters/adapter-zuora/src/__tests__/zuora-adapter.test.ts
+++ b/packages/adapters/adapter-zuora/src/__tests__/zuora-adapter.test.ts
@@ -3,7 +3,7 @@ import { buildTestServer, type TestServer } from '@mimicai/adapter-sdk';
 import type { ExpandedData, Blueprint } from '@mimicai/core';
 import { ZuoraAdapter } from '../zuora-adapter.js';
 
-const BP = '/zuora/v1';
+const BP = '/v1';
 
 describe('ZuoraAdapter', () => {
   let ts: TestServer;
@@ -25,7 +25,7 @@ describe('ZuoraAdapter', () => {
       expect(adapter.id).toBe('zuora');
       expect(adapter.name).toBe('Zuora API');
       expect(adapter.type).toBe('api-mock');
-      expect(adapter.basePath).toBe('/zuora/v1');
+      expect(adapter.basePath).toBe('');
     });
   });
 

--- a/packages/adapters/adapter-zuora/src/generated/meta.ts
+++ b/packages/adapters/adapter-zuora/src/generated/meta.ts
@@ -1,6 +1,6 @@
 // !! AUTO-GENERATED — do not edit. Run: pnpm --filter @mimicai/adapter-zuora generate
 // Zuora OpenAPI spec version: 2026-03-06
-// Generated at: 2026-03-13T11:04:03.117Z
+// Generated at: 2026-03-20T11:08:32.352Z
 
 export const ZUORA_SPEC_VERSION = "2026-03-06";
-export const ZUORA_SPEC_GENERATED_AT = "2026-03-13T11:04:03.117Z";
+export const ZUORA_SPEC_GENERATED_AT = "2026-03-20T11:08:32.352Z";

--- a/packages/adapters/adapter-zuora/src/generated/routes.ts
+++ b/packages/adapters/adapter-zuora/src/generated/routes.ts
@@ -19,7 +19,7 @@ export interface GeneratedRoute {
 export const GENERATED_ROUTES: GeneratedRoute[] = [
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/product",
+    fastifyPath: "/v1/object/product",
     stripePath: "/v1/object/product",
     resource: "products",
     operation: "create",
@@ -29,7 +29,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/product/:id",
+    fastifyPath: "/v1/object/product/:id",
     stripePath: "/v1/object/product/{id}",
     resource: "products",
     operation: "retrieve",
@@ -40,7 +40,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/object/product/:id",
+    fastifyPath: "/v1/object/product/:id",
     stripePath: "/v1/object/product/{id}",
     resource: "products",
     operation: "update",
@@ -51,7 +51,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/object/product/:id",
+    fastifyPath: "/v1/object/product/:id",
     stripePath: "/v1/object/product/{id}",
     resource: "products",
     operation: "delete",
@@ -62,7 +62,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/catalog/products",
+    fastifyPath: "/v1/catalog/products",
     stripePath: "/v1/catalog/products",
     resource: "products",
     operation: "list",
@@ -72,7 +72,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/catalog/products/:productKey",
+    fastifyPath: "/v1/catalog/products/:productKey",
     stripePath: "/v1/catalog/products/{product-key}",
     resource: "products",
     operation: "retrieve",
@@ -83,7 +83,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/catalog-groups",
+    fastifyPath: "/v1/catalog-groups",
     stripePath: "/v1/catalog-groups",
     resource: "catalog-groups",
     operation: "list",
@@ -93,7 +93,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/catalog-groups",
+    fastifyPath: "/v1/catalog-groups",
     stripePath: "/v1/catalog-groups",
     resource: "catalog-groups",
     operation: "create",
@@ -103,7 +103,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/catalog-groups/:catalogGroupKey",
+    fastifyPath: "/v1/catalog-groups/:catalogGroupKey",
     stripePath: "/v1/catalog-groups/{catalog-group-key}",
     resource: "catalog-groups",
     operation: "retrieve",
@@ -114,7 +114,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/catalog-groups/:catalogGroupKey",
+    fastifyPath: "/v1/catalog-groups/:catalogGroupKey",
     stripePath: "/v1/catalog-groups/{catalog-group-key}",
     resource: "catalog-groups",
     operation: "update",
@@ -125,7 +125,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/catalog-groups/:catalogGroupKey",
+    fastifyPath: "/v1/catalog-groups/:catalogGroupKey",
     stripePath: "/v1/catalog-groups/{catalog-group-key}",
     resource: "catalog-groups",
     operation: "delete",
@@ -136,7 +136,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/products/:productKey/product-rate-plans",
+    fastifyPath: "/v1/products/:productKey/product-rate-plans",
     stripePath: "/v1/products/{product-key}/product-rate-plans",
     resource: "products",
     operation: "list",
@@ -147,7 +147,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-rate-plans/:id",
+    fastifyPath: "/v1/product-rate-plans/:id",
     stripePath: "/v1/product-rate-plans/{id}",
     resource: "product-rate-plans",
     operation: "retrieve",
@@ -158,7 +158,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-rate-plans/external-id/:id",
+    fastifyPath: "/v1/product-rate-plans/external-id/:id",
     stripePath: "/v1/product-rate-plans/external-id/{id}",
     resource: "product-rate-plans",
     operation: "retrieve",
@@ -169,7 +169,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/product-rate-plan",
+    fastifyPath: "/v1/object/product-rate-plan",
     stripePath: "/v1/object/product-rate-plan",
     resource: "product-rate-plans",
     operation: "create",
@@ -179,7 +179,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/product-rate-plan/:id",
+    fastifyPath: "/v1/object/product-rate-plan/:id",
     stripePath: "/v1/object/product-rate-plan/{id}",
     resource: "product-rate-plans",
     operation: "retrieve",
@@ -190,7 +190,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/object/product-rate-plan/:id",
+    fastifyPath: "/v1/object/product-rate-plan/:id",
     stripePath: "/v1/object/product-rate-plan/{id}",
     resource: "product-rate-plans",
     operation: "update",
@@ -201,7 +201,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/object/product-rate-plan/:id",
+    fastifyPath: "/v1/object/product-rate-plan/:id",
     stripePath: "/v1/object/product-rate-plan/{id}",
     resource: "product-rate-plans",
     operation: "delete",
@@ -212,7 +212,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-rateplan-definitions",
+    fastifyPath: "/v1/product-rateplan-definitions",
     stripePath: "/v1/product-rateplan-definitions",
     resource: "product-rateplan-definitions",
     operation: "list",
@@ -221,7 +221,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/product-rateplan-definitions",
+    fastifyPath: "/v1/product-rateplan-definitions",
     stripePath: "/v1/product-rateplan-definitions",
     resource: "product-rateplan-definitions",
     operation: "create",
@@ -230,7 +230,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-rateplan-definitions/:productRateplanDefinitionKey",
+    fastifyPath: "/v1/product-rateplan-definitions/:productRateplanDefinitionKey",
     stripePath: "/v1/product-rateplan-definitions/{product-rateplan-definition-key}",
     resource: "product-rateplan-definitions",
     operation: "retrieve",
@@ -240,7 +240,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/product-rateplan-definitions/:productRateplanDefinitionKey",
+    fastifyPath: "/v1/product-rateplan-definitions/:productRateplanDefinitionKey",
     stripePath: "/v1/product-rateplan-definitions/{product-rateplan-definition-key}",
     resource: "product-rateplan-definitions",
     operation: "delete",
@@ -250,7 +250,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-rate-plan-charges/:productRatePlanChargeKey",
+    fastifyPath: "/v1/product-rate-plan-charges/:productRatePlanChargeKey",
     stripePath: "/v1/product-rate-plan-charges/{product-rate-plan-charge-key}",
     resource: "product-rate-plan-charges",
     operation: "retrieve",
@@ -260,7 +260,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge",
+    fastifyPath: "/v1/object/product-rate-plan-charge",
     stripePath: "/v1/object/product-rate-plan-charge",
     resource: "product-rate-plan-charges",
     operation: "create",
@@ -269,7 +269,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge/:id",
+    fastifyPath: "/v1/object/product-rate-plan-charge/:id",
     stripePath: "/v1/object/product-rate-plan-charge/{id}",
     resource: "product-rate-plan-charges",
     operation: "retrieve",
@@ -279,7 +279,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge/:id",
+    fastifyPath: "/v1/object/product-rate-plan-charge/:id",
     stripePath: "/v1/object/product-rate-plan-charge/{id}",
     resource: "product-rate-plan-charges",
     operation: "update",
@@ -289,7 +289,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge/:id",
+    fastifyPath: "/v1/object/product-rate-plan-charge/:id",
     stripePath: "/v1/object/product-rate-plan-charge/{id}",
     resource: "product-rate-plan-charges",
     operation: "delete",
@@ -299,7 +299,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-charge-definitions",
+    fastifyPath: "/v1/product-charge-definitions",
     stripePath: "/v1/product-charge-definitions",
     resource: "product-charge-definitions",
     operation: "list",
@@ -308,7 +308,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/product-charge-definitions",
+    fastifyPath: "/v1/product-charge-definitions",
     stripePath: "/v1/product-charge-definitions",
     resource: "product-charge-definitions",
     operation: "create",
@@ -317,7 +317,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/product-charge-definitions/bulk",
+    fastifyPath: "/v1/product-charge-definitions/bulk",
     stripePath: "/v1/product-charge-definitions/bulk",
     resource: "product-charge-definitions",
     operation: "action",
@@ -326,7 +326,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/product-charge-definitions/bulk",
+    fastifyPath: "/v1/product-charge-definitions/bulk",
     stripePath: "/v1/product-charge-definitions/bulk",
     resource: "product-charge-definitions",
     operation: "action",
@@ -335,7 +335,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/product-charge-definitions/:productChargeDefinitionKey",
+    fastifyPath: "/v1/product-charge-definitions/:productChargeDefinitionKey",
     stripePath: "/v1/product-charge-definitions/{product-charge-definition-key}",
     resource: "product-charge-definitions",
     operation: "retrieve",
@@ -345,7 +345,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/product-charge-definitions/:productChargeDefinitionKey",
+    fastifyPath: "/v1/product-charge-definitions/:productChargeDefinitionKey",
     stripePath: "/v1/product-charge-definitions/{product-charge-definition-key}",
     resource: "product-charge-definitions",
     operation: "update",
@@ -355,7 +355,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/product-charge-definitions/:productChargeDefinitionKey",
+    fastifyPath: "/v1/product-charge-definitions/:productChargeDefinitionKey",
     stripePath: "/v1/product-charge-definitions/{product-charge-definition-key}",
     resource: "product-charge-definitions",
     operation: "delete",
@@ -365,7 +365,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge-tier/:id",
+    fastifyPath: "/v1/object/product-rate-plan-charge-tier/:id",
     stripePath: "/v1/object/product-rate-plan-charge-tier/{id}",
     resource: "object",
     operation: "retrieve",
@@ -375,7 +375,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/object/product-rate-plan-charge-tier/:id",
+    fastifyPath: "/v1/object/product-rate-plan-charge-tier/:id",
     stripePath: "/v1/object/product-rate-plan-charge-tier/{id}",
     resource: "object",
     operation: "update",
@@ -385,7 +385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/revpro-accounting-codes",
+    fastifyPath: "/v1/revpro-accounting-codes",
     stripePath: "/v1/revpro-accounting-codes",
     resource: "revpro-accounting-codes",
     operation: "action",
@@ -394,7 +394,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/accounts",
+    fastifyPath: "/v1/accounts",
     stripePath: "/v1/accounts",
     resource: "accounts",
     operation: "create",
@@ -404,7 +404,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/:accountKey",
+    fastifyPath: "/v1/accounts/:accountKey",
     stripePath: "/v1/accounts/{account-key}",
     resource: "accounts",
     operation: "retrieve",
@@ -415,7 +415,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounts/:accountKey",
+    fastifyPath: "/v1/accounts/:accountKey",
     stripePath: "/v1/accounts/{account-key}",
     resource: "accounts",
     operation: "update",
@@ -426,7 +426,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/accounts/:accountKey",
+    fastifyPath: "/v1/accounts/:accountKey",
     stripePath: "/v1/accounts/{account-key}",
     resource: "accounts",
     operation: "delete",
@@ -437,7 +437,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/:accountKey/payment-methods",
+    fastifyPath: "/v1/accounts/:accountKey/payment-methods",
     stripePath: "/v1/accounts/{account-key}/payment-methods",
     resource: "accounts",
     operation: "list",
@@ -448,7 +448,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/:accountKey/payment-methods/cascading",
+    fastifyPath: "/v1/accounts/:accountKey/payment-methods/cascading",
     stripePath: "/v1/accounts/{account-key}/payment-methods/cascading",
     resource: "accounts",
     operation: "list",
@@ -459,7 +459,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounts/:accountKey/payment-methods/cascading",
+    fastifyPath: "/v1/accounts/:accountKey/payment-methods/cascading",
     stripePath: "/v1/accounts/{account-key}/payment-methods/cascading",
     resource: "accounts",
     operation: "action",
@@ -470,7 +470,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/:accountKey/payment-methods/default",
+    fastifyPath: "/v1/accounts/:accountKey/payment-methods/default",
     stripePath: "/v1/accounts/{account-key}/payment-methods/default",
     resource: "accounts",
     operation: "list",
@@ -481,7 +481,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/:accountKey/summary",
+    fastifyPath: "/v1/accounts/:accountKey/summary",
     stripePath: "/v1/accounts/{account-key}/summary",
     resource: "accounts",
     operation: "list",
@@ -492,7 +492,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/contacts",
+    fastifyPath: "/v1/contacts",
     stripePath: "/v1/contacts",
     resource: "contacts",
     operation: "create",
@@ -502,7 +502,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/contacts/:contactId",
+    fastifyPath: "/v1/contacts/:contactId",
     stripePath: "/v1/contacts/{contactId}",
     resource: "contacts",
     operation: "retrieve",
@@ -513,7 +513,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/contacts/:contactId",
+    fastifyPath: "/v1/contacts/:contactId",
     stripePath: "/v1/contacts/{contactId}",
     resource: "contacts",
     operation: "update",
@@ -524,7 +524,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/contacts/:contactId",
+    fastifyPath: "/v1/contacts/:contactId",
     stripePath: "/v1/contacts/{contactId}",
     resource: "contacts",
     operation: "delete",
@@ -535,7 +535,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/contacts/:contactId/transfer",
+    fastifyPath: "/v1/contacts/:contactId/transfer",
     stripePath: "/v1/contacts/{contactId}/transfer",
     resource: "contacts",
     operation: "action",
@@ -546,7 +546,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/contacts/:contactId/scrub",
+    fastifyPath: "/v1/contacts/:contactId/scrub",
     stripePath: "/v1/contacts/{contactId}/scrub",
     resource: "contacts",
     operation: "action",
@@ -557,7 +557,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/contact-snapshots/:contactSnapshotId",
+    fastifyPath: "/v1/contact-snapshots/:contactSnapshotId",
     stripePath: "/v1/contact-snapshots/{contact-snapshot-id}",
     resource: "contact-snapshots",
     operation: "retrieve",
@@ -567,7 +567,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/sign-up",
+    fastifyPath: "/v1/sign-up",
     stripePath: "/v1/sign-up",
     resource: "sign-up",
     operation: "create",
@@ -576,7 +576,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/orders/preview",
+    fastifyPath: "/v1/orders/preview",
     stripePath: "/v1/orders/preview",
     resource: "orders",
     operation: "action",
@@ -586,7 +586,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/async/orders/preview",
+    fastifyPath: "/v1/async/orders/preview",
     stripePath: "/v1/async/orders/preview",
     resource: "async",
     operation: "action",
@@ -595,7 +595,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders",
+    fastifyPath: "/v1/orders",
     stripePath: "/v1/orders",
     resource: "orders",
     operation: "list",
@@ -605,7 +605,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/orders",
+    fastifyPath: "/v1/orders",
     stripePath: "/v1/orders",
     resource: "orders",
     operation: "create",
@@ -615,7 +615,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/async/orders",
+    fastifyPath: "/v1/async/orders",
     stripePath: "/v1/async/orders",
     resource: "async",
     operation: "create",
@@ -624,7 +624,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/:orderNumber",
+    fastifyPath: "/v1/orders/:orderNumber",
     stripePath: "/v1/orders/{orderNumber}",
     resource: "orders",
     operation: "retrieve",
@@ -635,7 +635,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orders/:orderNumber",
+    fastifyPath: "/v1/orders/:orderNumber",
     stripePath: "/v1/orders/{orderNumber}",
     resource: "orders",
     operation: "update",
@@ -646,7 +646,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/orders/:orderNumber",
+    fastifyPath: "/v1/orders/:orderNumber",
     stripePath: "/v1/orders/{orderNumber}",
     resource: "orders",
     operation: "delete",
@@ -657,7 +657,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/async/orders/:orderNumber",
+    fastifyPath: "/v1/async/orders/:orderNumber",
     stripePath: "/v1/async/orders/{orderNumber}",
     resource: "async",
     operation: "delete",
@@ -667,7 +667,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/async-jobs/:jobId",
+    fastifyPath: "/v1/async-jobs/:jobId",
     stripePath: "/v1/async-jobs/{jobId}",
     resource: "async-jobs",
     operation: "retrieve",
@@ -677,7 +677,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/subscriptionOwner/:accountNumber",
+    fastifyPath: "/v1/orders/subscriptionOwner/:accountNumber",
     stripePath: "/v1/orders/subscriptionOwner/{accountNumber}",
     resource: "orders",
     operation: "retrieve",
@@ -688,7 +688,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/subscription/:subscriptionNumber",
+    fastifyPath: "/v1/orders/subscription/:subscriptionNumber",
     stripePath: "/v1/orders/subscription/{subscriptionNumber}",
     resource: "orders",
     operation: "retrieve",
@@ -699,7 +699,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/invoiceOwner/:accountNumber",
+    fastifyPath: "/v1/orders/invoiceOwner/:accountNumber",
     stripePath: "/v1/orders/invoiceOwner/{accountNumber}",
     resource: "orders",
     operation: "retrieve",
@@ -710,7 +710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/customFields",
+    fastifyPath: "/v1/orders/:orderNumber/customFields",
     stripePath: "/v1/orders/{orderNumber}/customFields",
     resource: "orders",
     operation: "action",
@@ -721,7 +721,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionNumber/customFields",
+    fastifyPath: "/v1/subscriptions/:subscriptionNumber/customFields",
     stripePath: "/v1/subscriptions/{subscriptionNumber}/customFields",
     resource: "subscriptions",
     operation: "action",
@@ -732,7 +732,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/triggerDates",
+    fastifyPath: "/v1/orders/:orderNumber/triggerDates",
     stripePath: "/v1/orders/{orderNumber}/triggerDates",
     resource: "orders",
     operation: "action",
@@ -743,7 +743,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/activate",
+    fastifyPath: "/v1/orders/:orderNumber/activate",
     stripePath: "/v1/orders/{orderNumber}/activate",
     resource: "orders",
     operation: "action",
@@ -754,7 +754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/cancel",
+    fastifyPath: "/v1/orders/:orderNumber/cancel",
     stripePath: "/v1/orders/{orderNumber}/cancel",
     resource: "orders",
     operation: "action",
@@ -765,7 +765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/revert",
+    fastifyPath: "/v1/orders/:orderNumber/revert",
     stripePath: "/v1/orders/{orderNumber}/revert",
     resource: "orders",
     operation: "create",
@@ -776,7 +776,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/subscription/:subscriptionKey/pending",
+    fastifyPath: "/v1/orders/subscription/:subscriptionKey/pending",
     stripePath: "/v1/orders/subscription/{subscription-key}/pending",
     resource: "orders",
     operation: "list",
@@ -787,7 +787,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/orderActions/:id",
+    fastifyPath: "/v1/orderActions/:id",
     stripePath: "/v1/orderActions/{id}",
     resource: "orderActions",
     operation: "update",
@@ -797,7 +797,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/order-line-items/:itemId",
+    fastifyPath: "/v1/order-line-items/:itemId",
     stripePath: "/v1/order-line-items/{itemId}",
     resource: "order-line-items",
     operation: "retrieve",
@@ -808,7 +808,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/order-line-items/:itemId",
+    fastifyPath: "/v1/order-line-items/:itemId",
     stripePath: "/v1/order-line-items/{itemId}",
     resource: "order-line-items",
     operation: "update",
@@ -819,7 +819,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/order-line-items/bulk",
+    fastifyPath: "/v1/order-line-items/bulk",
     stripePath: "/v1/order-line-items/bulk",
     resource: "order-line-items",
     operation: "action",
@@ -829,7 +829,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/fulfillments",
+    fastifyPath: "/v1/fulfillments",
     stripePath: "/v1/fulfillments",
     resource: "fulfillments",
     operation: "create",
@@ -839,7 +839,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/fulfillments/:key",
+    fastifyPath: "/v1/fulfillments/:key",
     stripePath: "/v1/fulfillments/{key}",
     resource: "fulfillments",
     operation: "retrieve",
@@ -850,7 +850,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/fulfillments/:key",
+    fastifyPath: "/v1/fulfillments/:key",
     stripePath: "/v1/fulfillments/{key}",
     resource: "fulfillments",
     operation: "update",
@@ -861,7 +861,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/fulfillments/:key",
+    fastifyPath: "/v1/fulfillments/:key",
     stripePath: "/v1/fulfillments/{key}",
     resource: "fulfillments",
     operation: "delete",
@@ -872,7 +872,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/fulfillment-items",
+    fastifyPath: "/v1/fulfillment-items",
     stripePath: "/v1/fulfillment-items",
     resource: "fulfillment-items",
     operation: "create",
@@ -881,7 +881,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/fulfillment-items/:id",
+    fastifyPath: "/v1/fulfillment-items/:id",
     stripePath: "/v1/fulfillment-items/{id}",
     resource: "fulfillment-items",
     operation: "retrieve",
@@ -891,7 +891,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/fulfillment-items/:id",
+    fastifyPath: "/v1/fulfillment-items/:id",
     stripePath: "/v1/fulfillment-items/{id}",
     resource: "fulfillment-items",
     operation: "update",
@@ -901,7 +901,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/fulfillment-items/:id",
+    fastifyPath: "/v1/fulfillment-items/:id",
     stripePath: "/v1/fulfillment-items/{id}",
     resource: "fulfillment-items",
     operation: "delete",
@@ -911,7 +911,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/ramps/:rampNumber",
+    fastifyPath: "/v1/ramps/:rampNumber",
     stripePath: "/v1/ramps/{rampNumber}",
     resource: "ramps",
     operation: "retrieve",
@@ -921,7 +921,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/ramps/:rampNumber/ramp-metrics",
+    fastifyPath: "/v1/ramps/:rampNumber/ramp-metrics",
     stripePath: "/v1/ramps/{rampNumber}/ramp-metrics",
     resource: "ramps",
     operation: "list",
@@ -931,7 +931,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/ramps",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/ramps",
     stripePath: "/v1/subscriptions/{subscriptionKey}/ramps",
     resource: "subscriptions",
     operation: "list",
@@ -942,7 +942,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/ramp-metrics",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/ramp-metrics",
     stripePath: "/v1/subscriptions/{subscriptionKey}/ramp-metrics",
     resource: "subscriptions",
     operation: "list",
@@ -953,7 +953,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/orders/:orderNumber/ramp-metrics",
+    fastifyPath: "/v1/orders/:orderNumber/ramp-metrics",
     stripePath: "/v1/orders/{orderNumber}/ramp-metrics",
     resource: "orders",
     operation: "list",
@@ -964,7 +964,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/subscriptions/preview",
+    fastifyPath: "/v1/subscriptions/preview",
     stripePath: "/v1/subscriptions/preview",
     resource: "subscriptions",
     operation: "action",
@@ -974,7 +974,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/preview",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/preview",
     stripePath: "/v1/subscriptions/{subscription-key}/preview",
     resource: "subscriptions",
     operation: "action",
@@ -985,7 +985,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/subscriptions",
+    fastifyPath: "/v1/subscriptions",
     stripePath: "/v1/subscriptions",
     resource: "subscriptions",
     operation: "create",
@@ -995,7 +995,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/accounts/:accountKey",
+    fastifyPath: "/v1/subscriptions/accounts/:accountKey",
     stripePath: "/v1/subscriptions/accounts/{account-key}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1006,7 +1006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey",
     stripePath: "/v1/subscriptions/{subscription-key}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1017,7 +1017,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey",
     stripePath: "/v1/subscriptions/{subscription-key}",
     resource: "subscriptions",
     operation: "update",
@@ -1028,7 +1028,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/versions/:version",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/versions/:version",
     stripePath: "/v1/subscriptions/{subscription-key}/versions/{version}",
     resource: "subscriptions",
     operation: "retrieve",
@@ -1039,7 +1039,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/renew",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/renew",
     stripePath: "/v1/subscriptions/{subscription-key}/renew",
     resource: "subscriptions",
     operation: "action",
@@ -1050,7 +1050,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/cancel",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/cancel",
     stripePath: "/v1/subscriptions/{subscription-key}/cancel",
     resource: "subscriptions",
     operation: "action",
@@ -1061,7 +1061,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/resume",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/resume",
     stripePath: "/v1/subscriptions/{subscription-key}/resume",
     resource: "subscriptions",
     operation: "action",
@@ -1072,7 +1072,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/suspend",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/suspend",
     stripePath: "/v1/subscriptions/{subscription-key}/suspend",
     resource: "subscriptions",
     operation: "action",
@@ -1083,7 +1083,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionKey/delete",
+    fastifyPath: "/v1/subscriptions/:subscriptionKey/delete",
     stripePath: "/v1/subscriptions/{subscription-key}/delete",
     resource: "subscriptions",
     operation: "action",
@@ -1094,7 +1094,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/subscriptions/:subscriptionNumber/versions/:version/customFields",
+    fastifyPath: "/v1/subscriptions/:subscriptionNumber/versions/:version/customFields",
     stripePath: "/v1/subscriptions/{subscriptionNumber}/versions/{version}/customFields",
     resource: "subscriptions",
     operation: "action",
@@ -1105,7 +1105,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscriptions/subscription-metrics",
+    fastifyPath: "/v1/subscriptions/subscription-metrics",
     stripePath: "/v1/subscriptions/subscription-metrics",
     resource: "subscriptions",
     operation: "list",
@@ -1115,7 +1115,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/rateplans/:ratePlanId",
+    fastifyPath: "/v1/rateplans/:ratePlanId",
     stripePath: "/v1/rateplans/{ratePlanId}",
     resource: "rateplans",
     operation: "retrieve",
@@ -1125,7 +1125,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/omni-channel-subscriptions",
+    fastifyPath: "/v1/omni-channel-subscriptions",
     stripePath: "/v1/omni-channel-subscriptions",
     resource: "omni-channel-subscriptions",
     operation: "create",
@@ -1134,7 +1134,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/omni-channel-subscriptions/:subscriptionKey",
+    fastifyPath: "/v1/omni-channel-subscriptions/:subscriptionKey",
     stripePath: "/v1/omni-channel-subscriptions/{subscriptionKey}",
     resource: "omni-channel-subscriptions",
     operation: "retrieve",
@@ -1144,7 +1144,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/omni-channel-subscriptions/:subscriptionKey",
+    fastifyPath: "/v1/omni-channel-subscriptions/:subscriptionKey",
     stripePath: "/v1/omni-channel-subscriptions/{subscriptionKey}",
     resource: "omni-channel-subscriptions",
     operation: "delete",
@@ -1154,7 +1154,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscription-change-logs/:subscriptionNumber",
+    fastifyPath: "/v1/subscription-change-logs/:subscriptionNumber",
     stripePath: "/v1/subscription-change-logs/{subscriptionNumber}",
     resource: "subscription-change-logs",
     operation: "retrieve",
@@ -1164,7 +1164,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscription-change-logs/orders/:orderNumber",
+    fastifyPath: "/v1/subscription-change-logs/orders/:orderNumber",
     stripePath: "/v1/subscription-change-logs/orders/{orderNumber}",
     resource: "subscription-change-logs",
     operation: "retrieve",
@@ -1174,7 +1174,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/subscription-change-logs/:subscriptionNumber/versions/:version",
+    fastifyPath: "/v1/subscription-change-logs/:subscriptionNumber/versions/:version",
     stripePath: "/v1/subscription-change-logs/{subscriptionNumber}/versions/{version}",
     resource: "subscription-change-logs",
     operation: "retrieve",
@@ -1184,7 +1184,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/ppdd/reverse-rollover",
+    fastifyPath: "/v1/ppdd/reverse-rollover",
     stripePath: "/v1/ppdd/reverse-rollover",
     resource: "ppdd",
     operation: "create",
@@ -1193,7 +1193,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/ppdd/rollover",
+    fastifyPath: "/v1/ppdd/rollover",
     stripePath: "/v1/ppdd/rollover",
     resource: "ppdd",
     operation: "create",
@@ -1202,7 +1202,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/prepaid-balance-funds/deplete",
+    fastifyPath: "/v1/prepaid-balance-funds/deplete",
     stripePath: "/v1/prepaid-balance-funds/deplete",
     resource: "prepaid-balance-funds",
     operation: "create",
@@ -1211,7 +1211,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/usage",
+    fastifyPath: "/v1/usage",
     stripePath: "/v1/usage",
     resource: "usage",
     operation: "create",
@@ -1221,7 +1221,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/invoice-item/:invoiceItemId/usage-rate-detail",
+    fastifyPath: "/v1/invoices/invoice-item/:invoiceItemId/usage-rate-detail",
     stripePath: "/v1/invoices/invoice-item/{invoice-item-id}/usage-rate-detail",
     resource: "invoices",
     operation: "list",
@@ -1232,7 +1232,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/usage",
+    fastifyPath: "/v1/object/usage",
     stripePath: "/v1/object/usage",
     resource: "usage",
     operation: "create",
@@ -1242,7 +1242,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/usage/:id",
+    fastifyPath: "/v1/object/usage/:id",
     stripePath: "/v1/object/usage/{id}",
     resource: "usage",
     operation: "retrieve",
@@ -1253,7 +1253,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/object/usage/:id",
+    fastifyPath: "/v1/object/usage/:id",
     stripePath: "/v1/object/usage/{id}",
     resource: "usage",
     operation: "update",
@@ -1264,7 +1264,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/object/usage/:id",
+    fastifyPath: "/v1/object/usage/:id",
     stripePath: "/v1/object/usage/{id}",
     resource: "usage",
     operation: "delete",
@@ -1275,7 +1275,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/adjustments",
+    fastifyPath: "/v1/adjustments",
     stripePath: "/v1/adjustments",
     resource: "adjustments",
     operation: "list",
@@ -1285,7 +1285,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/adjustments",
+    fastifyPath: "/v1/adjustments",
     stripePath: "/v1/adjustments",
     resource: "adjustments",
     operation: "create",
@@ -1295,7 +1295,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/adjustments/preview",
+    fastifyPath: "/v1/adjustments/preview",
     stripePath: "/v1/adjustments/preview",
     resource: "adjustments",
     operation: "action",
@@ -1305,7 +1305,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/adjustments/:adjustmentKey",
+    fastifyPath: "/v1/adjustments/:adjustmentKey",
     stripePath: "/v1/adjustments/{adjustment-key}",
     resource: "adjustments",
     operation: "retrieve",
@@ -1316,7 +1316,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/adjustments/:adjustmentId/cancel",
+    fastifyPath: "/v1/adjustments/:adjustmentId/cancel",
     stripePath: "/v1/adjustments/{adjustmentId}/cancel",
     resource: "adjustments",
     operation: "action",
@@ -1327,7 +1327,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/billing-documents",
+    fastifyPath: "/v1/billing-documents",
     stripePath: "/v1/billing-documents",
     resource: "billing-documents",
     operation: "list",
@@ -1336,7 +1336,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/accounts/billing-documents/files/deletion-jobs",
+    fastifyPath: "/v1/accounts/billing-documents/files/deletion-jobs",
     stripePath: "/v1/accounts/billing-documents/files/deletion-jobs",
     resource: "accounts",
     operation: "create",
@@ -1346,7 +1346,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounts/billing-documents/files/deletion-jobs/:jobId",
+    fastifyPath: "/v1/accounts/billing-documents/files/deletion-jobs/:jobId",
     stripePath: "/v1/accounts/billing-documents/files/deletion-jobs/{jobId}",
     resource: "accounts",
     operation: "retrieve",
@@ -1357,7 +1357,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/accounts/:key/billing-documents/generate",
+    fastifyPath: "/v1/accounts/:key/billing-documents/generate",
     stripePath: "/v1/accounts/{key}/billing-documents/generate",
     resource: "accounts",
     operation: "action",
@@ -1368,7 +1368,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices",
+    fastifyPath: "/v1/invoices",
     stripePath: "/v1/invoices",
     resource: "invoices",
     operation: "create",
@@ -1378,7 +1378,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices",
+    fastifyPath: "/v1/invoices",
     stripePath: "/v1/invoices",
     resource: "invoices",
     operation: "action",
@@ -1388,7 +1388,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices/batch",
+    fastifyPath: "/v1/invoices/batch",
     stripePath: "/v1/invoices/batch",
     resource: "invoices",
     operation: "action",
@@ -1398,7 +1398,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices/bulk-post",
+    fastifyPath: "/v1/invoices/bulk-post",
     stripePath: "/v1/invoices/bulk-post",
     resource: "invoices",
     operation: "create",
@@ -1408,7 +1408,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/pdf-status",
+    fastifyPath: "/v1/invoices/pdf-status",
     stripePath: "/v1/invoices/pdf-status",
     resource: "invoices",
     operation: "action",
@@ -1418,7 +1418,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey",
+    fastifyPath: "/v1/invoices/:invoiceKey",
     stripePath: "/v1/invoices/{invoiceKey}",
     resource: "invoices",
     operation: "retrieve",
@@ -1429,7 +1429,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey",
+    fastifyPath: "/v1/invoices/:invoiceKey",
     stripePath: "/v1/invoices/{invoiceKey}",
     resource: "invoices",
     operation: "update",
@@ -1440,7 +1440,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey",
+    fastifyPath: "/v1/invoices/:invoiceKey",
     stripePath: "/v1/invoices/{invoiceKey}",
     resource: "invoices",
     operation: "delete",
@@ -1451,7 +1451,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/application-parts",
+    fastifyPath: "/v1/invoices/:invoiceKey/application-parts",
     stripePath: "/v1/invoices/{invoiceKey}/application-parts",
     resource: "invoices",
     operation: "list",
@@ -1462,7 +1462,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/emails",
+    fastifyPath: "/v1/invoices/:invoiceKey/emails",
     stripePath: "/v1/invoices/{invoiceKey}/emails",
     resource: "invoices",
     operation: "create",
@@ -1473,7 +1473,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/files",
+    fastifyPath: "/v1/invoices/:invoiceKey/files",
     stripePath: "/v1/invoices/{invoiceKey}/files",
     resource: "invoices",
     operation: "list",
@@ -1484,7 +1484,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/files",
+    fastifyPath: "/v1/invoices/:invoiceKey/files",
     stripePath: "/v1/invoices/{invoiceKey}/files",
     resource: "invoices",
     operation: "create",
@@ -1495,7 +1495,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/items",
+    fastifyPath: "/v1/invoices/:invoiceKey/items",
     stripePath: "/v1/invoices/{invoiceKey}/items",
     resource: "invoices",
     operation: "list",
@@ -1506,7 +1506,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/items/:itemId/taxation-items",
+    fastifyPath: "/v1/invoices/:invoiceKey/items/:itemId/taxation-items",
     stripePath: "/v1/invoices/{invoiceKey}/items/{itemId}/taxation-items",
     resource: "invoices",
     operation: "list",
@@ -1517,7 +1517,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/reverse",
+    fastifyPath: "/v1/invoices/:invoiceKey/reverse",
     stripePath: "/v1/invoices/{invoiceKey}/reverse",
     resource: "invoices",
     operation: "action",
@@ -1528,7 +1528,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/taxation-items",
+    fastifyPath: "/v1/invoices/:invoiceKey/taxation-items",
     stripePath: "/v1/invoices/{invoiceKey}/taxation-items",
     resource: "invoices",
     operation: "create",
@@ -1539,7 +1539,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/write-off",
+    fastifyPath: "/v1/invoices/:invoiceKey/write-off",
     stripePath: "/v1/invoices/{invoiceKey}/write-off",
     resource: "invoices",
     operation: "action",
@@ -1550,7 +1550,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos",
+    fastifyPath: "/v1/credit-memos",
     stripePath: "/v1/credit-memos",
     resource: "credit-memos",
     operation: "list",
@@ -1560,7 +1560,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos",
+    fastifyPath: "/v1/credit-memos",
     stripePath: "/v1/credit-memos",
     resource: "credit-memos",
     operation: "create",
@@ -1570,7 +1570,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/bulk",
+    fastifyPath: "/v1/credit-memos/bulk",
     stripePath: "/v1/credit-memos/bulk",
     resource: "credit-memos",
     operation: "action",
@@ -1580,7 +1580,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/bulk",
+    fastifyPath: "/v1/credit-memos/bulk",
     stripePath: "/v1/credit-memos/bulk",
     resource: "credit-memos",
     operation: "action",
@@ -1590,7 +1590,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/pdf-status",
+    fastifyPath: "/v1/credit-memos/pdf-status",
     stripePath: "/v1/credit-memos/pdf-status",
     resource: "credit-memos",
     operation: "action",
@@ -1600,7 +1600,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoId/items/:cmitemid/taxation-items",
+    fastifyPath: "/v1/credit-memos/:creditMemoId/items/:cmitemid/taxation-items",
     stripePath: "/v1/credit-memos/{creditMemoId}/items/{cmitemid}/taxation-items",
     resource: "credit-memos",
     operation: "list",
@@ -1611,7 +1611,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoId/write-off",
+    fastifyPath: "/v1/credit-memos/:creditMemoId/write-off",
     stripePath: "/v1/credit-memos/{creditMemoId}/write-off",
     resource: "credit-memos",
     operation: "action",
@@ -1622,7 +1622,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey",
     stripePath: "/v1/credit-memos/{creditMemoKey}",
     resource: "credit-memos",
     operation: "retrieve",
@@ -1633,7 +1633,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey",
     stripePath: "/v1/credit-memos/{creditMemoKey}",
     resource: "credit-memos",
     operation: "update",
@@ -1644,7 +1644,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey",
     stripePath: "/v1/credit-memos/{creditMemoKey}",
     resource: "credit-memos",
     operation: "delete",
@@ -1655,7 +1655,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/apply",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/apply",
     stripePath: "/v1/credit-memos/{creditMemoKey}/apply",
     resource: "credit-memos",
     operation: "action",
@@ -1666,7 +1666,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/cancel",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/cancel",
     stripePath: "/v1/credit-memos/{creditMemoKey}/cancel",
     resource: "credit-memos",
     operation: "action",
@@ -1677,7 +1677,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/emails",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/emails",
     stripePath: "/v1/credit-memos/{creditMemoKey}/emails",
     resource: "credit-memos",
     operation: "create",
@@ -1688,7 +1688,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/files",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/files",
     stripePath: "/v1/credit-memos/{creditMemoKey}/files",
     resource: "credit-memos",
     operation: "list",
@@ -1699,7 +1699,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/files",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/files",
     stripePath: "/v1/credit-memos/{creditMemoKey}/files",
     resource: "credit-memos",
     operation: "create",
@@ -1710,7 +1710,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/items",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/items",
     stripePath: "/v1/credit-memos/{creditMemoKey}/items",
     resource: "credit-memos",
     operation: "list",
@@ -1721,7 +1721,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/items/:cmitemid",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/items/:cmitemid",
     stripePath: "/v1/credit-memos/{creditMemoKey}/items/{cmitemid}",
     resource: "credit-memos",
     operation: "retrieve",
@@ -1732,7 +1732,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/parts",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/parts",
     stripePath: "/v1/credit-memos/{creditMemoKey}/parts",
     resource: "credit-memos",
     operation: "list",
@@ -1743,7 +1743,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/parts/:partid",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/parts/:partid",
     stripePath: "/v1/credit-memos/{creditMemoKey}/parts/{partid}",
     resource: "credit-memos",
     operation: "retrieve",
@@ -1754,7 +1754,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/pdfs",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/pdfs",
     stripePath: "/v1/credit-memos/{creditMemoKey}/pdfs",
     resource: "credit-memos",
     operation: "create",
@@ -1765,7 +1765,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/post",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/post",
     stripePath: "/v1/credit-memos/{creditMemoKey}/post",
     resource: "credit-memos",
     operation: "action",
@@ -1776,7 +1776,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/refund",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/refund",
     stripePath: "/v1/credit-memos/{creditMemoKey}/refund",
     resource: "credit-memos",
     operation: "action",
@@ -1787,7 +1787,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/reverse",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/reverse",
     stripePath: "/v1/credit-memos/{creditMemoKey}/reverse",
     resource: "credit-memos",
     operation: "action",
@@ -1798,7 +1798,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/taxation-items",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/taxation-items",
     stripePath: "/v1/credit-memos/{creditMemoKey}/taxation-items",
     resource: "credit-memos",
     operation: "create",
@@ -1809,7 +1809,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/unapply",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/unapply",
     stripePath: "/v1/credit-memos/{creditMemoKey}/unapply",
     resource: "credit-memos",
     operation: "action",
@@ -1820,7 +1820,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/unpost",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/unpost",
     stripePath: "/v1/credit-memos/{creditMemoKey}/unpost",
     resource: "credit-memos",
     operation: "action",
@@ -1831,7 +1831,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/credit-memos/invoice/:invoiceKey",
+    fastifyPath: "/v1/credit-memos/invoice/:invoiceKey",
     stripePath: "/v1/credit-memos/invoice/{invoiceKey}",
     resource: "credit-memos",
     operation: "create",
@@ -1842,7 +1842,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/unapply-async-jobs/:unapplyAsyncJobId",
+    fastifyPath: "/v1/credit-memos/unapply-async-jobs/:unapplyAsyncJobId",
     stripePath: "/v1/credit-memos/unapply-async-jobs/{unapplyAsyncJobId}",
     resource: "credit-memos",
     operation: "retrieve",
@@ -1853,7 +1853,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/apply-async-jobs/:applyAsyncJobId",
+    fastifyPath: "/v1/credit-memos/apply-async-jobs/:applyAsyncJobId",
     stripePath: "/v1/credit-memos/apply-async-jobs/{applyAsyncJobId}",
     resource: "credit-memos",
     operation: "retrieve",
@@ -1864,7 +1864,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/apply-async",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/apply-async",
     stripePath: "/v1/credit-memos/{creditMemoKey}/apply-async",
     resource: "credit-memos",
     operation: "action",
@@ -1875,7 +1875,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/unapply-async",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/unapply-async",
     stripePath: "/v1/credit-memos/{creditMemoKey}/unapply-async",
     resource: "credit-memos",
     operation: "action",
@@ -1886,7 +1886,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos",
+    fastifyPath: "/v1/debit-memos",
     stripePath: "/v1/debit-memos",
     resource: "debit-memos",
     operation: "list",
@@ -1896,7 +1896,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos",
+    fastifyPath: "/v1/debit-memos",
     stripePath: "/v1/debit-memos",
     resource: "debit-memos",
     operation: "create",
@@ -1906,7 +1906,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos",
+    fastifyPath: "/v1/debit-memos",
     stripePath: "/v1/debit-memos",
     resource: "debit-memos",
     operation: "action",
@@ -1916,7 +1916,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/bulk",
+    fastifyPath: "/v1/debit-memos/bulk",
     stripePath: "/v1/debit-memos/bulk",
     resource: "debit-memos",
     operation: "action",
@@ -1926,7 +1926,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/bulk",
+    fastifyPath: "/v1/debit-memos/bulk",
     stripePath: "/v1/debit-memos/bulk",
     resource: "debit-memos",
     operation: "action",
@@ -1936,7 +1936,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/pdf-status",
+    fastifyPath: "/v1/debit-memos/pdf-status",
     stripePath: "/v1/debit-memos/pdf-status",
     resource: "debit-memos",
     operation: "action",
@@ -1946,7 +1946,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoId/application-parts",
+    fastifyPath: "/v1/debit-memos/:debitMemoId/application-parts",
     stripePath: "/v1/debit-memos/{debitMemoId}/application-parts",
     resource: "debit-memos",
     operation: "list",
@@ -1957,7 +1957,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoId/items/:dmitemid/taxation-items",
+    fastifyPath: "/v1/debit-memos/:debitMemoId/items/:dmitemid/taxation-items",
     stripePath: "/v1/debit-memos/{debitMemoId}/items/{dmitemid}/taxation-items",
     resource: "debit-memos",
     operation: "list",
@@ -1968,7 +1968,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey",
     stripePath: "/v1/debit-memos/{debitMemoKey}",
     resource: "debit-memos",
     operation: "retrieve",
@@ -1979,7 +1979,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey",
     stripePath: "/v1/debit-memos/{debitMemoKey}",
     resource: "debit-memos",
     operation: "update",
@@ -1990,7 +1990,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey",
     stripePath: "/v1/debit-memos/{debitMemoKey}",
     resource: "debit-memos",
     operation: "delete",
@@ -2001,7 +2001,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/cancel",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/cancel",
     stripePath: "/v1/debit-memos/{debitMemoKey}/cancel",
     resource: "debit-memos",
     operation: "action",
@@ -2012,7 +2012,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/collect",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/collect",
     stripePath: "/v1/debit-memos/{debitMemoKey}/collect",
     resource: "debit-memos",
     operation: "action",
@@ -2023,7 +2023,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/emails",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/emails",
     stripePath: "/v1/debit-memos/{debitMemoKey}/emails",
     resource: "debit-memos",
     operation: "create",
@@ -2034,7 +2034,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/files",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/files",
     stripePath: "/v1/debit-memos/{debitMemoKey}/files",
     resource: "debit-memos",
     operation: "list",
@@ -2045,7 +2045,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/files",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/files",
     stripePath: "/v1/debit-memos/{debitMemoKey}/files",
     resource: "debit-memos",
     operation: "create",
@@ -2056,7 +2056,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/items",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/items",
     stripePath: "/v1/debit-memos/{debitMemoKey}/items",
     resource: "debit-memos",
     operation: "list",
@@ -2067,7 +2067,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/items/:dmitemid",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/items/:dmitemid",
     stripePath: "/v1/debit-memos/{debitMemoKey}/items/{dmitemid}",
     resource: "debit-memos",
     operation: "retrieve",
@@ -2078,7 +2078,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/pdfs",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/pdfs",
     stripePath: "/v1/debit-memos/{debitMemoKey}/pdfs",
     resource: "debit-memos",
     operation: "create",
@@ -2089,7 +2089,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/post",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/post",
     stripePath: "/v1/debit-memos/{debitMemoKey}/post",
     resource: "debit-memos",
     operation: "action",
@@ -2100,7 +2100,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/taxation-items",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/taxation-items",
     stripePath: "/v1/debit-memos/{debitMemoKey}/taxation-items",
     resource: "debit-memos",
     operation: "create",
@@ -2111,7 +2111,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/unpost",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/unpost",
     stripePath: "/v1/debit-memos/{debitMemoKey}/unpost",
     resource: "debit-memos",
     operation: "action",
@@ -2122,7 +2122,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/debit-memos/invoice/:invoiceKey",
+    fastifyPath: "/v1/debit-memos/invoice/:invoiceKey",
     stripePath: "/v1/debit-memos/invoice/{invoiceKey}",
     resource: "debit-memos",
     operation: "create",
@@ -2133,7 +2133,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/write-off",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/write-off",
     stripePath: "/v1/debit-memos/{debitMemoKey}/write-off",
     resource: "debit-memos",
     operation: "action",
@@ -2144,7 +2144,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/service-providers",
+    fastifyPath: "/v1/einvoice/service-providers",
     stripePath: "/v1/einvoice/service-providers",
     resource: "einvoice",
     operation: "list",
@@ -2153,7 +2153,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/einvoice/service-providers",
+    fastifyPath: "/v1/einvoice/service-providers",
     stripePath: "/v1/einvoice/service-providers",
     resource: "einvoice",
     operation: "create",
@@ -2162,7 +2162,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/service-providers/:key",
+    fastifyPath: "/v1/einvoice/service-providers/:key",
     stripePath: "/v1/einvoice/service-providers/{key}",
     resource: "einvoice",
     operation: "retrieve",
@@ -2172,7 +2172,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/einvoice/service-providers/:key",
+    fastifyPath: "/v1/einvoice/service-providers/:key",
     stripePath: "/v1/einvoice/service-providers/{key}",
     resource: "einvoice",
     operation: "update",
@@ -2182,7 +2182,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/einvoice/service-providers/:key",
+    fastifyPath: "/v1/einvoice/service-providers/:key",
     stripePath: "/v1/einvoice/service-providers/{key}",
     resource: "einvoice",
     operation: "delete",
@@ -2192,7 +2192,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/business-regions",
+    fastifyPath: "/v1/einvoice/business-regions",
     stripePath: "/v1/einvoice/business-regions",
     resource: "einvoice",
     operation: "list",
@@ -2201,7 +2201,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/einvoice/business-regions",
+    fastifyPath: "/v1/einvoice/business-regions",
     stripePath: "/v1/einvoice/business-regions",
     resource: "einvoice",
     operation: "create",
@@ -2210,7 +2210,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/business-regions/:key",
+    fastifyPath: "/v1/einvoice/business-regions/:key",
     stripePath: "/v1/einvoice/business-regions/{key}",
     resource: "einvoice",
     operation: "retrieve",
@@ -2220,7 +2220,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/einvoice/business-regions/:key",
+    fastifyPath: "/v1/einvoice/business-regions/:key",
     stripePath: "/v1/einvoice/business-regions/{key}",
     resource: "einvoice",
     operation: "update",
@@ -2230,7 +2230,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/einvoice/business-regions/:key",
+    fastifyPath: "/v1/einvoice/business-regions/:key",
     stripePath: "/v1/einvoice/business-regions/{key}",
     resource: "einvoice",
     operation: "delete",
@@ -2240,7 +2240,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/e-invoice/mandates",
+    fastifyPath: "/v1/e-invoice/mandates",
     stripePath: "/v1/e-invoice/mandates",
     resource: "e-invoice",
     operation: "list",
@@ -2249,7 +2249,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/e-invoice/mandate",
+    fastifyPath: "/v1/invoices/:invoiceKey/e-invoice/mandate",
     stripePath: "/v1/invoices/{invoiceKey}/e-invoice/mandate",
     resource: "invoices",
     operation: "list",
@@ -2260,7 +2260,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/e-invoice/mandate",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/e-invoice/mandate",
     stripePath: "/v1/credit-memos/{creditMemoKey}/e-invoice/mandate",
     resource: "credit-memos",
     operation: "list",
@@ -2271,7 +2271,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/e-invoice/mandate",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/e-invoice/mandate",
     stripePath: "/v1/debit-memos/{debitMemoKey}/e-invoice/mandate",
     resource: "debit-memos",
     operation: "list",
@@ -2282,7 +2282,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/e-invoice/download",
+    fastifyPath: "/v1/invoices/:invoiceKey/e-invoice/download",
     stripePath: "/v1/invoices/{invoiceKey}/e-invoice/download",
     resource: "invoices",
     operation: "list",
@@ -2293,7 +2293,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/e-invoice/download",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/e-invoice/download",
     stripePath: "/v1/credit-memos/{creditMemoKey}/e-invoice/download",
     resource: "credit-memos",
     operation: "list",
@@ -2304,7 +2304,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/e-invoice/download",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/e-invoice/download",
     stripePath: "/v1/debit-memos/{debitMemoKey}/e-invoice/download",
     resource: "debit-memos",
     operation: "list",
@@ -2315,7 +2315,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/e-invoice/cancel",
+    fastifyPath: "/v1/invoices/:invoiceKey/e-invoice/cancel",
     stripePath: "/v1/invoices/{invoiceKey}/e-invoice/cancel",
     resource: "invoices",
     operation: "action",
@@ -2326,7 +2326,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/templates",
+    fastifyPath: "/v1/einvoice/templates",
     stripePath: "/v1/einvoice/templates",
     resource: "einvoice",
     operation: "list",
@@ -2335,7 +2335,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/einvoice/templates",
+    fastifyPath: "/v1/einvoice/templates",
     stripePath: "/v1/einvoice/templates",
     resource: "einvoice",
     operation: "create",
@@ -2344,7 +2344,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/einvoice/templates/:key",
+    fastifyPath: "/v1/einvoice/templates/:key",
     stripePath: "/v1/einvoice/templates/{key}",
     resource: "einvoice",
     operation: "retrieve",
@@ -2354,7 +2354,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/einvoice/templates/:key",
+    fastifyPath: "/v1/einvoice/templates/:key",
     stripePath: "/v1/einvoice/templates/{key}",
     resource: "einvoice",
     operation: "update",
@@ -2364,7 +2364,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/einvoice/templates/:key",
+    fastifyPath: "/v1/einvoice/templates/:key",
     stripePath: "/v1/einvoice/templates/{key}",
     resource: "einvoice",
     operation: "delete",
@@ -2374,7 +2374,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/e-invoice/sync-status",
+    fastifyPath: "/v1/invoices/:invoiceKey/e-invoice/sync-status",
     stripePath: "/v1/invoices/{invoiceKey}/e-invoice/sync-status",
     resource: "invoices",
     operation: "action",
@@ -2385,7 +2385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/e-invoice/sync-status",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/e-invoice/sync-status",
     stripePath: "/v1/debit-memos/{debitMemoKey}/e-invoice/sync-status",
     resource: "debit-memos",
     operation: "action",
@@ -2396,7 +2396,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/e-invoice/sync-status",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/e-invoice/sync-status",
     stripePath: "/v1/credit-memos/{creditMemoKey}/e-invoice/sync-status",
     resource: "credit-memos",
     operation: "action",
@@ -2407,7 +2407,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoices/:invoiceKey/einvoice/generate",
+    fastifyPath: "/v1/invoices/:invoiceKey/einvoice/generate",
     stripePath: "/v1/invoices/{invoiceKey}/einvoice/generate",
     resource: "invoices",
     operation: "action",
@@ -2418,7 +2418,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/credit-memos/:creditMemoKey/e-invoice/generate",
+    fastifyPath: "/v1/credit-memos/:creditMemoKey/e-invoice/generate",
     stripePath: "/v1/credit-memos/{creditMemoKey}/e-invoice/generate",
     resource: "credit-memos",
     operation: "action",
@@ -2429,7 +2429,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/debit-memos/:debitMemoKey/e-invoice/generate",
+    fastifyPath: "/v1/debit-memos/:debitMemoKey/e-invoice/generate",
     stripePath: "/v1/debit-memos/{debitMemoKey}/e-invoice/generate",
     resource: "debit-memos",
     operation: "action",
@@ -2440,7 +2440,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoice-schedules",
+    fastifyPath: "/v1/invoice-schedules",
     stripePath: "/v1/invoice-schedules",
     resource: "invoice-schedules",
     operation: "create",
@@ -2450,7 +2450,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey",
     stripePath: "/v1/invoice-schedules/{scheduleKey}",
     resource: "invoice-schedules",
     operation: "retrieve",
@@ -2461,7 +2461,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey",
     stripePath: "/v1/invoice-schedules/{scheduleKey}",
     resource: "invoice-schedules",
     operation: "update",
@@ -2472,7 +2472,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey",
     stripePath: "/v1/invoice-schedules/{scheduleKey}",
     resource: "invoice-schedules",
     operation: "delete",
@@ -2483,7 +2483,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey/execute",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey/execute",
     stripePath: "/v1/invoice-schedules/{scheduleKey}/execute",
     resource: "invoice-schedules",
     operation: "action",
@@ -2494,7 +2494,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey/pause",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey/pause",
     stripePath: "/v1/invoice-schedules/{scheduleKey}/pause",
     resource: "invoice-schedules",
     operation: "action",
@@ -2505,7 +2505,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey/resume",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey/resume",
     stripePath: "/v1/invoice-schedules/{scheduleKey}/resume",
     resource: "invoice-schedules",
     operation: "action",
@@ -2516,7 +2516,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey/detach",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey/detach",
     stripePath: "/v1/invoice-schedules/{scheduleKey}/detach",
     resource: "invoice-schedules",
     operation: "action",
@@ -2527,7 +2527,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/invoice-schedules/:scheduleKey/attach",
+    fastifyPath: "/v1/invoice-schedules/:scheduleKey/attach",
     stripePath: "/v1/invoice-schedules/{scheduleKey}/attach",
     resource: "invoice-schedules",
     operation: "action",
@@ -2538,7 +2538,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/taxation-item",
+    fastifyPath: "/v1/object/taxation-item",
     stripePath: "/v1/object/taxation-item",
     resource: "object",
     operation: "create",
@@ -2547,7 +2547,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/taxation-items/:id",
+    fastifyPath: "/v1/taxation-items/:id",
     stripePath: "/v1/taxation-items/{id}",
     resource: "taxation-items",
     operation: "retrieve",
@@ -2557,7 +2557,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/taxation-items/:id",
+    fastifyPath: "/v1/taxation-items/:id",
     stripePath: "/v1/taxation-items/{id}",
     resource: "taxation-items",
     operation: "update",
@@ -2567,7 +2567,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/taxation-items/:id",
+    fastifyPath: "/v1/taxation-items/:id",
     stripePath: "/v1/taxation-items/{id}",
     resource: "taxation-items",
     operation: "delete",
@@ -2577,7 +2577,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/sequence-sets",
+    fastifyPath: "/v1/sequence-sets",
     stripePath: "/v1/sequence-sets",
     resource: "sequence-sets",
     operation: "list",
@@ -2587,7 +2587,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/sequence-sets",
+    fastifyPath: "/v1/sequence-sets",
     stripePath: "/v1/sequence-sets",
     resource: "sequence-sets",
     operation: "create",
@@ -2597,7 +2597,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/sequence-sets/:id",
+    fastifyPath: "/v1/sequence-sets/:id",
     stripePath: "/v1/sequence-sets/{id}",
     resource: "sequence-sets",
     operation: "retrieve",
@@ -2608,7 +2608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/sequence-sets/:id",
+    fastifyPath: "/v1/sequence-sets/:id",
     stripePath: "/v1/sequence-sets/{id}",
     resource: "sequence-sets",
     operation: "update",
@@ -2619,7 +2619,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/sequence-sets/:id",
+    fastifyPath: "/v1/sequence-sets/:id",
     stripePath: "/v1/sequence-sets/{id}",
     resource: "sequence-sets",
     operation: "delete",
@@ -2630,7 +2630,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/operations/billing-preview",
+    fastifyPath: "/v1/operations/billing-preview",
     stripePath: "/v1/operations/billing-preview",
     resource: "operations",
     operation: "create",
@@ -2639,7 +2639,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/operations/invoice-collect",
+    fastifyPath: "/v1/operations/invoice-collect",
     stripePath: "/v1/operations/invoice-collect",
     resource: "operations",
     operation: "create",
@@ -2648,7 +2648,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/operations/jobs/:jobId",
+    fastifyPath: "/v1/operations/jobs/:jobId",
     stripePath: "/v1/operations/jobs/{jobId}",
     resource: "operations",
     operation: "retrieve",
@@ -2658,7 +2658,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/operations/bulk-pdf",
+    fastifyPath: "/v1/operations/bulk-pdf",
     stripePath: "/v1/operations/bulk-pdf",
     resource: "operations",
     operation: "create",
@@ -2667,7 +2667,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/operations/bulk-pdf/:jobId",
+    fastifyPath: "/v1/operations/bulk-pdf/:jobId",
     stripePath: "/v1/operations/bulk-pdf/{jobId}",
     resource: "operations",
     operation: "retrieve",
@@ -2677,7 +2677,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/bill-runs",
+    fastifyPath: "/v1/bill-runs",
     stripePath: "/v1/bill-runs",
     resource: "bill-runs",
     operation: "create",
@@ -2687,7 +2687,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/bill-runs/:billRunId",
+    fastifyPath: "/v1/bill-runs/:billRunId",
     stripePath: "/v1/bill-runs/{billRunId}",
     resource: "bill-runs",
     operation: "retrieve",
@@ -2698,7 +2698,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/bill-runs/:billRunId",
+    fastifyPath: "/v1/bill-runs/:billRunId",
     stripePath: "/v1/bill-runs/{billRunId}",
     resource: "bill-runs",
     operation: "delete",
@@ -2709,7 +2709,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/bill-runs/:billRunId/cancel",
+    fastifyPath: "/v1/bill-runs/:billRunId/cancel",
     stripePath: "/v1/bill-runs/{billRunId}/cancel",
     resource: "bill-runs",
     operation: "action",
@@ -2720,7 +2720,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/bill-runs/:billRunId/post",
+    fastifyPath: "/v1/bill-runs/:billRunId/post",
     stripePath: "/v1/bill-runs/{billRunId}/post",
     resource: "bill-runs",
     operation: "action",
@@ -2731,7 +2731,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/bill-runs/:billRunKey/emails",
+    fastifyPath: "/v1/bill-runs/:billRunKey/emails",
     stripePath: "/v1/bill-runs/{billRunKey}/emails",
     resource: "bill-runs",
     operation: "create",
@@ -2742,7 +2742,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/billing-preview-runs",
+    fastifyPath: "/v1/billing-preview-runs",
     stripePath: "/v1/billing-preview-runs",
     resource: "billing-preview-runs",
     operation: "create",
@@ -2751,7 +2751,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/billing-preview-runs/:billingPreviewRunId",
+    fastifyPath: "/v1/billing-preview-runs/:billingPreviewRunId",
     stripePath: "/v1/billing-preview-runs/{billingPreviewRunId}",
     resource: "billing-preview-runs",
     operation: "retrieve",
@@ -2761,7 +2761,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods",
+    fastifyPath: "/v1/payment-methods",
     stripePath: "/v1/payment-methods",
     resource: "payment-methods",
     operation: "create",
@@ -2771,7 +2771,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/decryption",
+    fastifyPath: "/v1/payment-methods/decryption",
     stripePath: "/v1/payment-methods/decryption",
     resource: "payment-methods",
     operation: "create",
@@ -2781,7 +2781,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId",
     stripePath: "/v1/payment-methods/{payment-method-id}",
     resource: "payment-methods",
     operation: "retrieve",
@@ -2792,7 +2792,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId",
     stripePath: "/v1/payment-methods/{payment-method-id}",
     resource: "payment-methods",
     operation: "update",
@@ -2803,7 +2803,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId",
     stripePath: "/v1/payment-methods/{payment-method-id}",
     resource: "payment-methods",
     operation: "delete",
@@ -2814,7 +2814,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/verify",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/verify",
     stripePath: "/v1/payment-methods/{payment-method-id}/verify",
     resource: "payment-methods",
     operation: "action",
@@ -2825,7 +2825,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/scrub",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/scrub",
     stripePath: "/v1/payment-methods/{payment-method-id}/scrub",
     resource: "payment-methods",
     operation: "action",
@@ -2836,7 +2836,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/balance",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/balance",
     stripePath: "/v1/payment-methods/{payment-method-id}/balance",
     resource: "payment-methods",
     operation: "list",
@@ -2847,7 +2847,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/profiles",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/profiles",
     stripePath: "/v1/payment-methods/{payment-method-id}/profiles",
     resource: "payment-methods",
     operation: "list",
@@ -2858,7 +2858,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/profiles",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/profiles",
     stripePath: "/v1/payment-methods/{payment-method-id}/profiles",
     resource: "payment-methods",
     operation: "create",
@@ -2869,7 +2869,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/profiles/:profileNumber/cancel",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/profiles/:profileNumber/cancel",
     stripePath: "/v1/payment-methods/{payment-method-id}/profiles/{profile-number}/cancel",
     resource: "payment-methods",
     operation: "action",
@@ -2880,7 +2880,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/profiles/:profileNumber/expire",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/profiles/:profileNumber/expire",
     stripePath: "/v1/payment-methods/{payment-method-id}/profiles/{profile-number}/expire",
     resource: "payment-methods",
     operation: "create",
@@ -2891,7 +2891,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-methods/apple-pay/domains",
+    fastifyPath: "/v1/payment-methods/apple-pay/domains",
     stripePath: "/v1/payment-methods/apple-pay/domains",
     resource: "payment-methods",
     operation: "list",
@@ -2901,7 +2901,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/apple-pay/domains",
+    fastifyPath: "/v1/payment-methods/apple-pay/domains",
     stripePath: "/v1/payment-methods/apple-pay/domains",
     resource: "payment-methods",
     operation: "create",
@@ -2911,7 +2911,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payment-methods/apple-pay/domains/:id",
+    fastifyPath: "/v1/payment-methods/apple-pay/domains/:id",
     stripePath: "/v1/payment-methods/apple-pay/domains/{id}",
     resource: "payment-methods",
     operation: "delete",
@@ -2922,7 +2922,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/payment-method-snapshot/:id",
+    fastifyPath: "/v1/object/payment-method-snapshot/:id",
     stripePath: "/v1/object/payment-method-snapshot/{id}",
     resource: "object",
     operation: "retrieve",
@@ -2932,7 +2932,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/payment-method-transaction-log/:id",
+    fastifyPath: "/v1/object/payment-method-transaction-log/:id",
     stripePath: "/v1/object/payment-method-transaction-log/{id}",
     resource: "object",
     operation: "retrieve",
@@ -2942,7 +2942,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-method-updaters",
+    fastifyPath: "/v1/payment-method-updaters",
     stripePath: "/v1/payment-method-updaters",
     resource: "payment-method-updaters",
     operation: "list",
@@ -2951,7 +2951,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-method-updaters/batches",
+    fastifyPath: "/v1/payment-method-updaters/batches",
     stripePath: "/v1/payment-method-updaters/batches",
     resource: "payment-method-updaters",
     operation: "create",
@@ -2960,7 +2960,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/rsa-signatures",
+    fastifyPath: "/v1/rsa-signatures",
     stripePath: "/v1/rsa-signatures",
     resource: "rsa-signatures",
     operation: "create",
@@ -2969,7 +2969,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/rsa-signatures/decrypt",
+    fastifyPath: "/v1/rsa-signatures/decrypt",
     stripePath: "/v1/rsa-signatures/decrypt",
     resource: "rsa-signatures",
     operation: "create",
@@ -2978,7 +2978,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/hostedpages",
+    fastifyPath: "/v1/hostedpages",
     stripePath: "/v1/hostedpages",
     resource: "hostedpages",
     operation: "list",
@@ -2987,7 +2987,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/authorize",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/authorize",
     stripePath: "/v1/payment-methods/{payment-method-id}/authorize",
     resource: "payment-methods",
     operation: "create",
@@ -2998,7 +2998,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-methods/:paymentMethodId/voidAuthorize",
+    fastifyPath: "/v1/payment-methods/:paymentMethodId/voidAuthorize",
     stripePath: "/v1/payment-methods/{payment-method-id}/voidAuthorize",
     resource: "payment-methods",
     operation: "create",
@@ -3009,7 +3009,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/paymentgateways",
+    fastifyPath: "/v1/paymentgateways",
     stripePath: "/v1/paymentgateways",
     resource: "paymentgateways",
     operation: "list",
@@ -3018,7 +3018,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-gateways/pre-debit-notification",
+    fastifyPath: "/v1/payment-gateways/pre-debit-notification",
     stripePath: "/v1/payment-gateways/pre-debit-notification",
     resource: "payment-gateways",
     operation: "create",
@@ -3027,7 +3027,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/gateway-settlement/payments/:paymentKey/chargeback",
+    fastifyPath: "/v1/gateway-settlement/payments/:paymentKey/chargeback",
     stripePath: "/v1/gateway-settlement/payments/{payment-key}/chargeback",
     resource: "gateway-settlement",
     operation: "create",
@@ -3037,7 +3037,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/gateway-settlement/payments/:paymentKey/reject",
+    fastifyPath: "/v1/gateway-settlement/payments/:paymentKey/reject",
     stripePath: "/v1/gateway-settlement/payments/{payment-key}/reject",
     resource: "gateway-settlement",
     operation: "create",
@@ -3047,7 +3047,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/gateway-settlement/payments/:paymentKey/settle",
+    fastifyPath: "/v1/gateway-settlement/payments/:paymentKey/settle",
     stripePath: "/v1/gateway-settlement/payments/{payment-key}/settle",
     resource: "gateway-settlement",
     operation: "create",
@@ -3057,7 +3057,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/reconcile",
+    fastifyPath: "/v1/refunds/:refundKey/reconcile",
     stripePath: "/v1/refunds/{refund-key}/reconcile",
     resource: "refunds",
     operation: "action",
@@ -3068,7 +3068,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments",
+    fastifyPath: "/v1/payments",
     stripePath: "/v1/payments",
     resource: "payments",
     operation: "list",
@@ -3078,7 +3078,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payments",
+    fastifyPath: "/v1/payments",
     stripePath: "/v1/payments",
     resource: "payments",
     operation: "create",
@@ -3088,7 +3088,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments/:paymentKey",
+    fastifyPath: "/v1/payments/:paymentKey",
     stripePath: "/v1/payments/{paymentKey}",
     resource: "payments",
     operation: "retrieve",
@@ -3099,7 +3099,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payments/:paymentKey",
+    fastifyPath: "/v1/payments/:paymentKey",
     stripePath: "/v1/payments/{paymentKey}",
     resource: "payments",
     operation: "update",
@@ -3110,7 +3110,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payments/:paymentKey",
+    fastifyPath: "/v1/payments/:paymentKey",
     stripePath: "/v1/payments/{paymentKey}",
     resource: "payments",
     operation: "delete",
@@ -3121,7 +3121,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/apply",
+    fastifyPath: "/v1/payments/:paymentKey/apply",
     stripePath: "/v1/payments/{paymentKey}/apply",
     resource: "payments",
     operation: "action",
@@ -3132,7 +3132,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/cancel",
+    fastifyPath: "/v1/payments/:paymentKey/cancel",
     stripePath: "/v1/payments/{paymentKey}/cancel",
     resource: "payments",
     operation: "action",
@@ -3143,7 +3143,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/parts",
+    fastifyPath: "/v1/payments/:paymentKey/parts",
     stripePath: "/v1/payments/{paymentKey}/parts",
     resource: "payments",
     operation: "list",
@@ -3154,7 +3154,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/parts/:partid",
+    fastifyPath: "/v1/payments/:paymentKey/parts/:partid",
     stripePath: "/v1/payments/{paymentKey}/parts/{partid}",
     resource: "payments",
     operation: "retrieve",
@@ -3165,7 +3165,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/parts/:partid/item-parts",
+    fastifyPath: "/v1/payments/:paymentKey/parts/:partid/item-parts",
     stripePath: "/v1/payments/{paymentKey}/parts/{partid}/item-parts",
     resource: "payments",
     operation: "list",
@@ -3176,7 +3176,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/parts/:partid/item-parts/:itempartid",
+    fastifyPath: "/v1/payments/:paymentKey/parts/:partid/item-parts/:itempartid",
     stripePath: "/v1/payments/{paymentKey}/parts/{partid}/item-parts/{itempartid}",
     resource: "payments",
     operation: "retrieve",
@@ -3187,7 +3187,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/refunds",
+    fastifyPath: "/v1/payments/:paymentKey/refunds",
     stripePath: "/v1/payments/{paymentKey}/refunds",
     resource: "payments",
     operation: "create",
@@ -3198,7 +3198,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/refunds/unapply",
+    fastifyPath: "/v1/payments/:paymentKey/refunds/unapply",
     stripePath: "/v1/payments/{paymentKey}/refunds/unapply",
     resource: "payments",
     operation: "action",
@@ -3209,7 +3209,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/transfer",
+    fastifyPath: "/v1/payments/:paymentKey/transfer",
     stripePath: "/v1/payments/{paymentKey}/transfer",
     resource: "payments",
     operation: "action",
@@ -3220,7 +3220,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payments/:paymentKey/unapply",
+    fastifyPath: "/v1/payments/:paymentKey/unapply",
     stripePath: "/v1/payments/{paymentKey}/unapply",
     resource: "payments",
     operation: "action",
@@ -3231,7 +3231,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/payment-transaction-log/:id",
+    fastifyPath: "/v1/object/payment-transaction-log/:id",
     stripePath: "/v1/object/payment-transaction-log/{id}",
     resource: "object",
     operation: "retrieve",
@@ -3241,7 +3241,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-runs",
+    fastifyPath: "/v1/payment-runs",
     stripePath: "/v1/payment-runs",
     resource: "payment-runs",
     operation: "list",
@@ -3251,7 +3251,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-runs",
+    fastifyPath: "/v1/payment-runs",
     stripePath: "/v1/payment-runs",
     resource: "payment-runs",
     operation: "create",
@@ -3261,7 +3261,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-runs/:paymentRunKey",
+    fastifyPath: "/v1/payment-runs/:paymentRunKey",
     stripePath: "/v1/payment-runs/{paymentRunKey}",
     resource: "payment-runs",
     operation: "retrieve",
@@ -3272,7 +3272,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-runs/:paymentRunKey",
+    fastifyPath: "/v1/payment-runs/:paymentRunKey",
     stripePath: "/v1/payment-runs/{paymentRunKey}",
     resource: "payment-runs",
     operation: "update",
@@ -3283,7 +3283,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payment-runs/:paymentRunKey",
+    fastifyPath: "/v1/payment-runs/:paymentRunKey",
     stripePath: "/v1/payment-runs/{paymentRunKey}",
     resource: "payment-runs",
     operation: "delete",
@@ -3294,7 +3294,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-runs/:paymentRunKey/data",
+    fastifyPath: "/v1/payment-runs/:paymentRunKey/data",
     stripePath: "/v1/payment-runs/{paymentRunKey}/data",
     resource: "payment-runs",
     operation: "list",
@@ -3305,7 +3305,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-runs/:paymentRunKey/summary",
+    fastifyPath: "/v1/payment-runs/:paymentRunKey/summary",
     stripePath: "/v1/payment-runs/{paymentRunKey}/summary",
     resource: "payment-runs",
     operation: "list",
@@ -3316,7 +3316,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-schedule-items/retry-payment",
+    fastifyPath: "/v1/payment-schedule-items/retry-payment",
     stripePath: "/v1/payment-schedule-items/retry-payment",
     resource: "payment-schedule-items",
     operation: "create",
@@ -3325,7 +3325,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedule-items/:itemId/cancel",
+    fastifyPath: "/v1/payment-schedule-items/:itemId/cancel",
     stripePath: "/v1/payment-schedule-items/{item-id}/cancel",
     resource: "payment-schedule-items",
     operation: "action",
@@ -3335,7 +3335,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedule-items/:itemId/skip",
+    fastifyPath: "/v1/payment-schedule-items/:itemId/skip",
     stripePath: "/v1/payment-schedule-items/{item-id}/skip",
     resource: "payment-schedule-items",
     operation: "action",
@@ -3345,7 +3345,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-schedule-items/:psiId",
+    fastifyPath: "/v1/payment-schedule-items/:psiId",
     stripePath: "/v1/payment-schedule-items/{psi-id}",
     resource: "payment-schedule-items",
     operation: "retrieve",
@@ -3355,7 +3355,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedule-items/:psiId",
+    fastifyPath: "/v1/payment-schedule-items/:psiId",
     stripePath: "/v1/payment-schedule-items/{psi-id}",
     resource: "payment-schedule-items",
     operation: "update",
@@ -3365,7 +3365,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payment-schedule-items/:psiId",
+    fastifyPath: "/v1/payment-schedule-items/:psiId",
     stripePath: "/v1/payment-schedule-items/{psi-id}",
     resource: "payment-schedule-items",
     operation: "delete",
@@ -3375,7 +3375,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-schedules",
+    fastifyPath: "/v1/payment-schedules",
     stripePath: "/v1/payment-schedules",
     resource: "payment-schedules",
     operation: "list",
@@ -3385,7 +3385,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-schedules",
+    fastifyPath: "/v1/payment-schedules",
     stripePath: "/v1/payment-schedules",
     resource: "payment-schedules",
     operation: "create",
@@ -3395,7 +3395,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-schedules/batch",
+    fastifyPath: "/v1/payment-schedules/batch",
     stripePath: "/v1/payment-schedules/batch",
     resource: "payment-schedules",
     operation: "action",
@@ -3405,7 +3405,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-schedules/statistics/:yyyyMmDd",
+    fastifyPath: "/v1/payment-schedules/statistics/:yyyyMmDd",
     stripePath: "/v1/payment-schedules/statistics/{yyyy-mm-dd}",
     resource: "payment-schedules",
     operation: "retrieve",
@@ -3416,7 +3416,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}",
     resource: "payment-schedules",
     operation: "retrieve",
@@ -3427,7 +3427,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}",
     resource: "payment-schedules",
     operation: "update",
@@ -3438,7 +3438,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}",
     resource: "payment-schedules",
     operation: "delete",
@@ -3449,7 +3449,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey/cancel",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey/cancel",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}/cancel",
     resource: "payment-schedules",
     operation: "action",
@@ -3460,7 +3460,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey/items",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey/items",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}/items",
     resource: "payment-schedules",
     operation: "create",
@@ -3471,7 +3471,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-schedules/:paymentScheduleKey/preview",
+    fastifyPath: "/v1/payment-schedules/:paymentScheduleKey/preview",
     stripePath: "/v1/payment-schedules/{paymentScheduleKey}/preview",
     resource: "payment-schedules",
     operation: "action",
@@ -3482,7 +3482,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds",
+    fastifyPath: "/v1/refunds",
     stripePath: "/v1/refunds",
     resource: "refunds",
     operation: "list",
@@ -3492,7 +3492,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds/:refundKey",
+    fastifyPath: "/v1/refunds/:refundKey",
     stripePath: "/v1/refunds/{refundKey}",
     resource: "refunds",
     operation: "retrieve",
@@ -3503,7 +3503,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/refunds/:refundKey",
+    fastifyPath: "/v1/refunds/:refundKey",
     stripePath: "/v1/refunds/{refundKey}",
     resource: "refunds",
     operation: "update",
@@ -3514,7 +3514,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/refunds/:refundKey",
+    fastifyPath: "/v1/refunds/:refundKey",
     stripePath: "/v1/refunds/{refundKey}",
     resource: "refunds",
     operation: "delete",
@@ -3525,7 +3525,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/cancel",
+    fastifyPath: "/v1/refunds/:refundKey/cancel",
     stripePath: "/v1/refunds/{refundKey}/cancel",
     resource: "refunds",
     operation: "action",
@@ -3536,7 +3536,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/parts",
+    fastifyPath: "/v1/refunds/:refundKey/parts",
     stripePath: "/v1/refunds/{refundKey}/parts",
     resource: "refunds",
     operation: "list",
@@ -3547,7 +3547,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/parts/:refundpartid",
+    fastifyPath: "/v1/refunds/:refundKey/parts/:refundpartid",
     stripePath: "/v1/refunds/{refundKey}/parts/{refundpartid}",
     resource: "refunds",
     operation: "retrieve",
@@ -3558,7 +3558,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/parts/:refundpartid/item-parts",
+    fastifyPath: "/v1/refunds/:refundKey/parts/:refundpartid/item-parts",
     stripePath: "/v1/refunds/{refundKey}/parts/{refundpartid}/item-parts",
     resource: "refunds",
     operation: "list",
@@ -3569,7 +3569,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/refunds/:refundKey/parts/:refundpartid/item-parts/:itempartid",
+    fastifyPath: "/v1/refunds/:refundKey/parts/:refundpartid/item-parts/:itempartid",
     stripePath: "/v1/refunds/{refundKey}/parts/{refundpartid}/item-parts/{itempartid}",
     resource: "refunds",
     operation: "retrieve",
@@ -3580,7 +3580,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/payment-profile",
+    fastifyPath: "/v1/payment-profile",
     stripePath: "/v1/payment-profile",
     resource: "payment-profile",
     operation: "action",
@@ -3589,7 +3589,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/summary-statement-runs",
+    fastifyPath: "/v1/summary-statement-runs",
     stripePath: "/v1/summary-statement-runs",
     resource: "summary-statement-runs",
     operation: "create",
@@ -3598,7 +3598,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounting-codes",
+    fastifyPath: "/v1/accounting-codes",
     stripePath: "/v1/accounting-codes",
     resource: "accounting-codes",
     operation: "list",
@@ -3608,7 +3608,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/accounting-codes",
+    fastifyPath: "/v1/accounting-codes",
     stripePath: "/v1/accounting-codes",
     resource: "accounting-codes",
     operation: "create",
@@ -3618,7 +3618,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounting-codes/:acId",
+    fastifyPath: "/v1/accounting-codes/:acId",
     stripePath: "/v1/accounting-codes/{ac-id}",
     resource: "accounting-codes",
     operation: "retrieve",
@@ -3629,7 +3629,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-codes/:acId",
+    fastifyPath: "/v1/accounting-codes/:acId",
     stripePath: "/v1/accounting-codes/{ac-id}",
     resource: "accounting-codes",
     operation: "update",
@@ -3640,7 +3640,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/accounting-codes/:acId",
+    fastifyPath: "/v1/accounting-codes/:acId",
     stripePath: "/v1/accounting-codes/{ac-id}",
     resource: "accounting-codes",
     operation: "delete",
@@ -3651,7 +3651,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-codes/:acId/activate",
+    fastifyPath: "/v1/accounting-codes/:acId/activate",
     stripePath: "/v1/accounting-codes/{ac-id}/activate",
     resource: "accounting-codes",
     operation: "action",
@@ -3662,7 +3662,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-codes/:acId/deactivate",
+    fastifyPath: "/v1/accounting-codes/:acId/deactivate",
     stripePath: "/v1/accounting-codes/{ac-id}/deactivate",
     resource: "accounting-codes",
     operation: "action",
@@ -3673,7 +3673,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounting-periods",
+    fastifyPath: "/v1/accounting-periods",
     stripePath: "/v1/accounting-periods",
     resource: "accounting-periods",
     operation: "list",
@@ -3683,7 +3683,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/accounting-periods",
+    fastifyPath: "/v1/accounting-periods",
     stripePath: "/v1/accounting-periods",
     resource: "accounting-periods",
     operation: "create",
@@ -3693,7 +3693,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId",
+    fastifyPath: "/v1/accounting-periods/:apId",
     stripePath: "/v1/accounting-periods/{ap-id}",
     resource: "accounting-periods",
     operation: "retrieve",
@@ -3704,7 +3704,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId",
+    fastifyPath: "/v1/accounting-periods/:apId",
     stripePath: "/v1/accounting-periods/{ap-id}",
     resource: "accounting-periods",
     operation: "update",
@@ -3715,7 +3715,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId",
+    fastifyPath: "/v1/accounting-periods/:apId",
     stripePath: "/v1/accounting-periods/{ap-id}",
     resource: "accounting-periods",
     operation: "delete",
@@ -3726,7 +3726,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId/close",
+    fastifyPath: "/v1/accounting-periods/:apId/close",
     stripePath: "/v1/accounting-periods/{ap-id}/close",
     resource: "accounting-periods",
     operation: "action",
@@ -3737,7 +3737,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId/pending-close",
+    fastifyPath: "/v1/accounting-periods/:apId/pending-close",
     stripePath: "/v1/accounting-periods/{ap-id}/pending-close",
     resource: "accounting-periods",
     operation: "action",
@@ -3748,7 +3748,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId/reopen",
+    fastifyPath: "/v1/accounting-periods/:apId/reopen",
     stripePath: "/v1/accounting-periods/{ap-id}/reopen",
     resource: "accounting-periods",
     operation: "action",
@@ -3759,7 +3759,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/accounting-periods/:apId/run-trial-balance",
+    fastifyPath: "/v1/accounting-periods/:apId/run-trial-balance",
     stripePath: "/v1/accounting-periods/{ap-id}/run-trial-balance",
     resource: "accounting-periods",
     operation: "action",
@@ -3770,7 +3770,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/journal-entries",
+    fastifyPath: "/v1/journal-entries",
     stripePath: "/v1/journal-entries",
     resource: "journal-entries",
     operation: "create",
@@ -3780,7 +3780,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/journal-entries/journal-runs/:jrNumber",
+    fastifyPath: "/v1/journal-entries/journal-runs/:jrNumber",
     stripePath: "/v1/journal-entries/journal-runs/{jr-number}",
     resource: "journal-entries",
     operation: "retrieve",
@@ -3791,7 +3791,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/journal-entries/:jeNumber",
+    fastifyPath: "/v1/journal-entries/:jeNumber",
     stripePath: "/v1/journal-entries/{je-number}",
     resource: "journal-entries",
     operation: "retrieve",
@@ -3802,7 +3802,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/journal-entries/:jeNumber",
+    fastifyPath: "/v1/journal-entries/:jeNumber",
     stripePath: "/v1/journal-entries/{je-number}",
     resource: "journal-entries",
     operation: "delete",
@@ -3813,7 +3813,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/journal-entries/:jeNumber/basic-information",
+    fastifyPath: "/v1/journal-entries/:jeNumber/basic-information",
     stripePath: "/v1/journal-entries/{je-number}/basic-information",
     resource: "journal-entries",
     operation: "action",
@@ -3824,7 +3824,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/journal-entries/:jeNumber/cancel",
+    fastifyPath: "/v1/journal-entries/:jeNumber/cancel",
     stripePath: "/v1/journal-entries/{je-number}/cancel",
     resource: "journal-entries",
     operation: "action",
@@ -3835,7 +3835,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/journal-runs",
+    fastifyPath: "/v1/journal-runs",
     stripePath: "/v1/journal-runs",
     resource: "journal-runs",
     operation: "create",
@@ -3844,7 +3844,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/journal-runs/:jrNumber",
+    fastifyPath: "/v1/journal-runs/:jrNumber",
     stripePath: "/v1/journal-runs/{jr-number}",
     resource: "journal-runs",
     operation: "retrieve",
@@ -3854,7 +3854,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/journal-runs/:jrNumber",
+    fastifyPath: "/v1/journal-runs/:jrNumber",
     stripePath: "/v1/journal-runs/{jr-number}",
     resource: "journal-runs",
     operation: "delete",
@@ -3864,7 +3864,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/journal-runs/:jrNumber/cancel",
+    fastifyPath: "/v1/journal-runs/:jrNumber/cancel",
     stripePath: "/v1/journal-runs/{jr-number}/cancel",
     resource: "journal-runs",
     operation: "action",
@@ -3874,7 +3874,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/bulk",
+    fastifyPath: "/v1/bulk",
     stripePath: "/v1/bulk",
     resource: "bulk",
     operation: "action",
@@ -3883,7 +3883,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/bulk/:bulkKey",
+    fastifyPath: "/v1/bulk/:bulkKey",
     stripePath: "/v1/bulk/{bulk-key}",
     resource: "bulk",
     operation: "retrieve",
@@ -3893,7 +3893,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/bulk/:bulkKey/stop",
+    fastifyPath: "/v1/bulk/:bulkKey/stop",
     stripePath: "/v1/bulk/{bulk-key}/stop",
     resource: "bulk",
     operation: "action",
@@ -3903,7 +3903,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/notification-history/callout",
+    fastifyPath: "/v1/notification-history/callout",
     stripePath: "/v1/notification-history/callout",
     resource: "notification-history",
     operation: "list",
@@ -3912,7 +3912,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/notification-history/email",
+    fastifyPath: "/v1/notification-history/email",
     stripePath: "/v1/notification-history/email",
     resource: "notification-history",
     operation: "action",
@@ -3921,7 +3921,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/batch-query",
+    fastifyPath: "/v1/batch-query",
     stripePath: "/v1/batch-query",
     resource: "batch-query",
     operation: "create",
@@ -3930,7 +3930,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/batch-query/jobs/partner/:partner/project/:project",
+    fastifyPath: "/v1/batch-query/jobs/partner/:partner/project/:project",
     stripePath: "/v1/batch-query/jobs/partner/{partner}/project/{project}",
     resource: "batch-query",
     operation: "retrieve",
@@ -3940,7 +3940,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/batch-query/jobs/:jobid",
+    fastifyPath: "/v1/batch-query/jobs/:jobid",
     stripePath: "/v1/batch-query/jobs/{jobid}",
     resource: "batch-query",
     operation: "retrieve",
@@ -3950,7 +3950,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/batch-query/jobs/:jobid",
+    fastifyPath: "/v1/batch-query/jobs/:jobid",
     stripePath: "/v1/batch-query/jobs/{jobid}",
     resource: "batch-query",
     operation: "delete",
@@ -3960,7 +3960,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/multi-organizations/data-labeling-job",
+    fastifyPath: "/v1/multi-organizations/data-labeling-job",
     stripePath: "/v1/multi-organizations/data-labeling-job",
     resource: "multi-organizations",
     operation: "create",
@@ -3969,7 +3969,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/multi-organizations/data-labeling-job/:jobId",
+    fastifyPath: "/v1/multi-organizations/data-labeling-job/:jobId",
     stripePath: "/v1/multi-organizations/data-labeling-job/{job-id}",
     resource: "multi-organizations",
     operation: "retrieve",
@@ -3979,7 +3979,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno-regenerate/booking-transaction",
+    fastifyPath: "/v1/uno-regenerate/booking-transaction",
     stripePath: "/v1/uno-regenerate/booking-transaction",
     resource: "uno-regenerate",
     operation: "create",
@@ -3988,7 +3988,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno-regenerate/billing-transaction",
+    fastifyPath: "/v1/uno-regenerate/billing-transaction",
     stripePath: "/v1/uno-regenerate/billing-transaction",
     resource: "uno-regenerate",
     operation: "create",
@@ -3997,7 +3997,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno-regenerate/rev-rec-events",
+    fastifyPath: "/v1/uno-regenerate/rev-rec-events",
     stripePath: "/v1/uno-regenerate/rev-rec-events",
     resource: "uno-regenerate",
     operation: "create",
@@ -4006,7 +4006,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno-regenerate/rev-rec-events/daily-consumption",
+    fastifyPath: "/v1/uno-regenerate/rev-rec-events/daily-consumption",
     stripePath: "/v1/uno-regenerate/rev-rec-events/daily-consumption",
     resource: "uno-regenerate",
     operation: "create",
@@ -4015,7 +4015,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/bookingdate/jobs",
+    fastifyPath: "/v1/uno/data-backfill/bookingdate/jobs",
     stripePath: "/v1/uno/data-backfill/bookingdate/jobs",
     resource: "uno",
     operation: "list",
@@ -4024,7 +4024,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno/data-backfill/bookingdate/jobs",
+    fastifyPath: "/v1/uno/data-backfill/bookingdate/jobs",
     stripePath: "/v1/uno/data-backfill/bookingdate/jobs",
     resource: "uno",
     operation: "create",
@@ -4033,7 +4033,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/bookingdate/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/bookingdate/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/bookingdate/jobs/{jobId}",
     resource: "uno",
     operation: "retrieve",
@@ -4043,7 +4043,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/uno/data-backfill/bookingdate/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/bookingdate/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/bookingdate/jobs/{jobId}",
     resource: "uno",
     operation: "update",
@@ -4053,7 +4053,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno/data-backfill/jobs",
+    fastifyPath: "/v1/uno/data-backfill/jobs",
     stripePath: "/v1/uno/data-backfill/jobs",
     resource: "uno",
     operation: "create",
@@ -4062,7 +4062,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/jobs/{jobId}",
     resource: "uno",
     operation: "retrieve",
@@ -4072,7 +4072,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/uno/data-backfill/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/jobs/{jobId}",
     resource: "uno",
     operation: "update",
@@ -4082,7 +4082,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/listjobs",
+    fastifyPath: "/v1/uno/data-backfill/listjobs",
     stripePath: "/v1/uno/data-backfill/listjobs",
     resource: "uno",
     operation: "list",
@@ -4091,7 +4091,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/jobs/:type/template",
+    fastifyPath: "/v1/uno/data-backfill/jobs/:type/template",
     stripePath: "/v1/uno/data-backfill/jobs/{type}/template",
     resource: "uno",
     operation: "list",
@@ -4101,7 +4101,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/propagation/jobs",
+    fastifyPath: "/v1/uno/data-backfill/propagation/jobs",
     stripePath: "/v1/uno/data-backfill/propagation/jobs",
     resource: "uno",
     operation: "list",
@@ -4110,7 +4110,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/uno/data-backfill/propagation/jobs",
+    fastifyPath: "/v1/uno/data-backfill/propagation/jobs",
     stripePath: "/v1/uno/data-backfill/propagation/jobs",
     resource: "uno",
     operation: "create",
@@ -4119,7 +4119,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/uno/data-backfill/propagation/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/propagation/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/propagation/jobs/{jobId}",
     resource: "uno",
     operation: "retrieve",
@@ -4129,7 +4129,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/uno/data-backfill/propagation/jobs/:jobId",
+    fastifyPath: "/v1/uno/data-backfill/propagation/jobs/:jobId",
     stripePath: "/v1/uno/data-backfill/propagation/jobs/{jobId}",
     resource: "uno",
     operation: "update",
@@ -4139,7 +4139,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/action/create",
+    fastifyPath: "/v1/action/create",
     stripePath: "/v1/action/create",
     resource: "action",
     operation: "create",
@@ -4148,7 +4148,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/action/delete",
+    fastifyPath: "/v1/action/delete",
     stripePath: "/v1/action/delete",
     resource: "action",
     operation: "action",
@@ -4157,7 +4157,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/action/query",
+    fastifyPath: "/v1/action/query",
     stripePath: "/v1/action/query",
     resource: "action",
     operation: "create",
@@ -4166,7 +4166,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/action/queryMore",
+    fastifyPath: "/v1/action/queryMore",
     stripePath: "/v1/action/queryMore",
     resource: "action",
     operation: "create",
@@ -4175,7 +4175,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/action/update",
+    fastifyPath: "/v1/action/update",
     stripePath: "/v1/action/update",
     resource: "action",
     operation: "create",
@@ -4184,7 +4184,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/files/:fileId",
+    fastifyPath: "/v1/files/:fileId",
     stripePath: "/v1/files/{file-id}",
     resource: "files",
     operation: "retrieve",
@@ -4194,7 +4194,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/files/:fileId/restore",
+    fastifyPath: "/v1/files/:fileId/restore",
     stripePath: "/v1/files/{file-id}/restore",
     resource: "files",
     operation: "action",
@@ -4204,7 +4204,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/files/:fileId/status",
+    fastifyPath: "/v1/files/:fileId/status",
     stripePath: "/v1/files/{file-id}/status",
     resource: "files",
     operation: "list",
@@ -4214,7 +4214,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/object/import",
+    fastifyPath: "/v1/object/import",
     stripePath: "/v1/object/import",
     resource: "object",
     operation: "create",
@@ -4223,7 +4223,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/object/import/:id",
+    fastifyPath: "/v1/object/import/:id",
     stripePath: "/v1/object/import/{id}",
     resource: "object",
     operation: "retrieve",
@@ -4233,7 +4233,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/custom-exchange-rates/:currency",
+    fastifyPath: "/v1/custom-exchange-rates/:currency",
     stripePath: "/v1/custom-exchange-rates/{currency}",
     resource: "custom-exchange-rates",
     operation: "retrieve",
@@ -4243,7 +4243,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "POST",
-    fastifyPath: "/zuora/v1/attachments",
+    fastifyPath: "/v1/attachments",
     stripePath: "/v1/attachments",
     resource: "attachments",
     operation: "create",
@@ -4252,7 +4252,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/attachments/:attachmentId",
+    fastifyPath: "/v1/attachments/:attachmentId",
     stripePath: "/v1/attachments/{attachment-id}",
     resource: "attachments",
     operation: "retrieve",
@@ -4262,7 +4262,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "PUT",
-    fastifyPath: "/zuora/v1/attachments/:attachmentId",
+    fastifyPath: "/v1/attachments/:attachmentId",
     stripePath: "/v1/attachments/{attachment-id}",
     resource: "attachments",
     operation: "update",
@@ -4272,7 +4272,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "DELETE",
-    fastifyPath: "/zuora/v1/attachments/:attachmentId",
+    fastifyPath: "/v1/attachments/:attachmentId",
     stripePath: "/v1/attachments/{attachment-id}",
     resource: "attachments",
     operation: "delete",
@@ -4282,7 +4282,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/attachments/:objectType/:objectKey",
+    fastifyPath: "/v1/attachments/:objectType/:objectKey",
     stripePath: "/v1/attachments/{object-type}/{object-key}",
     resource: "attachments",
     operation: "retrieve",
@@ -4292,7 +4292,7 @@ export const GENERATED_ROUTES: GeneratedRoute[] = [
   },
   {
     method: "GET",
-    fastifyPath: "/zuora/v1/describe/:object",
+    fastifyPath: "/v1/describe/:object",
     stripePath: "/v1/describe/{object}",
     resource: "describe",
     operation: "retrieve",

--- a/packages/adapters/adapter-zuora/src/mcp.ts
+++ b/packages/adapters/adapter-zuora/src/mcp.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import meta from './adapter-meta.js';
 
-const BP = '/zuora/v1';
+const BP = '/v1';
 
 function makeCall(baseUrl: string) {
   return async (method: string, path: string, body?: unknown): Promise<unknown> => {

--- a/packages/adapters/adapter-zuora/src/zuora-adapter.ts
+++ b/packages/adapters/adapter-zuora/src/zuora-adapter.ts
@@ -155,7 +155,7 @@ export class ZuoraAdapter extends OpenApiMockAdapter<ZuoraConfig> {
   // ---------------------------------------------------------------------------
 
   private mountOverrides(server: FastifyInstance, store: StateStore): void {
-    const BP = '/zuora/v1';
+    const BP = '/v1';
 
     // ── Accounts ──────────────────────────────────────────────────────
     this.registerOverride('POST', `${BP}/accounts`, async (req, reply) => {

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -85,8 +85,9 @@ async function runHost(opts: HostOptions): Promise<void> {
     );
   }
 
-  // Auto-detect transport: stdio for single server, Streamable HTTP for multiple
-  const transport: 'stdio' | 'http' = totalServers > 1 ? 'http' : 'stdio';
+  // Always use HTTP transport so the host command runs as a background server.
+  // Stdio is only useful when a parent process (IDE) spawns and pipes to us.
+  const transport: 'stdio' | 'http' = 'http';
 
   const mcpBasePort = opts.mcpBasePort ?? 4201;
   const apiBasePort = opts.apiBasePort ?? 4101;

--- a/packages/core/src/llm/client.ts
+++ b/packages/core/src/llm/client.ts
@@ -633,6 +633,15 @@ function normalizePattern(pattern: Record<string, unknown>): void {
           } else {
             s.type = 'pick';
           }
+
+          // Coerce ISO date strings in min/max to epoch ms and fix type
+          const minIsDateStr = typeof s.min === 'string' && !Number.isNaN(Date.parse(s.min as string));
+          const maxIsDateStr = typeof s.max === 'string' && !Number.isNaN(Date.parse(s.max as string));
+          if (minIsDateStr || maxIsDateStr) {
+            if (minIsDateStr) s.min = Date.parse(s.min as string);
+            if (maxIsDateStr) s.max = Date.parse(s.max as string);
+            s.type = 'date_in_period';
+          }
         } else {
           // Bare value — wrap into a pick spec
           (v.randomFields as Record<string, unknown>)[field] = { type: 'pick', values: [spec] };

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -132,7 +132,8 @@ export class MimicMcpServer {
   private readonly queryBuilder: QueryBuilder | null;
   private readonly tableMap: Map<string, TableInfo>;
   private httpServer: HttpServer | null = null;
-  private sessions: Map<string, StreamableHTTPServerTransport> = new Map();
+  private sessions: Map<string, { transport: StreamableHTTPServerTransport; server: McpServer }> = new Map();
+  private readonly externalRegistrars: Array<(mcpServer: McpServer) => void> = [];
 
   constructor(
     private readonly schema?: SchemaModel,
@@ -155,11 +156,26 @@ export class MimicMcpServer {
   }
 
   /**
+   * Create a fresh McpServer with all tools registered.
+   * Each Streamable HTTP session needs its own McpServer instance
+   * because the MCP SDK only allows one transport per protocol instance.
+   */
+  private createSessionServer(): McpServer {
+    const server = new McpServer({ name: 'mimic', version: '0.1.0' });
+    this.registerToolsOn(server);
+    for (const registrar of this.externalRegistrars) {
+      registrar(server);
+    }
+    return server;
+  }
+
+  /**
    * Allow external code (e.g. API adapters with mcp: true) to register
    * additional tools on the underlying MCP server.
    */
   registerExternalTools(registrar: (mcpServer: McpServer) => void): void {
     registrar(this.mcpServer);
+    this.externalRegistrars.push(registrar);
   }
 
   // -----------------------------------------------------------------------
@@ -167,12 +183,18 @@ export class MimicMcpServer {
   // -----------------------------------------------------------------------
 
   private registerTools(): void {
-    const tools = generateTools(this.schema!);
+    this.registerToolsOn(this.mcpServer);
+  }
+
+  /** Register database tools on any McpServer instance. */
+  private registerToolsOn(server: McpServer): void {
+    if (!this.schema) return;
+    const tools = generateTools(this.schema);
 
     for (const tool of tools) {
       const zodShape = inputSchemaToZod(tool);
 
-      this.mcpServer.tool(
+      server.tool(
         tool.name,
         tool.description,
         zodShape,
@@ -295,7 +317,13 @@ export class MimicMcpServer {
 
         // DELETE — explicit session termination
         if (req.method === 'DELETE') {
-          if (sessionId) this.sessions.delete(sessionId);
+          if (sessionId) {
+            const session = this.sessions.get(sessionId);
+            if (session) {
+              this.sessions.delete(sessionId);
+              await session.server.close().catch(() => {});
+            }
+          }
           res.writeHead(204);
           res.end();
           return;
@@ -308,7 +336,7 @@ export class MimicMcpServer {
             res.end(JSON.stringify({ error: 'invalid or missing mcp-session-id' }));
             return;
           }
-          await this.sessions.get(sessionId)!.handleRequest(req, res);
+          await this.sessions.get(sessionId)!.transport.handleRequest(req, res);
           return;
         }
 
@@ -316,15 +344,16 @@ export class MimicMcpServer {
         if (req.method === 'POST') {
           if (sessionId && this.sessions.has(sessionId)) {
             // Resume existing session
-            await this.sessions.get(sessionId)!.handleRequest(req, res);
+            await this.sessions.get(sessionId)!.transport.handleRequest(req, res);
             return;
           }
 
-          // New session
+          // New session — each session gets its own McpServer instance
+          // because the MCP SDK only allows one transport per protocol instance.
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (id) => {
-              this.sessions.set(id, transport);
+              this.sessions.set(id, { transport, server: sessionServer });
             },
           });
 
@@ -332,7 +361,8 @@ export class MimicMcpServer {
             if (transport.sessionId) this.sessions.delete(transport.sessionId);
           };
 
-          await this.mcpServer.connect(transport);
+          const sessionServer = this.createSessionServer();
+          await sessionServer.connect(transport);
           await transport.handleRequest(req, res);
           return;
         }
@@ -357,9 +387,14 @@ export class MimicMcpServer {
    */
   async stop(): Promise<void> {
     // Close all active Streamable HTTP sessions
-    for (const transport of this.sessions.values()) {
+    for (const { transport, server } of this.sessions.values()) {
       try {
         await transport.close();
+      } catch {
+        // Best-effort cleanup
+      }
+      try {
+        await server.close();
       } catch {
         // Best-effort cleanup
       }

--- a/packages/docs/src/content/docs/04-cli.md
+++ b/packages/docs/src/content/docs/04-cli.md
@@ -97,14 +97,9 @@ Ports are assigned sequentially starting from the base port values:
 
 Use `--mcp-base-port` and `--api-base-port` to shift the port ranges if they conflict with other services.
 
-#### Transport auto-detection
+#### Transport
 
-The MCP transport protocol is chosen automatically based on server count:
-
-- **One server** &rarr; `stdio` (reads/writes stdin&sol;stdout directly)
-- **Multiple servers** &rarr; `http` (each MCP server listens at `http://localhost:&lt;port&gt;/mcp`, Streamable HTTP per MCP spec 2025-03-26)
-
-You cannot override this &mdash; use `--no-api` to reduce server count if you need `stdio` with a single adapter.
+All MCP servers use the **Streamable HTTP** transport (`http://localhost:<port>/mcp`, per MCP spec 2025-03-26). This allows `mimic host` to run as a background server that agents connect to over HTTP.
 
 #### Connection summary
 
@@ -126,6 +121,52 @@ Skips starting mock HTTP API servers for all adapters. MCP servers for adapters 
 #### Graceful shutdown
 
 `mimic host` blocks the terminal until you press `Ctrl+C` (or send `SIGTERM`). On shutdown it stops all MCP servers, mock API servers, and closes all database connections cleanly.
+
+<h2 id="cli-explore">mimic explore</h2>
+
+Open the interactive data explorer UI in your browser.
+
+<div class="code-block">
+  <div class="code-bar"><span class="code-bar-lang">bash</span><button class="code-copy">Copy</button></div>
+  <pre><code><span class="prompt">$</span> mimic explore [options]
+&#8203;
+<span class="cm">Options:</span>
+  <span class="flag">--port</span> &lt;number&gt;           Port for the explorer UI (default: 7879)
+  <span class="flag">--no-open</span>                Do not auto-open the browser</code></pre>
+</div>
+
+Launches a local web UI for browsing and inspecting generated persona data. The explorer reads from `.mimic/data/` and presents it in a navigable interface.
+
+#### Background process
+
+`mimic explore` spawns the explorer as a **detached background process** and exits immediately &mdash; it does not block your terminal. The background process PID is printed so you can stop it later:
+
+<div class="code-block">
+  <div class="code-bar"><span class="code-bar-lang">bash</span><button class="code-copy">Copy</button></div>
+  <pre><code><span class="prompt">$</span> mimic explore
+&#8203;
+  mimic explore
+  ✔ Using port 7879
+  ✔ Explorer running at http://localhost:7879
+  ℹ Background process PID 12345 — to stop: kill 12345</code></pre>
+</div>
+
+#### Port selection
+
+By default the explorer uses port **7879**. If that port is in use, it automatically finds the next available port. Use `--port` to specify a custom port.
+
+#### Browser auto-open
+
+The explorer automatically opens your default browser. Pass `--no-open` to disable this behavior &mdash; useful in headless or CI environments.
+
+#### Requirements
+
+The explorer requires the `@mimicai/explorer` package. If it is not installed, the command will exit with an install hint:
+
+<div class="code-block">
+  <div class="code-bar"><span class="code-bar-lang">bash</span><button class="code-copy">Copy</button></div>
+  <pre><code><span class="prompt">$</span> pnpm add @mimicai/explorer</code></pre>
+</div>
 
 <h2 id="cli-test">mimic test</h2>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,35 +42,32 @@ importers:
   examples/cfo-agent:
     dependencies:
       '@mimicai/adapter-chargebee':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-chargebee
       '@mimicai/adapter-gocardless':
-        specifier: ^0.10.2
-        version: 0.10.2
-      '@mimicai/adapter-lemonsqueezy':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-gocardless
       '@mimicai/adapter-paddle':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-paddle
       '@mimicai/adapter-postgres':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-postgres
       '@mimicai/adapter-recurly':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-recurly
       '@mimicai/adapter-revenuecat':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-revenuecat
       '@mimicai/adapter-stripe':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-stripe
       '@mimicai/adapter-zuora':
-        specifier: ^0.10.2
-        version: 0.10.2
+        specifier: workspace:*
+        version: link:../../packages/adapters/adapter-zuora
       '@mimicai/cli':
-        specifier: ^0.10.2
-        version: 0.10.2(@types/node@25.5.0)(better-sqlite3@11.10.0)(mongodb@6.21.0)(mysql2@3.20.0(@types/node@25.5.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: workspace:*
+        version: link:../../packages/cli
 
   examples/stripe-explorer:
     dependencies:
@@ -90,8 +87,8 @@ importers:
   examples/tasks-sqlite:
     dependencies:
       '@mimicai/cli':
-        specifier: ^0.10.0
-        version: 0.10.0(@types/node@25.5.0)(better-sqlite3@12.8.0)(mongodb@6.21.0)(mysql2@3.20.0(@types/node@25.5.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: workspace:*
+        version: link:../../packages/cli
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -1084,9 +1081,6 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
-  '@fastify/cors@10.1.0':
-    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
-
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
 
@@ -1110,9 +1104,6 @@ packages:
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
-
-  '@fastify/static@8.3.0':
-    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
 
   '@fastify/static@9.0.0':
     resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
@@ -1266,35 +1257,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/ansi@1.0.2':
-    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
-    engines: {node: '>=18'}
-
   '@inquirer/ansi@2.0.4':
     resolution: {integrity: sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
-  '@inquirer/checkbox@4.3.2':
-    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/checkbox@5.1.2':
     resolution: {integrity: sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/confirm@5.1.21':
-    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1310,15 +1279,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.3.2':
-    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/core@11.1.7':
     resolution: {integrity: sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1328,27 +1288,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.23':
-    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/editor@5.0.10':
     resolution: {integrity: sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/expand@4.0.23':
-    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1382,35 +1324,13 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
-
   '@inquirer/figures@2.0.4':
     resolution: {integrity: sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
-  '@inquirer/input@4.3.1':
-    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/input@5.0.10':
     resolution: {integrity: sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/number@3.0.23':
-    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1426,27 +1346,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.23':
-    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/password@5.0.10':
     resolution: {integrity: sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/prompts@7.10.1':
-    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1462,27 +1364,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.1.11':
-    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/rawlist@5.2.6':
     resolution: {integrity: sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/search@3.2.2':
-    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1498,27 +1382,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.4.2':
-    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/select@5.1.2':
     resolution: {integrity: sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/type@3.0.10':
-    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1533,10 +1399,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1567,192 +1429,6 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@mimicai/adapter-chargebee@0.10.0':
-    resolution: {integrity: sha512-w2zK8FXC26/O7QK0C7GLU6IRO//e3gbBrY2OZQum7nkC1Z/3m0H+t9pHEQ05rsMGM1zkUwJG+kRGQDHXYdL3kw==}
-    hasBin: true
-
-  '@mimicai/adapter-chargebee@0.10.2':
-    resolution: {integrity: sha512-JyxuF6jdty3Y+T81unxq0OBgCIY45kol0G+pB9mDnOmHmqSaM29JPOvOc2ZwO/JoxaS9h/f38oF+/pgVosnZgA==}
-    hasBin: true
-
-  '@mimicai/adapter-gocardless@0.10.0':
-    resolution: {integrity: sha512-Pz3V1+Q48wNXyGCC/zRbKPmuMTQ/gPb9ze0A9C6NPo1YS4fYLlWt2cQv0VEPTYhsOcHoK33iTjHvAlTwkSy0cg==}
-    hasBin: true
-
-  '@mimicai/adapter-gocardless@0.10.2':
-    resolution: {integrity: sha512-3CMZxtOygn0hNapcvmTpzG9hM8O+mcieqgBsy6+sN2lm0bt9Y81Ayl2ATILL0xnX9nSKDCQlv/7jR9ZzpUTEEw==}
-    hasBin: true
-
-  '@mimicai/adapter-lemonsqueezy@0.10.0':
-    resolution: {integrity: sha512-tsziIqvpQ071Q9C+u+PPh5sLPjV7X/Z2qFIUv55nTc+660uoTWf/CRSFCS5ZJ4EfCQrbDrR9XqN3Kio7eFr/6g==}
-    hasBin: true
-
-  '@mimicai/adapter-lemonsqueezy@0.10.2':
-    resolution: {integrity: sha512-UIWRyFtOuZM5lSeGwIjd0dnhp1LoDL56x231Lk7hnIt33az1oSseVDQ2K1RtG+WVAk0XOqr47I82ymio6K8bZw==}
-    hasBin: true
-
-  '@mimicai/adapter-mongodb@0.10.0':
-    resolution: {integrity: sha512-NdWJchjvATyewsFclu1m33NdzihmRbJpaYVOvXWByMadA6cRdFp+4wCqFPCfcwI4DruRsio1dycoiDnLhjSVow==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      mongodb: ^6.0.0
-    peerDependenciesMeta:
-      mongodb:
-        optional: true
-
-  '@mimicai/adapter-mongodb@0.10.2':
-    resolution: {integrity: sha512-lV1B+X3SA5LZq9+hPH9fUa41m3GbVPHL/NtkJ6g1rqqP8NjmhLhNQYEx6RaILtN1PIDXr4d4WkN5d7i4pxeKkQ==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      mongodb: ^6.0.0
-    peerDependenciesMeta:
-      mongodb:
-        optional: true
-
-  '@mimicai/adapter-mysql@0.10.0':
-    resolution: {integrity: sha512-1NmrvF58s2uv1p04R8EuR3+gQEeCr/8b1LGdS8yk3dNm/MWKQLDCMN2Zj+gzotigMyJENzjxPSBR/HdTgUE73w==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      mysql2: ^3.0.0
-    peerDependenciesMeta:
-      mysql2:
-        optional: true
-
-  '@mimicai/adapter-mysql@0.10.2':
-    resolution: {integrity: sha512-Hdi6tOYcIsDFlt/Rn+Mrbe17+vViXBU7e6eBFp6jkZlaoiORXWXbspx61jOl3C1s4ruUxjF/DoG2Wkk+WirVCg==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      mysql2: ^3.0.0
-    peerDependenciesMeta:
-      mysql2:
-        optional: true
-
-  '@mimicai/adapter-paddle@0.10.0':
-    resolution: {integrity: sha512-HRkgjf/h2Kvv85VObxzDOugsLbvtuuDToY5yWBY0/NRmG8/ZZppioJGmCOZCYBZkRt2uuY2Obrc0C9zRg5Z4Iw==}
-    hasBin: true
-
-  '@mimicai/adapter-paddle@0.10.2':
-    resolution: {integrity: sha512-yp6Zu9gNeVB+uFXo7oZ8OKelTeS0vywfSKMCqrV0CpXDfAaaB0iQYbFaqy89vu/ERNObLW4cS5PgI/MDijOj5w==}
-    hasBin: true
-
-  '@mimicai/adapter-plaid@0.10.0':
-    resolution: {integrity: sha512-dsFoej8fy/JcmRWLiPGVQwFgnYq7m17cq/zXRHh5eHZzguzsuREeETnpVWyOMAFkB/630ffP0YU7QjeTTDraPg==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-plaid@0.10.2':
-    resolution: {integrity: sha512-fI68OhSQLQdf8rJtEQOzQNaiz1h6DlRZInz62/2fgQlemLgbgeNX2p7fJ8+eiYDByYSZOOWUlZdDCdQyCn7m5Q==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-postgres@0.10.0':
-    resolution: {integrity: sha512-dagQ+XuJQDGgQpEgMkYuoiVNj0IaAaMowLWlTnnhA2HWxWjfGkF4NfuBHAiV6SNQTOpCTZ66Gh/AQWWHVOZb/g==}
-    engines: {node: '>=22'}
-
-  '@mimicai/adapter-postgres@0.10.2':
-    resolution: {integrity: sha512-AtyF2oGK57L0rmB+4G55zv2Jrl/Bb/vXfSSJnDFBnnOsNmjjgPnkUIb0oYroApyhdVOfodVBz9fGKfyT8OgZfA==}
-    engines: {node: '>=22'}
-
-  '@mimicai/adapter-recurly@0.10.0':
-    resolution: {integrity: sha512-2k5vmSM130ehVamCLZ1KG96POMWrGjleM+LF/AV9N2N2cZULEo8/XrXC5652enCScVOF1UKPnFL6vPsAWlRBXQ==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-recurly@0.10.2':
-    resolution: {integrity: sha512-I5ZlvGdSs9UrRDSAYFFqukItjwYucdgiJHrhBtznUKGAciVEHH+sgey+HWUEMBplsM580Z+JcBAByaTCwr9B2w==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-revenuecat@0.10.0':
-    resolution: {integrity: sha512-+744iEgApHllee1rBBmfBQrsvO2XH1zVifpyQXHLUm4ggbeKlHKrSERr8sZeD9IVERNr8ohL9BB9FCgWVlSfjg==}
-    hasBin: true
-
-  '@mimicai/adapter-revenuecat@0.10.2':
-    resolution: {integrity: sha512-vBdIm1JEa//bibbf8OxKw3l3BNzSTLT6w5KVvClLpqBuyg6SA5ZQTWFMxBU1VOV5hho2Ee/ej9oyohJlKoiT1A==}
-    hasBin: true
-
-  '@mimicai/adapter-sdk@0.10.0':
-    resolution: {integrity: sha512-AcD5LRvEHSgJVPF6kPb8jbLuZo/MItuqDJ2MIr6B9oKqB5rwuSI5OcXtJtnb/vAeo47FF4TN7MjoIyfqkvgXeA==}
-    engines: {node: '>=22'}
-
-  '@mimicai/adapter-sdk@0.10.2':
-    resolution: {integrity: sha512-HP1P9XCCVmqHTqnEq+N2U9B29YFVDUI8I0l8qQ3WGnsDqSWoVlE7mJAVJeDnYkBwbA3E6hyKSKiZa/MmZFo7GA==}
-    engines: {node: '>=22'}
-
-  '@mimicai/adapter-sqlite@0.10.0':
-    resolution: {integrity: sha512-DnYyE2lhFV90SHBRTmqccSanPRnq4hWixdcAFdR+q+VDO4UNVF6Hf4SuYidkK4sRpKkmRVTO5fclfdrkcL35GA==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      better-sqlite3: ^11.0.0
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-
-  '@mimicai/adapter-sqlite@0.10.2':
-    resolution: {integrity: sha512-H9k7EdCVHhi4tFsH3oS6bZulpiBMrDmOXfXPGaapsv7gIxk/mXhf0/0VeML5hhAQyx2SkwQ6r3e7N6UEHb86Bw==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      better-sqlite3: ^11.0.0
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-
-  '@mimicai/adapter-stripe@0.10.0':
-    resolution: {integrity: sha512-xKyzpMelG2IYe+Vxvm/EEzXXfX2EiaQZNJwbKS/+964xXgWlYXgkB5TxqaRXnld6M3J1okMoS2X4/yFHOcAWQQ==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-stripe@0.10.2':
-    resolution: {integrity: sha512-MATifrt1DtPNgE0hLex79R0OqwmU2XNj1Jq0oOvUYbYNrNiQMgh1N1qpmCHViDgehi0HSOOntha0Upvv+X24YQ==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/adapter-zuora@0.10.0':
-    resolution: {integrity: sha512-DOHynHeP6Un66xI6sGH9xDqzVHK/YbRa6smJNfGXd7oFBOCsYW/aEiFAc8V17ZCxbU6qzbQcbIdePRnem6DXxA==}
-    hasBin: true
-
-  '@mimicai/adapter-zuora@0.10.2':
-    resolution: {integrity: sha512-g503CkNIiqnOfvBs5Mpdz66UGdrYJtwzs9Mnj/0cgBT67kUwUqNhBMT0ZxqJxFQRqP2WksmyZqFGqRz+Yy6yRg==}
-    hasBin: true
-
-  '@mimicai/blueprints@0.10.0':
-    resolution: {integrity: sha512-8U/Z0bYRksYn1AC4Yzml7IsEzrzC1PaE6O9WdYE0KJmfrWhBaHUbEWOWyxL0xEcfvKMBMsXlF0A8kbRTaE85ww==}
-    engines: {node: '>=22'}
-
-  '@mimicai/blueprints@0.10.2':
-    resolution: {integrity: sha512-2uYzc6522GXknx2GrNa+WaNADNXTFaTPzFjVVWtR22L+SZxt4QsSX3DS/Ur1rAk09KuH/wy1mPL3NqtQurXsfw==}
-    engines: {node: '>=22'}
-
-  '@mimicai/cli@0.10.0':
-    resolution: {integrity: sha512-oPGXYrAIfKIJ1mH6KdMnzg6zvPKzGEqETW2IGmt/Lv0niQhtfeuC+QfKwUmJec1zwT2Y9a810G3WMQohnekKUg==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/cli@0.10.2':
-    resolution: {integrity: sha512-F2nmKbSs9PCiro7BzSeSks40+0loesLHBzHl4t6eGUr9a7xfpPYQYT7O9PNAR/E+4vnMKydhblL7FXyLZDVtZA==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@mimicai/core@0.10.0':
-    resolution: {integrity: sha512-oOoYl9tFS0D4oCg1bcgbmOyKhRYoeTN/sgN3TrDdyBccqpfigtVXsECLBi0zH7/XJAmdad8U54pFF1u0lqMbwg==}
-    engines: {node: '>=22'}
-
-  '@mimicai/core@0.10.2':
-    resolution: {integrity: sha512-5myPK3dsaLu/3MeVcWxBzsy4TfuPbhsUTz1yXqKeQR9OgVYFa0UHJcupXZdmA2n31m0zcQJQ0LygEq16rFdrvQ==}
-    engines: {node: '>=22'}
-
-  '@mimicai/explorer@0.10.0':
-    resolution: {integrity: sha512-CGdD/g/mCLtt0ZUUsmox/suLWJHhIYTT3h3PixDs7kkV1lJqSIlYN+KlBOqb6FERgtYV8loS2scJQXh/I2qTqA==}
-    peerDependencies:
-      react: ^19.0.0
-      react-dom: ^19.0.0
-
-  '@mimicai/explorer@0.10.2':
-    resolution: {integrity: sha512-8mM8ug5V779uweneUovEfC4YLk9L8IbPyGQImG2e9GUSox8TWy+H/zEycsk9P57rEzme11S2p9fF/Spycyn4pQ==}
-    peerDependencies:
-      react: ^19.0.0
-      react-dom: ^19.0.0
-
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
@@ -1765,10 +1441,6 @@ packages:
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
-
-  '@mrleebo/prisma-ast@0.12.1':
-    resolution: {integrity: sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==}
-    engines: {node: '>=16'}
 
   '@mrleebo/prisma-ast@0.13.1':
     resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
@@ -2386,10 +2058,6 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -2598,10 +2266,6 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
-
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
@@ -2621,23 +2285,12 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2660,10 +2313,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -2831,9 +2480,6 @@ packages:
 
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3125,12 +2771,6 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3318,10 +2958,6 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -3336,10 +2972,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -3478,10 +3110,6 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
-    engines: {node: '>=18'}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -3737,9 +3365,6 @@ packages:
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
-  mnemonist@0.40.0:
-    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
-
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
@@ -3780,10 +3405,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -3873,12 +3494,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obliterator@2.0.5:
-    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
-
-  obuf@1.1.2:
-    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -3908,10 +3523,6 @@ packages:
 
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
-
-  ora@8.2.0:
-    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
-    engines: {node: '>=18'}
 
   ora@9.3.0:
     resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
@@ -3951,9 +3562,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -4004,9 +3612,6 @@ packages:
 
   pg-connection-string@2.12.0:
     resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
-
-  pg-copy-streams@6.0.6:
-    resolution: {integrity: sha512-Z+Dd2C2NIDTsjyFKmc6a9QLlpM8tjpERx+43RSx0WmL7j3uNChERi3xSvZUL0hWJ1oRUn4S3fhyt3apdSrTyKQ==}
 
   pg-copy-streams@7.0.0:
     resolution: {integrity: sha512-zBvnY6wtaBRE2ae2xXWOOGMaNVPkXh1vhypAkNSKgMdciJeTyIQAHZaEeRAxUjs/p1El5jgzYmwG5u871Zj3dQ==}
@@ -4529,10 +4134,6 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
-    engines: {node: '>=18'}
-
   stdin-discarder@0.3.1:
     resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
     engines: {node: '>=18'}
@@ -4540,10 +4141,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
 
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
@@ -5067,10 +4664,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5093,10 +4686,6 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
-
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -5554,12 +5143,6 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
-  '@fastify/cors@10.1.0':
-    dependencies:
-      fastify-plugin: 5.1.0
-      mnemonist: 0.40.0
-    optional: true
-
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
@@ -5594,16 +5177,6 @@ snapshots:
       fast-decode-uri-component: 1.0.1
       http-errors: 2.0.1
       mime: 3.0.0
-
-  '@fastify/static@8.3.0':
-    dependencies:
-      '@fastify/accept-negotiator': 2.0.1
-      '@fastify/send': 4.1.0
-      content-disposition: 0.5.4
-      fastify-plugin: 5.1.0
-      fastq: 1.20.1
-      glob: 11.1.0
-    optional: true
 
   '@fastify/static@9.0.0':
     dependencies:
@@ -5719,19 +5292,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/ansi@1.0.2': {}
-
   '@inquirer/ansi@2.0.4': {}
-
-  '@inquirer/checkbox@4.3.2(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
 
   '@inquirer/checkbox@5.1.2(@types/node@25.5.0)':
     dependencies:
@@ -5742,30 +5303,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/confirm@5.1.21(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/confirm@6.0.10(@types/node@25.5.0)':
     dependencies:
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/core@10.3.2(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5781,27 +5322,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/editor@4.2.23(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/editor@5.0.10(@types/node@25.5.0)':
     dependencies:
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/external-editor': 2.0.4(@types/node@25.5.0)
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/expand@4.0.23(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5826,28 +5351,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/figures@1.0.15': {}
-
   '@inquirer/figures@2.0.4': {}
-
-  '@inquirer/input@4.3.1(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
 
   '@inquirer/input@5.0.10(@types/node@25.5.0)':
     dependencies:
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/number@3.0.23(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5858,34 +5367,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/password@4.0.23(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/password@5.0.10(@types/node@25.5.0)':
     dependencies:
       '@inquirer/ansi': 2.0.4
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/prompts@7.10.1(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@25.5.0)
-      '@inquirer/confirm': 5.1.21(@types/node@25.5.0)
-      '@inquirer/editor': 4.2.23(@types/node@25.5.0)
-      '@inquirer/expand': 4.0.23(@types/node@25.5.0)
-      '@inquirer/input': 4.3.1(@types/node@25.5.0)
-      '@inquirer/number': 3.0.23(@types/node@25.5.0)
-      '@inquirer/password': 4.0.23(@types/node@25.5.0)
-      '@inquirer/rawlist': 4.1.11(@types/node@25.5.0)
-      '@inquirer/search': 3.2.2(@types/node@25.5.0)
-      '@inquirer/select': 4.4.2(@types/node@25.5.0)
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5904,27 +5390,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/rawlist@4.1.11(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/rawlist@5.2.6(@types/node@25.5.0)':
     dependencies:
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/search@3.2.2(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5933,16 +5402,6 @@ snapshots:
       '@inquirer/core': 11.1.7(@types/node@25.5.0)
       '@inquirer/figures': 2.0.4
       '@inquirer/type': 4.0.4(@types/node@25.5.0)
-    optionalDependencies:
-      '@types/node': 25.5.0
-
-  '@inquirer/select@4.4.2(@types/node@25.5.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.5.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.5.0)
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -5955,16 +5414,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@inquirer/type@3.0.10(@types/node@25.5.0)':
-    optionalDependencies:
-      '@types/node': 25.5.0
-
   '@inquirer/type@4.0.4(@types/node@25.5.0)':
     optionalDependencies:
       '@types/node': 25.5.0
-
-  '@isaacs/cliui@9.0.0':
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6033,455 +5485,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mimicai/adapter-chargebee@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-chargebee@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-gocardless@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-gocardless@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-lemonsqueezy@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-lemonsqueezy@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-mongodb@0.10.0(mongodb@6.21.0)':
-    dependencies:
-      '@mimicai/core': 0.10.0
-    optionalDependencies:
-      mongodb: 6.21.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-mongodb@0.10.2(mongodb@6.21.0)':
-    dependencies:
-      '@mimicai/core': 0.10.2
-    optionalDependencies:
-      mongodb: 6.21.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-mysql@0.10.0(mysql2@3.20.0(@types/node@25.5.0))':
-    dependencies:
-      '@mimicai/core': 0.10.0
-    optionalDependencies:
-      mysql2: 3.20.0(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-mysql@0.10.2(mysql2@3.20.0(@types/node@25.5.0))':
-    dependencies:
-      '@mimicai/core': 0.10.2
-    optionalDependencies:
-      mysql2: 3.20.0(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-paddle@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-paddle@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-plaid@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-plaid@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-postgres@0.10.0':
-    dependencies:
-      '@mimicai/core': 0.10.0
-      pg: 8.20.0
-      pg-copy-streams: 6.0.6
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - pg-native
-      - supports-color
-
-  '@mimicai/adapter-postgres@0.10.2':
-    dependencies:
-      '@mimicai/core': 0.10.2
-      pg: 8.20.0
-      pg-copy-streams: 7.0.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - pg-native
-      - supports-color
-
-  '@mimicai/adapter-recurly@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-recurly@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-revenuecat@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-revenuecat@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-sdk@0.10.0':
-    dependencies:
-      '@fastify/formbody': 8.0.2
-      '@mimicai/core': 0.10.0
-      fastify: 5.8.2
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-sdk@0.10.2':
-    dependencies:
-      '@fastify/formbody': 8.0.2
-      '@mimicai/core': 0.10.2
-      fastify: 5.8.2
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-sqlite@0.10.0(better-sqlite3@12.8.0)':
-    dependencies:
-      '@mimicai/core': 0.10.0
-    optionalDependencies:
-      better-sqlite3: 12.8.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-sqlite@0.10.2(better-sqlite3@11.10.0)':
-    dependencies:
-      '@mimicai/core': 0.10.2
-    optionalDependencies:
-      better-sqlite3: 11.10.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-stripe@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-stripe@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/adapter-zuora@0.10.0':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.0
-      '@mimicai/core': 0.10.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/adapter-zuora@0.10.2':
-    dependencies:
-      '@mimicai/adapter-sdk': 0.10.2
-      '@mimicai/core': 0.10.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      fastify: 5.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/blueprints@0.10.0':
-    dependencies:
-      '@mimicai/core': 0.10.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/blueprints@0.10.2':
-    dependencies:
-      '@mimicai/core': 0.10.2
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/cli@0.10.0(@types/node@25.5.0)(better-sqlite3@12.8.0)(mongodb@6.21.0)(mysql2@3.20.0(@types/node@25.5.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@25.5.0)
-      '@mimicai/adapter-mongodb': 0.10.0(mongodb@6.21.0)
-      '@mimicai/adapter-mysql': 0.10.0(mysql2@3.20.0(@types/node@25.5.0))
-      '@mimicai/adapter-postgres': 0.10.0
-      '@mimicai/adapter-sqlite': 0.10.0(better-sqlite3@12.8.0)
-      '@mimicai/blueprints': 0.10.0
-      '@mimicai/core': 0.10.0
-      chalk: 5.6.2
-      cli-table3: 0.6.5
-      commander: 13.1.0
-      ora: 8.2.0
-      pg: 8.20.0
-    optionalDependencies:
-      '@mimicai/adapter-chargebee': 0.10.0
-      '@mimicai/adapter-gocardless': 0.10.0
-      '@mimicai/adapter-lemonsqueezy': 0.10.0
-      '@mimicai/adapter-paddle': 0.10.0
-      '@mimicai/adapter-plaid': 0.10.0
-      '@mimicai/adapter-recurly': 0.10.0
-      '@mimicai/adapter-revenuecat': 0.10.0
-      '@mimicai/adapter-stripe': 0.10.0
-      '@mimicai/adapter-zuora': 0.10.0
-      '@mimicai/explorer': 0.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@types/node'
-      - better-sqlite3
-      - mongodb
-      - mysql2
-      - pg-native
-      - react
-      - react-dom
-      - supports-color
-
-  '@mimicai/cli@0.10.2(@types/node@25.5.0)(better-sqlite3@11.10.0)(mongodb@6.21.0)(mysql2@3.20.0(@types/node@25.5.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@inquirer/prompts': 8.3.2(@types/node@25.5.0)
-      '@mimicai/adapter-mongodb': 0.10.2(mongodb@6.21.0)
-      '@mimicai/adapter-mysql': 0.10.2(mysql2@3.20.0(@types/node@25.5.0))
-      '@mimicai/adapter-postgres': 0.10.2
-      '@mimicai/adapter-sqlite': 0.10.2(better-sqlite3@11.10.0)
-      '@mimicai/blueprints': 0.10.2
-      '@mimicai/core': 0.10.2
-      chalk: 5.6.2
-      cli-table3: 0.6.5
-      commander: 14.0.3
-      ora: 9.3.0
-      pg: 8.20.0
-    optionalDependencies:
-      '@mimicai/adapter-chargebee': 0.10.2
-      '@mimicai/adapter-gocardless': 0.10.2
-      '@mimicai/adapter-lemonsqueezy': 0.10.2
-      '@mimicai/adapter-paddle': 0.10.2
-      '@mimicai/adapter-plaid': 0.10.2
-      '@mimicai/adapter-recurly': 0.10.2
-      '@mimicai/adapter-revenuecat': 0.10.2
-      '@mimicai/adapter-stripe': 0.10.2
-      '@mimicai/adapter-zuora': 0.10.2
-      '@mimicai/explorer': 0.10.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@types/node'
-      - better-sqlite3
-      - mongodb
-      - mysql2
-      - pg-native
-      - react
-      - react-dom
-      - supports-color
-
-  '@mimicai/core@0.10.0':
-    dependencies:
-      '@ai-sdk/anthropic': 3.0.58(zod@3.25.76)
-      '@ai-sdk/openai': 3.0.41(zod@3.25.76)
-      '@faker-js/faker': 10.3.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      '@mrleebo/prisma-ast': 0.12.1
-      ai: 6.0.116(zod@3.25.76)
-      chalk: 5.6.2
-      fastify: 5.8.2
-      ora: 8.2.0
-      pgsql-parser: 17.9.14
-      seedrandom: 3.0.5
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/core@0.10.2':
-    dependencies:
-      '@ai-sdk/anthropic': 3.0.58(zod@3.25.76)
-      '@ai-sdk/openai': 3.0.41(zod@3.25.76)
-      '@faker-js/faker': 10.3.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      '@mrleebo/prisma-ast': 0.15.0
-      ai: 6.0.116(zod@3.25.76)
-      chalk: 5.6.2
-      fastify: 5.8.2
-      ora: 9.3.0
-      pgsql-parser: 17.9.14
-      seedrandom: 3.0.5
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@mimicai/explorer@0.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@fastify/cors': 10.1.0
-      '@fastify/static': 8.3.0
-      '@mimicai/core': 0.10.0
-      fastify: 5.8.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
-  '@mimicai/explorer@0.10.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@fastify/cors': 11.2.0
-      '@fastify/static': 9.0.0
-      '@mimicai/core': 0.10.2
-      fastify: 5.8.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-    optional: true
-
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
@@ -6507,11 +5510,6 @@ snapshots:
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
       sparse-bitfield: 3.0.3
-
-  '@mrleebo/prisma-ast@0.12.1':
-    dependencies:
-      chevrotain: 10.5.0
-      lilconfig: 2.1.0
 
   '@mrleebo/prisma-ast@0.13.1':
     dependencies:
@@ -7043,10 +6041,6 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -7347,8 +6341,6 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-spinners@2.9.2: {}
-
   cli-spinners@3.4.0: {}
 
   cli-table3@0.6.5:
@@ -7363,17 +6355,9 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
-
-  commander@13.1.0: {}
 
   commander@14.0.3: {}
 
@@ -7386,11 +6370,6 @@ snapshots:
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
-
-  content-disposition@0.5.4:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
 
   content-disposition@1.0.1: {}
 
@@ -7531,8 +6510,6 @@ snapshots:
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.321: {}
-
-  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -7902,16 +6879,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
-    optional: true
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
@@ -8164,8 +7131,6 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
-  is-unicode-supported@1.3.0: {}
-
   is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
@@ -8175,11 +7140,6 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
-
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
-    optional: true
 
   jiti@2.6.1: {}
 
@@ -8286,11 +7246,6 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.17.21: {}
-
-  log-symbols@6.0.0:
-    dependencies:
-      chalk: 5.6.2
-      is-unicode-supported: 1.3.0
 
   log-symbols@7.0.1:
     dependencies:
@@ -8800,11 +7755,6 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mnemonist@0.40.0:
-    dependencies:
-      obliterator: 2.0.5
-    optional: true
-
   mongodb-connection-string-url@3.0.2:
     dependencies:
       '@types/whatwg-url': 11.0.5
@@ -8821,8 +7771,6 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
-
-  mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
 
@@ -8914,11 +7862,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obliterator@2.0.5:
-    optional: true
-
-  obuf@1.1.2: {}
-
   obug@2.1.1: {}
 
   ofetch@1.5.1:
@@ -8950,18 +7893,6 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  ora@8.2.0:
-    dependencies:
-      chalk: 5.6.2
-      cli-cursor: 5.0.0
-      cli-spinners: 2.9.2
-      is-interactive: 2.0.0
-      is-unicode-supported: 2.1.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
 
   ora@9.3.0:
     dependencies:
@@ -9002,9 +7933,6 @@ snapshots:
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
-
-  package-json-from-dist@1.0.1:
-    optional: true
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -9058,10 +7986,6 @@ snapshots:
     optional: true
 
   pg-connection-string@2.12.0: {}
-
-  pg-copy-streams@6.0.6:
-    dependencies:
-      obuf: 1.1.2
 
   pg-copy-streams@7.0.0: {}
 
@@ -9721,8 +8645,6 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  stdin-discarder@0.2.2: {}
-
   stdin-discarder@0.3.1: {}
 
   string-width@4.2.3:
@@ -9730,12 +8652,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
 
   string-width@8.2.0:
     dependencies:
@@ -10153,12 +9069,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
@@ -10170,8 +9080,6 @@ snapshots:
   yargs-parser@22.0.0: {}
 
   yocto-queue@1.2.2: {}
-
-  yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
## Summary
- **fix(cli):** Always use HTTP transport for `mimic host` so it runs as a background server (stdio blocked on stdin for single-server setups)
- **docs:** Add `mimic explore` command to CLI reference
- **feat(core):** Add `StateStore.serialize()` and `hydrate()` for cloud persistence
- **feat(core):** Add Anthropic Claude model support in LLM client
- **adapters:** Codegen updates across all 9 adapters — remove basePath prefixes, update MCP tool descriptions, regenerate routes/meta

## Test plan
- [ ] Verify `mimic host` starts correctly with a single adapter (HTTP transport, not stdio)
- [ ] Verify `mimic host` can be backgrounded without blocking
- [ ] Verify `mimic explore` docs render correctly on the docs site
- [ ] Run adapter test suites: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)