### PR TITLE
ci: wrap changeset version + lockfile refresh in a single npm script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,15 @@ jobs:
           # pnpm-lock.yaml so the resulting "version packages" PR doesn't
           # leave the lockfile out of date with the bumped package.jsons —
           # otherwise CI on main fails next push with ERR_PNPM_OUTDATED_LOCKFILE.
-          version: pnpm changeset version && pnpm install --lockfile-only
+          #
+          # Wrapped as a single npm script (`ci:version`) because
+          # changesets/action@v1 forwards the `version:` value to the
+          # changeset binary as positional args rather than shell-evaluating
+          # the string. The previous inline form
+          #     `pnpm changeset version && pnpm install --lockfile-only`
+          # made changeset see ["version", "&&", "pnpm", "install", ...] and
+          # reject with "Too many arguments passed to changesets".
+          version: pnpm ci:version
           publish: pnpm release
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "clean": "turbo clean",
+    "ci:version": "changeset version && pnpm install --lockfile-only",
     "release": "pnpm build && pnpm changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- changesets/action@v1's `version:` input forwards the string to the `changeset` binary as positional args rather than shell-evaluating it. The previous inline form (`pnpm changeset version && pnpm install --lockfile-only`) caused changeset to see `["version", "&&", "pnpm", "install", ...]` and reject with "Too many arguments passed to changesets".
- The release workflow then proceeded to push an empty `changeset-release/main` branch and failed on "No commits between main and changeset-release/main".
- Wrap both steps in a root `ci:version` script so the action only has to exec a single command name.

## Test plan

- [ ] Workflow run on this PR's merge to main produces a successful "Create release PR or publish" step.
- [ ] Resulting `changeset-release/main` PR contains the persona-conformance changeset bumps (`@mimicai/core`, `@mimicai/cli`, etc.) plus a refreshed lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)