### PR TITLE
chore(changesets): ignore briefing-agent-example

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,5 +32,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": ["stripe-explorer-example", "cfo-agent-example"]
+  "ignore": ["stripe-explorer-example", "cfo-agent-example", "briefing-agent-example"]
 }


### PR DESCRIPTION
## Summary

- Adds `briefing-agent-example` to `.changeset/config.json`'s `ignore` list, alongside the existing `stripe-explorer-example` and `cfo-agent-example`.
- Prevents the changesets bot from bumping the example's internal-dep specifiers on every adapter minor release without regenerating `pnpm-lock.yaml` — which is exactly what broke the 0.12.0 release CI (`ERR_PNPM_OUTDATED_LOCKFILE` on `pnpm install --frozen-lockfile`).

## Why this is safe

Examples use semver specifiers (e.g. `^0.11.1`) instead of `workspace:*` by project convention so they remain installable outside the monorepo. The downside is that changesets sees them as bumpable; the upside is they're immune to monorepo internals. The `ignore` list is the project's chosen escape hatch — `cfo-agent-example` and `stripe-explorer-example` already follow this pattern.

This change does not affect what gets published to npm — these examples are `private: true` and aren't released anyway.

## Test plan

- [ ] Next release PR (`changeset-release/main`) does not modify `examples/briefing-agent/package.json`
- [ ] No spurious lockfile diffs from changeset version-bumping the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)