### PR TITLE
fix: update cfo-agent example for npm packages and Prisma 7

### DIFF
--- a/examples/cfo-agent/README.md
+++ b/examples/cfo-agent/README.md
@@ -49,11 +49,10 @@ For a deeper architecture walkthrough, see `ARCHITECTURE.md`.
 ## Prerequisites
 
 - Node.js `>=22`
-- `pnpm` for rebuilding workspace packages
 - Docker for PostgreSQL
 - One model provider key:
-  - `OPENAI_API_KEY` for OpenAI models (default: gpt-5.4), or
-  - `ANTHROPIC_API_KEY` for Claude models
+  - `ANTHROPIC_API_KEY` for Claude models (default: claude-sonnet-4-6), or
+  - `OPENAI_API_KEY` for OpenAI models
 
 ## Quick Start
 
@@ -73,25 +72,28 @@ This starts PostgreSQL 17 on port `5435` with:
 
 ```bash
 cp .env.example .env
-# Add OPENAI_API_KEY (required for data generation with gpt-5.4)
-# Optionally add ANTHROPIC_API_KEY for the agent
+# Add ANTHROPIC_API_KEY (required for data generation and the agent)
+# Optionally add OPENAI_API_KEY if you prefer OpenAI models
 ```
 
-### 3. Generate Prisma client and run the schema
+### 3. Install dependencies and set up the database
 
 ```bash
+npm install
 export $(cat .env | xargs)
 npx prisma generate
 npx prisma migrate dev --name init
 ```
+
+> **Note:** This example uses Prisma 7, which requires a `prisma.config.ts` file for the datasource URL (already included). The Prisma schema itself does not contain a `url` property.
 
 ### 4. Generate synthetic data and seed PostgreSQL
 
 From the `examples/cfo-agent` root:
 
 ```bash
-pnpm exec mimic run -g        # generate blueprints + expand + generate facts
-pnpm exec mimic seed --verbose # push DB tables into PostgreSQL
+npx mimic run -g        # generate blueprints + expand + generate facts
+npx mimic seed --verbose # push DB tables into PostgreSQL
 ```
 
 The `-g` flag forces fresh blueprint generation. Without it, cached blueprints under `.mimic/blueprints/` are reused and only expansion runs.
@@ -109,7 +111,7 @@ Generated artifacts are written under:
 ### 5. Explore the data (optional)
 
 ```bash
-pnpm exec mimic explore
+npx mimic explore
 ```
 
 Opens an interactive UI at `http://localhost:7879` showing all adapters, endpoint counts, persona data, and facts.
@@ -120,7 +122,7 @@ In a new terminal, from the `examples/cfo-agent` root:
 
 ```bash
 export $(cat .env | xargs)
-pnpm exec mimic host
+npx mimic host
 ```
 
 You should see all 9 MCP servers come up:
@@ -173,22 +175,6 @@ If Turbopack cache errors appear after switching branches or rebuilding packages
 ```bash
 rm -rf ui/.next
 ```
-
-## Local Development After Package Changes
-
-If you edit code under `packages/` such as an adapter or the CLI, rebuild the affected workspace packages before restarting the example:
-
-```bash
-pnpm --filter @mimicai/adapter-revenuecat build
-pnpm --filter @mimicai/cli build
-```
-
-In general, after changing adapter or CLI source:
-
-1. rebuild the changed packages with `pnpm`
-2. restart `mimic host`
-3. restart the agent
-4. restart the UI if needed
 
 ## Demo Questions
 
@@ -269,6 +255,6 @@ curl -H "Authorization: Bearer sk_test_growth-saas_demo" \
 
 ```bash
 docker compose down -v
-pnpm exec mimic clean --yes
+npx mimic clean --yes
 rm -rf ui/.next
 ```

--- a/examples/cfo-agent/package-lock.json
+++ b/examples/cfo-agent/package-lock.json
@@ -8,26 +8,30 @@
       "name": "cfo-agent-example",
       "version": "0.0.4",
       "dependencies": {
-        "@mimicai/adapter-chargebee": "^0.10.2",
-        "@mimicai/adapter-gocardless": "^0.10.2",
-        "@mimicai/adapter-lemonsqueezy": "^0.10.2",
-        "@mimicai/adapter-paddle": "^0.10.2",
-        "@mimicai/adapter-postgres": "^0.10.2",
-        "@mimicai/adapter-recurly": "^0.10.2",
-        "@mimicai/adapter-revenuecat": "^0.10.2",
-        "@mimicai/adapter-stripe": "^0.10.2",
-        "@mimicai/adapter-zuora": "^0.10.2",
-        "@mimicai/cli": "^0.10.2"
+        "@mimicai/adapter-chargebee": "^0.11.1",
+        "@mimicai/adapter-gocardless": "^0.11.1",
+        "@mimicai/adapter-lemonsqueezy": "^0.11.1",
+        "@mimicai/adapter-paddle": "^0.11.1",
+        "@mimicai/adapter-postgres": "^0.11.1",
+        "@mimicai/adapter-recurly": "^0.11.1",
+        "@mimicai/adapter-revenuecat": "^0.11.1",
+        "@mimicai/adapter-stripe": "^0.11.1",
+        "@mimicai/adapter-zuora": "^0.11.1",
+        "@mimicai/cli": "^0.11.1"
+      },
+      "devDependencies": {
+        "@prisma/client": "^7.5.0",
+        "prisma": "^7.5.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.58.tgz",
-      "integrity": "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==",
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.64.tgz",
+      "integrity": "sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19"
+        "@ai-sdk/provider-utils": "4.0.21"
       },
       "engines": {
         "node": ">=18"
@@ -37,13 +41,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.66",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
-      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.80.tgz",
+      "integrity": "sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19",
+        "@ai-sdk/provider-utils": "4.0.21",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -54,13 +58,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.41",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.41.tgz",
-      "integrity": "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==",
+      "version": "3.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.48.tgz",
+      "integrity": "sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19"
+        "@ai-sdk/provider-utils": "4.0.21"
       },
       "engines": {
         "node": ">=18"
@@ -82,9 +86,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
-      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
+      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -147,10 +151,40 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
+      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-socket": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
+      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "pglite-server": "dist/scripts/server.js"
+      },
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
+      }
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
+      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
+      }
+    },
     "node_modules/@faker-js/faker": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.3.0.tgz",
-      "integrity": "sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
       "funding": [
         {
           "type": "opencollective",
@@ -732,12 +766,12 @@
       }
     },
     "node_modules/@mimicai/adapter-chargebee": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-chargebee/-/adapter-chargebee-0.10.2.tgz",
-      "integrity": "sha512-JyxuF6jdty3Y+T81unxq0OBgCIY45kol0G+pB9mDnOmHmqSaM29JPOvOc2ZwO/JoxaS9h/f38oF+/pgVosnZgA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-chargebee/-/adapter-chargebee-0.11.1.tgz",
+      "integrity": "sha512-dWAOqqeq7Q7FgbfoX7kp2BbglBE5FR51Cuj96bWE/FeqvFHm4Pobmh2dK5fAylP5SQxQ/fNfC2y0j5WrqeB/SA==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -747,12 +781,12 @@
       }
     },
     "node_modules/@mimicai/adapter-gocardless": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-gocardless/-/adapter-gocardless-0.10.2.tgz",
-      "integrity": "sha512-3CMZxtOygn0hNapcvmTpzG9hM8O+mcieqgBsy6+sN2lm0bt9Y81Ayl2ATILL0xnX9nSKDCQlv/7jR9ZzpUTEEw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-gocardless/-/adapter-gocardless-0.11.1.tgz",
+      "integrity": "sha512-kuFf/ER2R3cXmKf955ja7WboFLj3HKAMq597naPbSkeuM1XBlEed+DPdZgS5IkjtWOBQ75V/FUEjWcUcdpPOXQ==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -762,12 +796,12 @@
       }
     },
     "node_modules/@mimicai/adapter-lemonsqueezy": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-lemonsqueezy/-/adapter-lemonsqueezy-0.10.2.tgz",
-      "integrity": "sha512-UIWRyFtOuZM5lSeGwIjd0dnhp1LoDL56x231Lk7hnIt33az1oSseVDQ2K1RtG+WVAk0XOqr47I82ymio6K8bZw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-lemonsqueezy/-/adapter-lemonsqueezy-0.11.1.tgz",
+      "integrity": "sha512-CZ6uDowP5nlMobmu6VhW/DnlNAsJ9dgTIdhlhKhc6YzxItbfj634Y3fnx3AXU54XlaONFbUEBtOMqOj/VVzTwA==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -777,12 +811,12 @@
       }
     },
     "node_modules/@mimicai/adapter-mongodb": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-mongodb/-/adapter-mongodb-0.10.2.tgz",
-      "integrity": "sha512-lV1B+X3SA5LZq9+hPH9fUa41m3GbVPHL/NtkJ6g1rqqP8NjmhLhNQYEx6RaILtN1PIDXr4d4WkN5d7i4pxeKkQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-mongodb/-/adapter-mongodb-0.11.1.tgz",
+      "integrity": "sha512-LSAwYuUyZRhPEuXRHJvwru4JPEUxL4KG4vSvKhejQ/yQD24eu7NVucR8ZDKWaP9UcQYYKYbyQYRbPy/chxD2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/core": "0.10.2"
+        "@mimicai/core": "0.11.1"
       },
       "engines": {
         "node": ">=22"
@@ -797,12 +831,12 @@
       }
     },
     "node_modules/@mimicai/adapter-mysql": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-mysql/-/adapter-mysql-0.10.2.tgz",
-      "integrity": "sha512-Hdi6tOYcIsDFlt/Rn+Mrbe17+vViXBU7e6eBFp6jkZlaoiORXWXbspx61jOl3C1s4ruUxjF/DoG2Wkk+WirVCg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-mysql/-/adapter-mysql-0.11.1.tgz",
+      "integrity": "sha512-u8uvnhaJVshwdGkGNp1HTdxox00CGp/wxzxfrSig3BOTCEqm+cGgnfRHYkYL1XcQn7mUoT8wb6cuwtwLkxQt0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/core": "0.10.2"
+        "@mimicai/core": "0.11.1"
       },
       "engines": {
         "node": ">=22"
@@ -817,12 +851,12 @@
       }
     },
     "node_modules/@mimicai/adapter-paddle": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-paddle/-/adapter-paddle-0.10.2.tgz",
-      "integrity": "sha512-yp6Zu9gNeVB+uFXo7oZ8OKelTeS0vywfSKMCqrV0CpXDfAaaB0iQYbFaqy89vu/ERNObLW4cS5PgI/MDijOj5w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-paddle/-/adapter-paddle-0.11.1.tgz",
+      "integrity": "sha512-TOQ4lwxMejrUihqoxsj+Zyqg5OeeUECdhwaFKUy6pwfZ2cODz8ojtJjhh7pqU/2fY+36fo5kGTrvfcMcFavGfw==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -832,14 +866,14 @@
       }
     },
     "node_modules/@mimicai/adapter-plaid": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-plaid/-/adapter-plaid-0.10.2.tgz",
-      "integrity": "sha512-fI68OhSQLQdf8rJtEQOzQNaiz1h6DlRZInz62/2fgQlemLgbgeNX2p7fJ8+eiYDByYSZOOWUlZdDCdQyCn7m5Q==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-plaid/-/adapter-plaid-0.11.1.tgz",
+      "integrity": "sha512-nSymBN8s5uN35qIgv9G3blXb0ZoQxeNRgXkJSYmDz0mDirIqinSZnHtXkvtgv9xPDHaGZXH7fbI2Th9iJFljpw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -852,12 +886,12 @@
       }
     },
     "node_modules/@mimicai/adapter-postgres": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-postgres/-/adapter-postgres-0.10.2.tgz",
-      "integrity": "sha512-AtyF2oGK57L0rmB+4G55zv2Jrl/Bb/vXfSSJnDFBnnOsNmjjgPnkUIb0oYroApyhdVOfodVBz9fGKfyT8OgZfA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-postgres/-/adapter-postgres-0.11.1.tgz",
+      "integrity": "sha512-ad8qBvIgJukKU2FJbSWNLCyHE7Wf0X3sAVkKm5SO+Dt44V7vJAnx4Nmd2/8SXITjGf3vQYePvl/znOMHm7yrEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/core": "0.10.2",
+        "@mimicai/core": "0.11.1",
         "pg": "^8.20.0",
         "pg-copy-streams": "^7.0.0"
       },
@@ -866,13 +900,13 @@
       }
     },
     "node_modules/@mimicai/adapter-recurly": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-recurly/-/adapter-recurly-0.10.2.tgz",
-      "integrity": "sha512-I5ZlvGdSs9UrRDSAYFFqukItjwYucdgiJHrhBtznUKGAciVEHH+sgey+HWUEMBplsM580Z+JcBAByaTCwr9B2w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-recurly/-/adapter-recurly-0.11.1.tgz",
+      "integrity": "sha512-P/vc/uAZRIN9BCQ9vX/sYVdUQ19HieLrL2YlNU9sRUhqNOdATeTn1d78FT2uu0lSsdkEhUzjnE61/VJ89lz3mg==",
       "license": "MIT",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -885,12 +919,12 @@
       }
     },
     "node_modules/@mimicai/adapter-revenuecat": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-revenuecat/-/adapter-revenuecat-0.10.2.tgz",
-      "integrity": "sha512-vBdIm1JEa//bibbf8OxKw3l3BNzSTLT6w5KVvClLpqBuyg6SA5ZQTWFMxBU1VOV5hho2Ee/ej9oyohJlKoiT1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-revenuecat/-/adapter-revenuecat-0.11.1.tgz",
+      "integrity": "sha512-sVJNYpS9uH+ok9JOTlVjYv5gsvdrKGWviKVdr97i/RMdLV4dVaE/KJowF/N2WMCTjSjTnuanqgUcN0IYmaO5rw==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -900,13 +934,13 @@
       }
     },
     "node_modules/@mimicai/adapter-sdk": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-sdk/-/adapter-sdk-0.10.2.tgz",
-      "integrity": "sha512-HP1P9XCCVmqHTqnEq+N2U9B29YFVDUI8I0l8qQ3WGnsDqSWoVlE7mJAVJeDnYkBwbA3E6hyKSKiZa/MmZFo7GA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-sdk/-/adapter-sdk-0.11.1.tgz",
+      "integrity": "sha512-v1FyCYncTNx7n++jhnUYQG4D5wmLLvz9u8gKp7X4WFWlv1qKNukvccg766B6mcsVUlb2YwclaphZFk0b7h63rA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/formbody": "^8.0.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/core": "0.11.1",
         "fastify": "^5.8.2"
       },
       "engines": {
@@ -914,12 +948,12 @@
       }
     },
     "node_modules/@mimicai/adapter-sqlite": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-sqlite/-/adapter-sqlite-0.10.2.tgz",
-      "integrity": "sha512-H9k7EdCVHhi4tFsH3oS6bZulpiBMrDmOXfXPGaapsv7gIxk/mXhf0/0VeML5hhAQyx2SkwQ6r3e7N6UEHb86Bw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-sqlite/-/adapter-sqlite-0.11.1.tgz",
+      "integrity": "sha512-Lk2ZCz/0a9nei4GSRNwk05TDnvJQtq0xaWP8beNStprrl0bYnlAOH8geGXPO+SPApRpY5gHCqUKciC93XUBL0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/core": "0.10.2"
+        "@mimicai/core": "0.11.1"
       },
       "engines": {
         "node": ">=22"
@@ -934,13 +968,13 @@
       }
     },
     "node_modules/@mimicai/adapter-stripe": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-stripe/-/adapter-stripe-0.10.2.tgz",
-      "integrity": "sha512-MATifrt1DtPNgE0hLex79R0OqwmU2XNj1Jq0oOvUYbYNrNiQMgh1N1qpmCHViDgehi0HSOOntha0Upvv+X24YQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-stripe/-/adapter-stripe-0.11.1.tgz",
+      "integrity": "sha512-UYOqEo6VKhW6Pn4wlcHptH6o/vumqqzuuXPqjF7M3dcRMmT2kC16W8kZmYj5wGvDdPxBYxH+UHo28hAK9g3ysw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -953,12 +987,12 @@
       }
     },
     "node_modules/@mimicai/adapter-zuora": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/adapter-zuora/-/adapter-zuora-0.10.2.tgz",
-      "integrity": "sha512-g503CkNIiqnOfvBs5Mpdz66UGdrYJtwzs9Mnj/0cgBT67kUwUqNhBMT0ZxqJxFQRqP2WksmyZqFGqRz+Yy6yRg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/adapter-zuora/-/adapter-zuora-0.11.1.tgz",
+      "integrity": "sha512-2T58j9wwPIxpkfphWL5f+v6KnmsMXyAibUeK3rjaIKYKRaml+MOeiAxW9eihAj4M3S6J/swuyyiDGB/gb85p5w==",
       "dependencies": {
-        "@mimicai/adapter-sdk": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-sdk": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "fastify": "^5.8.2",
         "zod": "^3.24.2"
@@ -968,30 +1002,30 @@
       }
     },
     "node_modules/@mimicai/blueprints": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/blueprints/-/blueprints-0.10.2.tgz",
-      "integrity": "sha512-2uYzc6522GXknx2GrNa+WaNADNXTFaTPzFjVVWtR22L+SZxt4QsSX3DS/Ur1rAk09KuH/wy1mPL3NqtQurXsfw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/blueprints/-/blueprints-0.11.1.tgz",
+      "integrity": "sha512-e6FD5tW5iNm/Zm5LUSSMnpn9/f4GyBWepXp9WwMSpRWUVKbaVPy7vLcqCZnTT2pfRPhgCtvBFbpV7auLyQxk/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mimicai/core": "0.10.2"
+        "@mimicai/core": "0.11.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@mimicai/cli": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/cli/-/cli-0.10.2.tgz",
-      "integrity": "sha512-F2nmKbSs9PCiro7BzSeSks40+0loesLHBzHl4t6eGUr9a7xfpPYQYT7O9PNAR/E+4vnMKydhblL7FXyLZDVtZA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/cli/-/cli-0.11.1.tgz",
+      "integrity": "sha512-vWwVhtVno1lyDEF74aW7/1jTA/98HWBDTuH14H3xy0oYrukRjgpJciz/jh3hPd8h8hlCAD2MFowocBNjX4GdAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@mimicai/adapter-mongodb": "0.10.2",
-        "@mimicai/adapter-mysql": "0.10.2",
-        "@mimicai/adapter-postgres": "0.10.2",
-        "@mimicai/adapter-sqlite": "0.10.2",
-        "@mimicai/blueprints": "0.10.2",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/adapter-mongodb": "0.11.1",
+        "@mimicai/adapter-mysql": "0.11.1",
+        "@mimicai/adapter-postgres": "0.11.1",
+        "@mimicai/adapter-sqlite": "0.11.1",
+        "@mimicai/blueprints": "0.11.1",
+        "@mimicai/core": "0.11.1",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1005,22 +1039,22 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@mimicai/adapter-chargebee": "0.10.2",
-        "@mimicai/adapter-gocardless": "0.10.2",
-        "@mimicai/adapter-lemonsqueezy": "0.10.2",
-        "@mimicai/adapter-paddle": "0.10.2",
-        "@mimicai/adapter-plaid": "0.10.2",
-        "@mimicai/adapter-recurly": "0.10.2",
-        "@mimicai/adapter-revenuecat": "0.10.2",
-        "@mimicai/adapter-stripe": "0.10.2",
-        "@mimicai/adapter-zuora": "0.10.2",
-        "@mimicai/explorer": "0.10.2"
+        "@mimicai/adapter-chargebee": "0.11.1",
+        "@mimicai/adapter-gocardless": "0.11.1",
+        "@mimicai/adapter-lemonsqueezy": "0.11.1",
+        "@mimicai/adapter-paddle": "0.11.1",
+        "@mimicai/adapter-plaid": "0.11.1",
+        "@mimicai/adapter-recurly": "0.11.1",
+        "@mimicai/adapter-revenuecat": "0.11.1",
+        "@mimicai/adapter-stripe": "0.11.1",
+        "@mimicai/adapter-zuora": "0.11.1",
+        "@mimicai/explorer": "0.11.1"
       }
     },
     "node_modules/@mimicai/core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/core/-/core-0.10.2.tgz",
-      "integrity": "sha512-5myPK3dsaLu/3MeVcWxBzsy4TfuPbhsUTz1yXqKeQR9OgVYFa0UHJcupXZdmA2n31m0zcQJQ0LygEq16rFdrvQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/core/-/core-0.11.1.tgz",
+      "integrity": "sha512-BbFyZJEv5bmB2pIqwo55flkfx7Clp4amsRTpwydZwEyURIs2LQEIb21ayv64OGsvDaypw4W1Tzz+cv1+OuycYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.58",
@@ -1041,14 +1075,14 @@
       }
     },
     "node_modules/@mimicai/explorer": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@mimicai/explorer/-/explorer-0.10.2.tgz",
-      "integrity": "sha512-8mM8ug5V779uweneUovEfC4YLk9L8IbPyGQImG2e9GUSox8TWy+H/zEycsk9P57rEzme11S2p9fF/Spycyn4pQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mimicai/explorer/-/explorer-0.11.1.tgz",
+      "integrity": "sha512-JheOfvd1yTQRCbfW4WJ0hPlp4PKFJKuXtB9c0+emuAtdixuQCT6SQGDfTiN28H22M9M3RBp3OZqSS7qZxePcDA==",
       "optional": true,
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/static": "^9.0.0",
-        "@mimicai/core": "0.10.2",
+        "@mimicai/core": "0.11.1",
         "fastify": "^5.8.2"
       },
       "peerDependencies": {
@@ -1057,9 +1091,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1136,11 +1170,282 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
+    "node_modules/@prisma/client": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.5.0.tgz",
+      "integrity": "sha512-h4hF9ctp+kSRs7ENHGsFQmHAgHcfkOCxbYt6Ti9Xi8x7D+kP4tTi9x51UKmiTH/OqdyJAO+8V+r+JA5AWdav7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.5.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.5.0.tgz",
+      "integrity": "sha512-KnJ2b4Si/pcWEtK68uM+h0h1oh80CZt2suhLTVuLaSKg4n58Q9jBF/A42Kw6Ma+aThy1yAhfDeTC0JvEmeZnFQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/config": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
+      "integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
+      "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
+      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electric-sql/pglite": "0.3.15",
+        "@electric-sql/pglite-socket": "0.0.20",
+        "@electric-sql/pglite-tools": "0.2.20",
+        "@hono/node-server": "1.19.9",
+        "@mrleebo/prisma-ast": "0.13.1",
+        "@prisma/get-platform": "7.2.0",
+        "@prisma/query-plan-executor": "7.2.0",
+        "foreground-child": "3.3.1",
+        "get-port-please": "3.2.0",
+        "hono": "4.11.4",
+        "http-status-codes": "2.3.0",
+        "pathe": "2.0.3",
+        "proper-lockfile": "4.1.2",
+        "remeda": "2.33.4",
+        "std-env": "3.10.0",
+        "valibot": "1.2.0",
+        "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/@chevrotain/types": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev/node_modules/@chevrotain/utils": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev/node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/@mrleebo/prisma-ast": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
+      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^10.5.0",
+        "lilconfig": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/chevrotain": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
+      "integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.5.0",
+        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+        "@prisma/fetch-engine": "7.5.0",
+        "@prisma/get-platform": "7.5.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
+      "integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
+      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.5.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
+      "integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.5.0",
+        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
+        "@prisma/get-platform": "7.5.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
+      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.5.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
+      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/query-plan-executor": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
+      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
+      "integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19 || ^22.12 || ^24.0",
+        "pnpm": "8"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
@@ -1171,14 +1476,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.116",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
-      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "version": "6.0.138",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.138.tgz",
+      "integrity": "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/gateway": "3.0.80",
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19",
+        "@ai-sdk/provider-utils": "4.0.21",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -1259,6 +1564,16 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1294,9 +1609,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1313,6 +1628,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1376,6 +1720,32 @@
         "lodash-es": "4.17.23"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -1434,6 +1804,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -1507,6 +1894,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1522,6 +1917,33 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1540,6 +1962,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -1562,11 +2004,32 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1704,6 +2167,36 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -1790,9 +2283,9 @@
       }
     },
     "node_modules/fastify": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.2.tgz",
-      "integrity": "sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==",
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
+      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
       "funding": [
         {
           "type": "github",
@@ -1882,6 +2375,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1907,6 +2417,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1945,6 +2465,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -1956,6 +2483,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob": {
@@ -1988,6 +2533,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grammex": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
+      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graphmatch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2013,9 +2579,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2040,6 +2606,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -2108,6 +2681,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -2125,6 +2705,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -2240,6 +2830,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
@@ -2262,6 +2859,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -2270,6 +2874,22 @@
       "optional": true,
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2393,6 +3013,40 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/mysql2": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2401,6 +3055,38 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2422,6 +3108,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -2577,6 +3270,20 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -2740,6 +3447,32 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -2779,6 +3512,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prisma": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
+      "integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "7.5.0",
+        "@prisma/dev": "0.20.0",
+        "@prisma/engines": "7.5.0",
+        "@prisma/studio-core": "0.21.1",
+        "mysql2": "3.15.3",
+        "postgres": "3.4.7"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": ">=9.0.0",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -2794,6 +3561,25 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -2816,6 +3602,23 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -2862,12 +3665,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2877,14 +3691,28 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/real-require": {
@@ -2894,6 +3722,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/remeda": {
+      "version": "2.33.4",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
+      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
       }
     },
     "node_modules/require-from-string": {
@@ -2928,6 +3773,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -3003,8 +3858,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true
     },
     "node_modules/secure-json-parse": {
@@ -3066,6 +3921,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
+      "devOptional": true
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
@@ -3221,6 +4082,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3229,6 +4100,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.1",
@@ -3280,6 +4158,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
@@ -3319,6 +4207,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {
@@ -3370,6 +4273,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeptomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
+      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "grammex": "^3.1.11",
+        "graphmatch": "^1.1.0"
       }
     },
     "node_modules/zod": {

--- a/examples/cfo-agent/package.json
+++ b/examples/cfo-agent/package.json
@@ -3,14 +3,19 @@
   "version": "0.0.4",
   "private": true,
   "dependencies": {
-    "@mimicai/cli": "workspace:*",
-    "@mimicai/adapter-stripe": "workspace:*",
-    "@mimicai/adapter-paddle": "workspace:*",
-    "@mimicai/adapter-chargebee": "workspace:*",
-    "@mimicai/adapter-gocardless": "workspace:*",
-    "@mimicai/adapter-revenuecat": "workspace:*",
-    "@mimicai/adapter-zuora": "workspace:*",
-    "@mimicai/adapter-recurly": "workspace:*",
-    "@mimicai/adapter-postgres": "workspace:*"
+    "@mimicai/adapter-chargebee": "^0.11.1",
+    "@mimicai/adapter-gocardless": "^0.11.1",
+    "@mimicai/adapter-lemonsqueezy": "^0.11.1",
+    "@mimicai/adapter-paddle": "^0.11.1",
+    "@mimicai/adapter-postgres": "^0.11.1",
+    "@mimicai/adapter-recurly": "^0.11.1",
+    "@mimicai/adapter-revenuecat": "^0.11.1",
+    "@mimicai/adapter-stripe": "^0.11.1",
+    "@mimicai/adapter-zuora": "^0.11.1",
+    "@mimicai/cli": "^0.11.1"
+  },
+  "devDependencies": {
+    "@prisma/client": "^7.5.0",
+    "prisma": "^7.5.0"
   }
 }

--- a/examples/cfo-agent/prisma.config.ts
+++ b/examples/cfo-agent/prisma.config.ts
@@ -1,0 +1,9 @@
+import path from 'node:path';
+import { defineConfig } from 'prisma/config';
+
+export default defineConfig({
+  schema: path.join(__dirname, 'prisma', 'schema.prisma'),
+  datasource: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/examples/cfo-agent/prisma/schema.prisma
+++ b/examples/cfo-agent/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 /// Internal user record — the product's source of truth for access and engagement.

--- a/packages/docs/src/content/docs/09-examples.md
+++ b/packages/docs/src/content/docs/09-examples.md
@@ -968,11 +968,11 @@ mimic host (separate terminal)
 <span class="prompt">$</span> npx prisma generate && npx prisma migrate dev --name init
 &#8203;
 <span class="cm"># 4. Generate and seed</span>
-<span class="prompt">$</span> pnpm exec mimic run
-<span class="prompt">$</span> pnpm exec mimic seed --verbose
+<span class="prompt">$</span> npx mimic run
+<span class="prompt">$</span> npx mimic seed --verbose
 &#8203;
 <span class="cm"># 5. Start mimic host (new terminal) — brings up all 9 MCP servers</span>
-<span class="prompt">$</span> export $(cat .env | xargs) && pnpm exec mimic host
+<span class="prompt">$</span> export $(cat .env | xargs) && npx mimic host
 &#8203;
 <span class="cm"># 6. Start the agent (new terminal)</span>
 <span class="prompt">$</span> cd agent && npm install && export $(cat ../.env | xargs) && npm start


### PR DESCRIPTION
## Summary
- Switch cfo-agent example dependencies from `workspace:*` to `^0.11.1` npm packages so it runs standalone
- Add missing `@mimicai/adapter-lemonsqueezy` dependency
- Upgrade to Prisma 7 with `prisma.config.ts` (removed `url` from schema datasource block)
- Update README: remove pnpm requirement, fix model references, replace `pnpm exec mimic` with `npx mimic`
- Update docs examples page: `pnpm exec mimic` → `npx mimic` in cfo-agent quick start

## Test plan
- [ ] `cd examples/cfo-agent && npm install` succeeds
- [ ] `docker compose up -d && npx prisma generate && npx prisma migrate dev --name init` creates tables
- [ ] `npx mimic seed --verbose` seeds data into PostgreSQL
- [ ] `npx mimic host` starts all 9 MCP servers
- [ ] Agent and UI start and connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)